### PR TITLE
feat: add copy button for NIP markdown

### DIFF
--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -108,6 +108,7 @@ export function WindowToolbar({
           <Button
             variant="link"
             size="icon"
+            className="text-muted-foreground"
             onClick={handleEdit}
             title="Edit command"
             aria-label="Edit command"
@@ -120,6 +121,7 @@ export function WindowToolbar({
             <Button
               variant="link"
               size="icon"
+              className="text-muted-foreground"
               onClick={handleCopyNip}
               title="Copy NIP markdown"
               aria-label="Copy NIP markdown"
@@ -136,6 +138,7 @@ export function WindowToolbar({
                 <Button
                   variant="link"
                   size="icon"
+                  className="text-muted-foreground"
                   title="More actions"
                   aria-label="More actions"
                 >
@@ -169,6 +172,7 @@ export function WindowToolbar({
         <Button
           variant="link"
           size="icon"
+          className="text-muted-foreground"
           onClick={onClose}
           title="Close window"
           aria-label="Close window"

--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -106,9 +106,8 @@ export function WindowToolbar({
         <>
           {/* Edit button */}
           <Button
-            variant="ghost"
+            variant="link"
             size="icon"
-            className="h-8 w-8"
             onClick={handleEdit}
             title="Edit command"
             aria-label="Edit command"
@@ -119,9 +118,8 @@ export function WindowToolbar({
           {/* Copy button for NIPs */}
           {isNipWindow && (
             <Button
-              variant="ghost"
+              variant="link"
               size="icon"
-              className="h-8 w-8"
               onClick={handleCopyNip}
               title="Copy NIP markdown"
               aria-label="Copy NIP markdown"
@@ -136,9 +134,8 @@ export function WindowToolbar({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
-                  variant="ghost"
+                  variant="link"
                   size="icon"
-                  className="h-8 w-8"
                   title="More actions"
                   aria-label="More actions"
                 >
@@ -170,9 +167,8 @@ export function WindowToolbar({
       )}
       {onClose && (
         <Button
-          variant="ghost"
+          variant="link"
           size="icon"
-          className="h-8 w-8"
           onClick={onClose}
           title="Close window"
           aria-label="Close window"

--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -1,4 +1,11 @@
-import { X, Pencil, MoreVertical, WandSparkles, Copy, CopyCheck } from "lucide-react";
+import {
+  X,
+  Pencil,
+  MoreVertical,
+  WandSparkles,
+  Copy,
+  CopyCheck,
+} from "lucide-react";
 import { useSetAtom } from "jotai";
 import { useState } from "react";
 import { WindowInstance } from "@/types/app";
@@ -10,6 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 import { SpellDialog } from "@/components/nostr/SpellDialog";
 import { reconstructCommand as reconstructReqCommand } from "@/lib/spell-conversion";
 import { toast } from "sonner";
@@ -66,7 +74,7 @@ export function WindowToolbar({
 
   // Fetch NIP content for regular NIPs
   const { content: nipContent } = useNip(
-    isNipWindow && window?.props?.number ? window.props.number : ""
+    isNipWindow && window?.props?.number ? window.props.number : "",
   );
 
   const handleCopyNip = () => {
@@ -96,44 +104,46 @@ export function WindowToolbar({
     <>
       {window && (
         <>
-          {/* Edit button with keyboard shortcut hint */}
-          <button
-            className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+          {/* Edit button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
             onClick={handleEdit}
-            title="Edit command (Cmd+E)"
+            title="Edit command"
             aria-label="Edit command"
           >
             <Pencil className="size-4" />
-          </button>
+          </Button>
 
           {/* Copy button for NIPs */}
           {isNipWindow && (
-            <button
-              className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
               onClick={handleCopyNip}
               title="Copy NIP markdown"
               aria-label="Copy NIP markdown"
               disabled={!nipContent}
             >
-              {copied ? (
-                <CopyCheck className="size-4" />
-              ) : (
-                <Copy className="size-4" />
-              )}
-            </button>
+              {copied ? <CopyCheck /> : <Copy />}
+            </Button>
           )}
 
           {/* More actions menu - only for REQ windows for now */}
           {isReqWindow && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button
-                  className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
                   title="More actions"
                   aria-label="More actions"
                 >
                   <MoreVertical className="size-4" />
-                </button>
+                </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={handleTurnIntoSpell}>
@@ -159,14 +169,16 @@ export function WindowToolbar({
         </>
       )}
       {onClose && (
-        <button
-          className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
           onClick={onClose}
-          title="Close window (Cmd+W)"
+          title="Close window"
           aria-label="Close window"
         >
           <X className="size-4" />
-        </button>
+        </Button>
       )}
     </>
   );

--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -1,4 +1,4 @@
-import { X, Pencil, MoreVertical, WandSparkles } from "lucide-react";
+import { X, Pencil, MoreVertical, WandSparkles, Copy, CopyCheck } from "lucide-react";
 import { useSetAtom } from "jotai";
 import { useState } from "react";
 import { WindowInstance } from "@/types/app";
@@ -13,6 +13,8 @@ import {
 import { SpellDialog } from "@/components/nostr/SpellDialog";
 import { reconstructCommand as reconstructReqCommand } from "@/lib/spell-conversion";
 import { toast } from "sonner";
+import { useCopy } from "@/hooks/useCopy";
+import { useNip } from "@/hooks/useNip";
 
 interface WindowToolbarProps {
   window?: WindowInstance;
@@ -58,6 +60,22 @@ export function WindowToolbar({
     setShowSpellDialog(true);
   };
 
+  // Copy functionality for NIPs
+  const { copy, copied } = useCopy();
+  const isNipWindow = window?.appId === "nip";
+
+  // Fetch NIP content for regular NIPs
+  const { content: nipContent } = useNip(
+    isNipWindow && window?.props?.number ? window.props.number : ""
+  );
+
+  const handleCopyNip = () => {
+    if (!window || !nipContent) return;
+
+    copy(nipContent);
+    toast.success("NIP markdown copied to clipboard");
+  };
+
   // Check if this is a REQ window for spell creation
   const isReqWindow = window?.appId === "req";
 
@@ -87,6 +105,23 @@ export function WindowToolbar({
           >
             <Pencil className="size-4" />
           </button>
+
+          {/* Copy button for NIPs */}
+          {isNipWindow && (
+            <button
+              className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              onClick={handleCopyNip}
+              title="Copy NIP markdown"
+              aria-label="Copy NIP markdown"
+              disabled={!nipContent}
+            >
+              {copied ? (
+                <CopyCheck className="size-4" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+            </button>
+          )}
 
           {/* More actions menu - only for REQ windows for now */}
           {isReqWindow && (

--- a/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
+++ b/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
@@ -48,7 +48,7 @@ export function CommunityNIPDetailRenderer({ event }: { event: NostrEvent }) {
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-3xl font-bold">{title}</h1>
           <Button
-            variant="ghost"
+            variant="link"
             size="icon"
             onClick={handleCopy}
             title="Copy NIP markdown"

--- a/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
+++ b/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
+import { Copy, CopyCheck } from "lucide-react";
 import { getTagValue } from "applesauce-core/helpers";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
+import { useCopy } from "@/hooks/useCopy";
+import { toast } from "sonner";
 import type { NostrEvent } from "@/types/nostr";
 
 /**
@@ -29,12 +32,33 @@ export function CommunityNIPDetailRenderer({ event }: { event: NostrEvent }) {
     },
   );
 
+  // Copy functionality
+  const { copy, copied } = useCopy();
+  const handleCopy = () => {
+    copy(event.content);
+    toast.success("Community NIP markdown copied to clipboard");
+  };
+
   return (
     <div dir="auto" className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
       {/* NIP Header */}
       <header className="flex flex-col gap-4 border-b border-border pb-6">
-        {/* Title */}
-        <h1 className="text-3xl font-bold">{title}</h1>
+        {/* Title with Copy Button */}
+        <div className="flex items-start justify-between gap-4">
+          <h1 className="text-3xl font-bold">{title}</h1>
+          <button
+            onClick={handleCopy}
+            className="p-2 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
+            title="Copy NIP markdown"
+            aria-label="Copy NIP markdown"
+          >
+            {copied ? (
+              <CopyCheck className="size-5" />
+            ) : (
+              <Copy className="size-5" />
+            )}
+          </button>
+        </div>
 
         {/* Metadata */}
         <div className="flex items-center gap-4 text-sm text-muted-foreground">

--- a/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
+++ b/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
@@ -3,6 +3,7 @@ import { Copy, CopyCheck } from "lucide-react";
 import { getTagValue } from "applesauce-core/helpers";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
+import { Button } from "@/components/ui/button";
 import { useCopy } from "@/hooks/useCopy";
 import { toast } from "sonner";
 import type { NostrEvent } from "@/types/nostr";
@@ -46,18 +47,15 @@ export function CommunityNIPDetailRenderer({ event }: { event: NostrEvent }) {
         {/* Title with Copy Button */}
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-3xl font-bold">{title}</h1>
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={handleCopy}
-            className="p-2 rounded text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors shrink-0"
             title="Copy NIP markdown"
             aria-label="Copy NIP markdown"
           >
-            {copied ? (
-              <CopyCheck className="size-5" />
-            ) : (
-              <Copy className="size-5" />
-            )}
-          </button>
+            {copied ? <CopyCheck /> : <Copy />}
+          </Button>
         </div>
 
         {/* Metadata */}


### PR DESCRIPTION
- Add copy button to WindowToolbar for regular NIPs (appId: "nip")
  - Button appears in window toolbar next to edit button
  - Uses Copy/CopyCheck icons from lucide-react
  - Fetches NIP content via useNip hook
  - Shows toast notification on successful copy

- Add copy button to CommunityNIPDetailRenderer for community NIPs (kind 30817)
  - Button appears in header next to title
  - Copies event.content (markdown) to clipboard
  - Uses same Copy/CopyCheck icon pattern
  - Shows toast notification on successful copy

Both implementations use the existing useCopy hook for state management
and maintain consistent styling with other toolbar buttons.