### PR TITLE
Fix image placeholder font size inconsistency

### DIFF
--- a/src/components/nostr/RichText/Link.tsx
+++ b/src/components/nostr/RichText/Link.tsx
@@ -10,7 +10,7 @@ import { PlainLink } from "../LinkPreview";
 import { useRichTextOptions } from "../RichText";
 
 function MediaPlaceholder({ type }: { type: "image" | "video" | "audio" }) {
-  return <span className="text-muted-foreground text-sm">[{type}]</span>;
+  return <span className="text-muted-foreground">[{type}]</span>;
 }
 
 interface LinkNodeProps {


### PR DESCRIPTION
The MediaPlaceholder component in Link.tsx had text-sm hardcoded, causing it to appear larger than surrounding text in compact contexts. Now all placeholder components (Link, Gallery, Mention) consistently inherit font size from their parent.