### PR TITLE
fix: don't show relay auth dialog when user is not logged in

### DIFF
--- a/src/services/relay-state-manager.ts
+++ b/src/services/relay-state-manager.ts
@@ -491,6 +491,9 @@ class RelayStateManager {
     try {
       const normalizedUrl = normalizeRelayURL(relayUrl);
 
+      // Don't prompt if there's no active account
+      if (!accountManager.active) return false;
+
       // Check permanent preferences
       const pref = this.authPreferences.get(normalizedUrl);
       if (pref === "never") return false;


### PR DESCRIPTION
Previously, the auth dialog would appear whenever a relay sent an AUTH
challenge, even when there was no active user session. This was confusing
for users who weren't logged in.

Now the shouldPromptAuth() method checks if there's an active account
before returning true, ensuring auth dialogs only appear for logged-in users.