### PR TITLE
fix: include since/until in spell filter JSON display

### DIFF
--- a/src/components/nostr/kinds/SpellRenderer.tsx
+++ b/src/components/nostr/kinds/SpellRenderer.tsx
@@ -220,6 +220,20 @@ export function SpellDetailRenderer({ event }: BaseEventProps) {
   try {
     const spell = decodeSpell(event as SpellEvent);
 
+    // Create a display filter that includes since/until even in relative format
+    const displayFilter = { ...spell.filter };
+
+    // Extract raw since/until values from tags
+    const sinceTag = event.tags.find((t) => t[0] === "since")?.[1];
+    const untilTag = event.tags.find((t) => t[0] === "until")?.[1];
+
+    if (sinceTag && !displayFilter.since) {
+      displayFilter.since = sinceTag as any; // Show relative format like "7d"
+    }
+    if (untilTag && !displayFilter.until) {
+      displayFilter.until = untilTag as any; // Show relative format like "now"
+    }
+
     return (
       <div className="flex flex-col gap-6 p-4">
         <div className="flex flex-col gap-2">
@@ -291,7 +305,7 @@ export function SpellDetailRenderer({ event }: BaseEventProps) {
           <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
             Filter
           </h3>
-          <CopyableJsonViewer json={JSON.stringify(spell.filter, null, 2)} />
+          <CopyableJsonViewer json={JSON.stringify(displayFilter, null, 2)} />
         </div>
 
         {spell.relays && spell.relays.length > 0 && (


### PR DESCRIPTION
The filter JSON in SpellDetailRenderer was missing since/until
fields when they were in relative format (e.g., "7d", "now").
This happened because decodeSpell only adds these fields to
the filter object when they're unix timestamps.

Now we extract the raw since/until values from event tags and
include them in a displayFilter object for the JSON viewer,
ensuring users see the complete filter regardless of format.

The command preview already worked correctly since it uses
the reconstructed command string which includes these values.