### PR TITLE
fix: memoize contact list pointer to fix $contacts alias

### DIFF
--- a/src/components/ReqViewer.tsx
+++ b/src/components/ReqViewer.tsx
@@ -659,12 +659,17 @@ export default function ReqViewer({
   const activeAccount = state.activeAccount;
   const accountPubkey = activeAccount?.pubkey;
 
-  // Fetch contact list (kind 3) if needed for $contacts resolution
-  const contactListEvent = useNostrEvent(
-    needsAccount && accountPubkey
-      ? { kind: 3, pubkey: accountPubkey, identifier: "" }
-      : undefined,
+  // Memoize contact list pointer to prevent unnecessary re-subscriptions
+  const contactPointer = useMemo(
+    () =>
+      needsAccount && accountPubkey
+        ? { kind: 3, pubkey: accountPubkey, identifier: "" }
+        : undefined,
+    [needsAccount, accountPubkey],
   );
+
+  // Fetch contact list (kind 3) if needed for $contacts resolution
+  const contactListEvent = useNostrEvent(contactPointer);
 
   // Extract contacts from kind 3 event (memoized to prevent unnecessary recalculation)
   const contacts = useMemo(


### PR DESCRIPTION
The $contacts alias in REQ command was broken due to an object reference issue.
The contact list pointer object was being created inline on every render, causing
useNostrEvent to treat it as a new pointer each time and disrupting the subscription.

Now properly memoize the pointer object so it only changes when accountPubkey or
needsAccount actually changes, ensuring stable subscriptions and proper contact
list retrieval.

Fixes the $contacts alias resolution in REQ commands.