### PR TITLE
feat: add preview routes for Nostr identifiers (npub, nevent, note, naddr)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "grimoire",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,8 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@react-router/dev": "^7.1.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.1",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.10.1",
         "@types/prismjs": "^1.26.5",
@@ -80,6 +82,8 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "fake-indexeddb": "^6.2.5",
         "globals": "^15.14.0",
+        "happy-dom": "^20.0.11",
+        "jsdom": "^27.4.0",
         "postcss": "^8.4.49",
         "prettier": "^3.7.4",
         "tailwindcss": "^3.4.17",
@@ -88,6 +92,13 @@
         "vite": "^6.0.5",
         "vitest": "^4.0.15"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.30",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.30.tgz",
+      "integrity": "sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -101,6 +112,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -647,6 +713,141 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.22.tgz",
+      "integrity": "sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1246,6 +1447,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.8.0.tgz",
+      "integrity": "sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3956,6 +4175,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.1.tgz",
+      "integrity": "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4142,6 +4416,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4616,6 +4897,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4888,6 +5179,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4974,6 +5275,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -5410,6 +5721,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5423,6 +5748,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.6.tgz",
+      "integrity": "sha512-legscpSpgSAeGEe0TNcai97DKt9Vd9AsAdOL7Uoetb52Ar/8eJm3LIa39qpv8wWzLFlNG4vVvppQM+teaMPj3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5434,6 +5785,30 @@
       "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
       "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -5470,6 +5845,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -5595,6 +5977,13 @@
         "dnd-core": "^16.0.1"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5615,6 +6004,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/err-code": {
       "version": "2.0.3",
@@ -6307,6 +6709,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/happy-dom": {
+      "version": "20.0.11",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.11.tgz",
+      "integrity": "sha512-QsCdAUHAmiDeKeaNojb1OHOPF7NjcWPBR7obdu3NwH2a/oyQaLg5d0aaCy/9My6CdPChYF07dvz5chaXBGaD4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6425,6 +6859,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6433,6 +6880,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -6611,6 +7086,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbot": {
       "version": "5.1.32",
       "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.32.tgz",
@@ -6699,6 +7181,56 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -6891,6 +7423,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -7194,6 +7736,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-chrome": {
       "version": "4.17.2",
@@ -8197,6 +8746,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8523,6 +9085,51 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -9084,6 +9691,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -9215,6 +9832,19 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9596,6 +10226,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -9809,6 +10446,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9830,6 +10487,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -10433,6 +11116,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -10576,6 +11306,45 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@react-router/dev": "^7.1.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.1",
     "@types/prismjs": "^1.26.5",
@@ -88,6 +90,8 @@
     "eslint-plugin-react-refresh": "^0.4.16",
     "fake-indexeddb": "^6.2.5",
     "globals": "^15.14.0",
+    "happy-dom": "^20.0.11",
+    "jsdom": "^27.4.0",
     "postcss": "^8.4.49",
     "prettier": "^3.7.4",
     "tailwindcss": "^3.4.17",

--- a/src/components/layouts/AppShell.tsx
+++ b/src/components/layouts/AppShell.tsx
@@ -13,9 +13,10 @@ import { AppShellContext } from "./AppShellContext";
 
 interface AppShellProps {
   children: ReactNode;
+  hideBottomBar?: boolean;
 }
 
-export function AppShell({ children }: AppShellProps) {
+export function AppShell({ children, hideBottomBar = false }: AppShellProps) {
   const [commandLauncherOpen, setCommandLauncherOpen] = useState(false);
 
   // Sync active account and fetch relay lists
@@ -76,7 +77,7 @@ export function AppShell({ children }: AppShellProps) {
         <section className="flex-1 relative overflow-hidden">
           {children}
         </section>
-        <TabBar />
+        {!hideBottomBar && <TabBar />}
       </main>
     </AppShellContext.Provider>
   );

--- a/src/components/pages/Nip19PreviewRouter.tsx
+++ b/src/components/pages/Nip19PreviewRouter.tsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router";
+import PreviewProfilePage from "./PreviewProfilePage";
+import PreviewEventPage from "./PreviewEventPage";
+import PreviewAddressPage from "./PreviewAddressPage";
+
+/**
+ * Nip19PreviewRouter - Routes to the appropriate preview component based on NIP-19 identifier type
+ * Handles npub, note, nevent, and naddr identifiers
+ */
+export default function Nip19PreviewRouter() {
+  const { identifier } = useParams<{ identifier: string }>();
+
+  if (!identifier) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-muted-foreground">No identifier provided</p>
+      </div>
+    );
+  }
+
+  // Route based on identifier prefix
+  if (identifier.startsWith("npub1")) {
+    return <PreviewProfilePage />;
+  } else if (identifier.startsWith("nevent1")) {
+    return <PreviewEventPage />;
+  } else if (identifier.startsWith("note1")) {
+    return <PreviewEventPage />;
+  } else if (identifier.startsWith("naddr1")) {
+    return <PreviewAddressPage />;
+  }
+
+  // Not a recognized NIP-19 identifier
+  return null;
+}

--- a/src/components/pages/PreviewAddressPage.tsx
+++ b/src/components/pages/PreviewAddressPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router";
+import { useNip19Decode } from "@/hooks/useNip19Decode";
 import { nip19 } from "nostr-tools";
-import type { AddressPointer } from "nostr-tools/nip19";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -14,54 +14,85 @@ import { toast } from "sonner";
 export default function PreviewAddressPage() {
   const { identifier } = useParams<{ identifier: string }>();
   const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
 
+  // Reconstruct the full identifier
+  const fullIdentifier = identifier ? `naddr${identifier}` : undefined;
+
+  // Decode the naddr identifier
+  const { decoded, isLoading, error, retry } = useNip19Decode(
+    fullIdentifier,
+    "naddr"
+  );
+
+  // Handle redirect when decoded successfully
   useEffect(() => {
-    if (!identifier) {
-      setError("No identifier provided");
-      return;
+    if (!decoded || decoded.type !== "naddr") return;
+
+    const pointer = decoded.data;
+
+    // Check if it's a spellbook (kind 30777)
+    if (pointer.kind === 30777) {
+      // Redirect to the spellbook route
+      const npub = nip19.npubEncode(pointer.pubkey);
+      navigate(`/${npub}/${pointer.identifier}`, { replace: true });
+    } else {
+      // For other kinds, we could extend this to handle them differently
+      // For now, show an error via toast
+      toast.error(`Addressable events of kind ${pointer.kind} are not yet supported in preview mode`);
     }
+  }, [decoded, navigate]);
 
-    // Reconstruct the full identifier
-    const fullIdentifier = `naddr${identifier}`;
-
-    try {
-      const decoded = nip19.decode(fullIdentifier);
-
-      if (decoded.type !== "naddr") {
-        setError(`Invalid identifier type: expected naddr, got ${decoded.type}`);
-        toast.error("Invalid naddr identifier");
-        return;
-      }
-
-      const pointer = decoded.data as AddressPointer;
-
-      // Check if it's a spellbook (kind 30777)
-      if (pointer.kind === 30777) {
-        // Redirect to the spellbook route
-        const npub = nip19.npubEncode(pointer.pubkey);
-        navigate(`/${npub}/${pointer.identifier}`, { replace: true });
-      } else {
-        // For other kinds, we could extend this to handle them differently
-        // For now, show an error
-        setError(
-          `Addressable events of kind ${pointer.kind} are not yet supported in preview mode`
-        );
-        toast.error("Unsupported event kind");
-      }
-    } catch (e) {
-      console.error("Failed to decode naddr:", e);
-      setError(e instanceof Error ? e.message : "Failed to decode identifier");
+  // Show error toast when error occurs
+  useEffect(() => {
+    if (error) {
       toast.error("Invalid naddr identifier");
     }
-  }, [identifier, navigate]);
+  }, [error]);
 
-  // Loading/error state
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+        <Loader2 className="size-8 animate-spin text-primary/50" />
+        <div className="flex flex-col items-center gap-1">
+          <p className="font-medium text-foreground">Redirecting...</p>
+          <p className="text-xs">Processing address pointer</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
   if (error) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-4">
-        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
           {error}
+        </div>
+        <div className="flex gap-3">
+          <button
+            onClick={retry}
+            className="text-sm text-primary hover:text-primary/80 underline"
+          >
+            Retry
+          </button>
+          <button
+            onClick={() => navigate("/")}
+            className="text-sm text-muted-foreground hover:text-foreground underline"
+          >
+            Return to dashboard
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show error for unsupported kinds
+  if (decoded && decoded.type === "naddr" && decoded.data.kind !== 30777) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
+          Addressable events of kind {decoded.data.kind} are not yet supported in preview mode
         </div>
         <button
           onClick={() => navigate("/")}
@@ -73,6 +104,7 @@ export default function PreviewAddressPage() {
     );
   }
 
+  // Still processing redirect
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
       <Loader2 className="size-8 animate-spin text-primary/50" />

--- a/src/components/pages/PreviewAddressPage.tsx
+++ b/src/components/pages/PreviewAddressPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router";
+import { nip19 } from "nostr-tools";
+import type { AddressPointer } from "nostr-tools/nip19";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * PreviewAddressPage - Redirect naddr identifiers to appropriate routes
+ * Route: /naddr...
+ * For spellbooks (kind 30777), redirects to /:actor/:identifier
+ * For other kinds, shows error (could be extended to handle other addressable events)
+ */
+export default function PreviewAddressPage() {
+  const { identifier } = useParams<{ identifier: string }>();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!identifier) {
+      setError("No identifier provided");
+      return;
+    }
+
+    // Reconstruct the full identifier
+    const fullIdentifier = `naddr${identifier}`;
+
+    try {
+      const decoded = nip19.decode(fullIdentifier);
+
+      if (decoded.type !== "naddr") {
+        setError(`Invalid identifier type: expected naddr, got ${decoded.type}`);
+        toast.error("Invalid naddr identifier");
+        return;
+      }
+
+      const pointer = decoded.data as AddressPointer;
+
+      // Check if it's a spellbook (kind 30777)
+      if (pointer.kind === 30777) {
+        // Redirect to the spellbook route
+        const npub = nip19.npubEncode(pointer.pubkey);
+        navigate(`/${npub}/${pointer.identifier}`, { replace: true });
+      } else {
+        // For other kinds, we could extend this to handle them differently
+        // For now, show an error
+        setError(
+          `Addressable events of kind ${pointer.kind} are not yet supported in preview mode`
+        );
+        toast.error("Unsupported event kind");
+      }
+    } catch (e) {
+      console.error("Failed to decode naddr:", e);
+      setError(e instanceof Error ? e.message : "Failed to decode identifier");
+      toast.error("Invalid naddr identifier");
+    }
+  }, [identifier, navigate]);
+
+  // Loading/error state
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">
+          {error}
+        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+      <Loader2 className="size-8 animate-spin text-primary/50" />
+      <div className="flex flex-col items-center gap-1">
+        <p className="font-medium text-foreground">Redirecting...</p>
+        <p className="text-xs">Processing address pointer</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/PreviewAddressPage.tsx
+++ b/src/components/pages/PreviewAddressPage.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useParams, useNavigate } from "react-router";
 import { useNip19Decode } from "@/hooks/useNip19Decode";
 import { nip19 } from "nostr-tools";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 /**
@@ -18,11 +17,8 @@ export default function PreviewAddressPage() {
   // Reconstruct the full identifier
   const fullIdentifier = identifier ? `naddr${identifier}` : undefined;
 
-  // Decode the naddr identifier
-  const { decoded, isLoading, error, retry } = useNip19Decode(
-    fullIdentifier,
-    "naddr"
-  );
+  // Decode the naddr identifier (synchronous, memoized)
+  const { decoded, error } = useNip19Decode(fullIdentifier, "naddr");
 
   // Handle redirect when decoded successfully
   useEffect(() => {
@@ -36,8 +32,7 @@ export default function PreviewAddressPage() {
       const npub = nip19.npubEncode(pointer.pubkey);
       navigate(`/${npub}/${pointer.identifier}`, { replace: true });
     } else {
-      // For other kinds, we could extend this to handle them differently
-      // For now, show an error via toast
+      // For other kinds, show error via toast
       toast.error(`Addressable events of kind ${pointer.kind} are not yet supported in preview mode`);
     }
   }, [decoded, navigate]);
@@ -49,19 +44,6 @@ export default function PreviewAddressPage() {
     }
   }, [error]);
 
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
-        <Loader2 className="size-8 animate-spin text-primary/50" />
-        <div className="flex flex-col items-center gap-1">
-          <p className="font-medium text-foreground">Redirecting...</p>
-          <p className="text-xs">Processing address pointer</p>
-        </div>
-      </div>
-    );
-  }
-
   // Error state
   if (error) {
     return (
@@ -69,20 +51,12 @@ export default function PreviewAddressPage() {
         <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
           {error}
         </div>
-        <div className="flex gap-3">
-          <button
-            onClick={retry}
-            className="text-sm text-primary hover:text-primary/80 underline"
-          >
-            Retry
-          </button>
-          <button
-            onClick={() => navigate("/")}
-            className="text-sm text-muted-foreground hover:text-foreground underline"
-          >
-            Return to dashboard
-          </button>
-        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
       </div>
     );
   }
@@ -104,14 +78,6 @@ export default function PreviewAddressPage() {
     );
   }
 
-  // Still processing redirect
-  return (
-    <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
-      <Loader2 className="size-8 animate-spin text-primary/50" />
-      <div className="flex flex-col items-center gap-1">
-        <p className="font-medium text-foreground">Redirecting...</p>
-        <p className="text-xs">Processing address pointer</p>
-      </div>
-    </div>
-  );
+  // Redirecting (shown briefly before redirect happens)
+  return null;
 }

--- a/src/components/pages/PreviewAddressPage.tsx
+++ b/src/components/pages/PreviewAddressPage.tsx
@@ -7,19 +7,16 @@ import { toast } from "sonner";
 
 /**
  * PreviewAddressPage - Preview or redirect naddr identifiers
- * Route: /naddr1*
+ * Route: /:identifier (where identifier starts with naddr1)
  * For spellbooks (kind 30777), redirects to /:actor/:identifier
  * For all other addressable events, shows detail view
  */
 export default function PreviewAddressPage() {
-  const params = useParams<{ "*": string }>();
+  const { identifier } = useParams<{ identifier: string }>();
   const navigate = useNavigate();
 
-  // Get the full naddr from the URL (naddr1 + captured part)
-  const fullIdentifier = params["*"] ? `naddr1${params["*"]}` : undefined;
-
   // Decode the naddr identifier (synchronous, memoized)
-  const { decoded, error } = useNip19Decode(fullIdentifier, "naddr");
+  const { decoded, error } = useNip19Decode(identifier, "naddr");
 
   // Handle redirect for spellbooks
   useEffect(() => {

--- a/src/components/pages/PreviewAddressPage.tsx
+++ b/src/components/pages/PreviewAddressPage.tsx
@@ -7,16 +7,16 @@ import { toast } from "sonner";
 
 /**
  * PreviewAddressPage - Preview or redirect naddr identifiers
- * Route: /naddr...
+ * Route: /naddr1*
  * For spellbooks (kind 30777), redirects to /:actor/:identifier
  * For all other addressable events, shows detail view
  */
 export default function PreviewAddressPage() {
-  const { identifier } = useParams<{ identifier: string }>();
+  const params = useParams<{ "*": string }>();
   const navigate = useNavigate();
 
-  // Reconstruct the full identifier
-  const fullIdentifier = identifier ? `naddr${identifier}` : undefined;
+  // Get the full naddr from the URL (naddr1 + captured part)
+  const fullIdentifier = params["*"] ? `naddr1${params["*"]}` : undefined;
 
   // Decode the naddr identifier (synchronous, memoized)
   const { decoded, error } = useNip19Decode(fullIdentifier, "naddr");

--- a/src/components/pages/PreviewEventPage.tsx
+++ b/src/components/pages/PreviewEventPage.tsx
@@ -55,7 +55,9 @@ export default function PreviewEventPage() {
   // Validate that we got an event-type entity
   useEffect(() => {
     if (decoded && decoded.type !== "nevent" && decoded.type !== "note") {
-      toast.error(`Invalid identifier type: expected nevent or note, got ${decoded.type}`);
+      toast.error(
+        `Invalid identifier type: expected nevent or note, got ${decoded.type}`,
+      );
     }
   }, [decoded]);
 

--- a/src/components/pages/PreviewEventPage.tsx
+++ b/src/components/pages/PreviewEventPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect } from "react";
-import { useParams, useNavigate, useLocation } from "react-router";
+import { useParams, useNavigate } from "react-router";
 import { useNip19Decode } from "@/hooks/useNip19Decode";
 import type { EventPointer } from "nostr-tools/nip19";
 import { EventDetailViewer } from "../EventDetailViewer";
@@ -7,30 +7,15 @@ import { toast } from "sonner";
 
 /**
  * PreviewEventPage - Preview a Nostr event from a nevent or note identifier
- * Routes: /nevent1*, /note1*
+ * Route: /:identifier (where identifier starts with nevent1 or note1)
  * This page shows a single event view without affecting user's workspace layout
  */
 export default function PreviewEventPage() {
-  const params = useParams<{ "*": string }>();
+  const { identifier } = useParams<{ identifier: string }>();
   const navigate = useNavigate();
-  const location = useLocation();
-
-  // Determine the prefix based on the current path and reconstruct full identifier
-  const fullIdentifier = useMemo(() => {
-    const captured = params["*"];
-    if (!captured) return undefined;
-
-    const path = location.pathname;
-    if (path.startsWith("/nevent1")) {
-      return `nevent1${captured}`;
-    } else if (path.startsWith("/note1")) {
-      return `note1${captured}`;
-    }
-    return undefined;
-  }, [params, location.pathname]);
 
   // Decode the event identifier (synchronous, memoized)
-  const { decoded, error } = useNip19Decode(fullIdentifier);
+  const { decoded, error } = useNip19Decode(identifier);
 
   // Convert decoded entity to EventPointer
   const pointer: EventPointer | null = useMemo(() => {

--- a/src/components/pages/PreviewEventPage.tsx
+++ b/src/components/pages/PreviewEventPage.tsx
@@ -7,26 +7,27 @@ import { toast } from "sonner";
 
 /**
  * PreviewEventPage - Preview a Nostr event from a nevent or note identifier
- * Routes: /nevent..., /note...
+ * Routes: /nevent1*, /note1*
  * This page shows a single event view without affecting user's workspace layout
  */
 export default function PreviewEventPage() {
-  const { identifier } = useParams<{ identifier: string }>();
+  const params = useParams<{ "*": string }>();
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Determine the prefix based on the current path
+  // Determine the prefix based on the current path and reconstruct full identifier
   const fullIdentifier = useMemo(() => {
-    if (!identifier) return undefined;
+    const captured = params["*"];
+    if (!captured) return undefined;
 
     const path = location.pathname;
-    if (path.startsWith("/nevent")) {
-      return `nevent${identifier}`;
-    } else if (path.startsWith("/note")) {
-      return `note${identifier}`;
+    if (path.startsWith("/nevent1")) {
+      return `nevent1${captured}`;
+    } else if (path.startsWith("/note1")) {
+      return `note1${captured}`;
     }
     return undefined;
-  }, [identifier, location.pathname]);
+  }, [params, location.pathname]);
 
   // Decode the event identifier (synchronous, memoized)
   const { decoded, error } = useNip19Decode(fullIdentifier);

--- a/src/components/pages/PreviewEventPage.tsx
+++ b/src/components/pages/PreviewEventPage.tsx
@@ -3,7 +3,6 @@ import { useParams, useNavigate, useLocation } from "react-router";
 import { useNip19Decode } from "@/hooks/useNip19Decode";
 import type { EventPointer } from "nostr-tools/nip19";
 import { EventDetailViewer } from "../EventDetailViewer";
-import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
 /**
@@ -29,8 +28,8 @@ export default function PreviewEventPage() {
     return undefined;
   }, [identifier, location.pathname]);
 
-  // Decode the event identifier (accepts both nevent and note)
-  const { decoded, isLoading, error, retry } = useNip19Decode(fullIdentifier);
+  // Decode the event identifier (synchronous, memoized)
+  const { decoded, error } = useNip19Decode(fullIdentifier);
 
   // Convert decoded entity to EventPointer
   const pointer: EventPointer | null = useMemo(() => {
@@ -59,19 +58,6 @@ export default function PreviewEventPage() {
     }
   }, [decoded]);
 
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
-        <Loader2 className="size-8 animate-spin text-primary/50" />
-        <div className="flex flex-col items-center gap-1">
-          <p className="font-medium text-foreground">Loading Event...</p>
-          <p className="text-xs">Decoding identifier</p>
-        </div>
-      </div>
-    );
-  }
-
   // Error state
   if (error || !pointer) {
     return (
@@ -79,20 +65,12 @@ export default function PreviewEventPage() {
         <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
           {error || "Failed to decode event identifier"}
         </div>
-        <div className="flex gap-3">
-          <button
-            onClick={retry}
-            className="text-sm text-primary hover:text-primary/80 underline"
-          >
-            Retry
-          </button>
-          <button
-            onClick={() => navigate("/")}
-            className="text-sm text-muted-foreground hover:text-foreground underline"
-          >
-            Return to dashboard
-          </button>
-        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
       </div>
     );
   }

--- a/src/components/pages/PreviewEventPage.tsx
+++ b/src/components/pages/PreviewEventPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router";
+import { nip19 } from "nostr-tools";
+import type { EventPointer } from "nostr-tools/nip19";
+import { EventDetailViewer } from "../EventDetailViewer";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * PreviewEventPage - Preview a Nostr event from a nevent or note identifier
+ * Routes: /nevent..., /note...
+ * This page shows a single event view without affecting user's workspace layout
+ */
+export default function PreviewEventPage() {
+  const { identifier } = useParams<{ identifier: string }>();
+  const navigate = useNavigate();
+  const [pointer, setPointer] = useState<EventPointer | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!identifier) {
+      setError("No identifier provided");
+      return;
+    }
+
+    // Determine the prefix based on the current path
+    const path = window.location.pathname;
+    let fullIdentifier: string;
+
+    if (path.startsWith("/nevent")) {
+      fullIdentifier = `nevent${identifier}`;
+    } else if (path.startsWith("/note")) {
+      fullIdentifier = `note${identifier}`;
+    } else {
+      setError("Invalid route");
+      return;
+    }
+
+    try {
+      const decoded = nip19.decode(fullIdentifier);
+
+      if (decoded.type === "nevent") {
+        setPointer(decoded.data);
+      } else if (decoded.type === "note") {
+        // note is just an event ID, convert to EventPointer
+        setPointer({
+          id: decoded.data,
+        });
+      } else {
+        setError(`Invalid identifier type: expected nevent or note, got ${decoded.type}`);
+        toast.error("Invalid event identifier");
+        return;
+      }
+    } catch (e) {
+      console.error("Failed to decode event identifier:", e);
+      setError(e instanceof Error ? e.message : "Failed to decode identifier");
+      toast.error("Invalid event identifier");
+    }
+  }, [identifier]);
+
+  // Loading state
+  if (!pointer && !error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+        <Loader2 className="size-8 animate-spin text-primary/50" />
+        <div className="flex flex-col items-center gap-1">
+          <p className="font-medium text-foreground">Loading Event...</p>
+          <p className="text-xs">Decoding identifier</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">
+          {error}
+        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      <EventDetailViewer pointer={pointer!} />
+    </div>
+  );
+}

--- a/src/components/pages/PreviewProfilePage.tsx
+++ b/src/components/pages/PreviewProfilePage.tsx
@@ -6,18 +6,15 @@ import { toast } from "sonner";
 
 /**
  * PreviewProfilePage - Preview a Nostr profile from an npub identifier
- * Route: /npub1*
+ * Route: /:identifier (where identifier starts with npub1)
  * This page shows a single profile view without affecting user's workspace layout
  */
 export default function PreviewProfilePage() {
-  const params = useParams<{ "*": string }>();
+  const { identifier } = useParams<{ identifier: string }>();
   const navigate = useNavigate();
 
-  // Get the full npub from the URL (npub1 + captured part)
-  const fullIdentifier = params["*"] ? `npub1${params["*"]}` : undefined;
-
   // Decode the npub identifier (synchronous, memoized)
-  const { decoded, error } = useNip19Decode(fullIdentifier, "npub");
+  const { decoded, error } = useNip19Decode(identifier, "npub");
 
   // Show error toast when error occurs
   useEffect(() => {

--- a/src/components/pages/PreviewProfilePage.tsx
+++ b/src/components/pages/PreviewProfilePage.tsx
@@ -1,9 +1,8 @@
 import { useParams, useNavigate } from "react-router";
 import { useNip19Decode } from "@/hooks/useNip19Decode";
 import { ProfileViewer } from "../ProfileViewer";
-import { Loader2 } from "lucide-react";
-import { toast } from "sonner";
 import { useEffect } from "react";
+import { toast } from "sonner";
 
 /**
  * PreviewProfilePage - Preview a Nostr profile from an npub identifier
@@ -17,11 +16,8 @@ export default function PreviewProfilePage() {
   // Reconstruct the full identifier (react-router splits on /)
   const fullIdentifier = identifier ? `npub${identifier}` : undefined;
 
-  // Decode the npub identifier
-  const { decoded, isLoading, error, retry } = useNip19Decode(
-    fullIdentifier,
-    "npub"
-  );
+  // Decode the npub identifier (synchronous, memoized)
+  const { decoded, error } = useNip19Decode(fullIdentifier, "npub");
 
   // Show error toast when error occurs
   useEffect(() => {
@@ -30,19 +26,6 @@ export default function PreviewProfilePage() {
     }
   }, [error]);
 
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
-        <Loader2 className="size-8 animate-spin text-primary/50" />
-        <div className="flex flex-col items-center gap-1">
-          <p className="font-medium text-foreground">Loading Profile...</p>
-          <p className="text-xs">Decoding identifier</p>
-        </div>
-      </div>
-    );
-  }
-
   // Error state
   if (error) {
     return (
@@ -50,20 +33,12 @@ export default function PreviewProfilePage() {
         <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
           {error}
         </div>
-        <div className="flex gap-3">
-          <button
-            onClick={retry}
-            className="text-sm text-primary hover:text-primary/80 underline"
-          >
-            Retry
-          </button>
-          <button
-            onClick={() => navigate("/")}
-            className="text-sm text-muted-foreground hover:text-foreground underline"
-          >
-            Return to dashboard
-          </button>
-        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
       </div>
     );
   }

--- a/src/components/pages/PreviewProfilePage.tsx
+++ b/src/components/pages/PreviewProfilePage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router";
+import { nip19 } from "nostr-tools";
+import { ProfileViewer } from "../ProfileViewer";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * PreviewProfilePage - Preview a Nostr profile from an npub identifier
+ * Route: /npub...
+ * This page shows a single profile view without affecting user's workspace layout
+ */
+export default function PreviewProfilePage() {
+  const { identifier } = useParams<{ identifier: string }>();
+  const navigate = useNavigate();
+  const [pubkey, setPubkey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!identifier) {
+      setError("No identifier provided");
+      return;
+    }
+
+    // Reconstruct the full identifier (react-router splits on /)
+    const fullIdentifier = `npub${identifier}`;
+
+    try {
+      const decoded = nip19.decode(fullIdentifier);
+      if (decoded.type !== "npub") {
+        setError(`Invalid identifier type: expected npub, got ${decoded.type}`);
+        toast.error("Invalid npub identifier");
+        return;
+      }
+
+      setPubkey(decoded.data);
+    } catch (e) {
+      console.error("Failed to decode npub:", e);
+      setError(e instanceof Error ? e.message : "Failed to decode identifier");
+      toast.error("Invalid npub identifier");
+    }
+  }, [identifier]);
+
+  // Loading state
+  if (!pubkey && !error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+        <Loader2 className="size-8 animate-spin text-primary/50" />
+        <div className="flex flex-col items-center gap-1">
+          <p className="font-medium text-foreground">Loading Profile...</p>
+          <p className="text-xs">Decoding identifier</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">
+          {error}
+        </div>
+        <button
+          onClick={() => navigate("/")}
+          className="text-sm text-muted-foreground hover:text-foreground underline"
+        >
+          Return to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      <ProfileViewer pubkey={pubkey!} />
+    </div>
+  );
+}

--- a/src/components/pages/PreviewProfilePage.tsx
+++ b/src/components/pages/PreviewProfilePage.tsx
@@ -6,15 +6,15 @@ import { toast } from "sonner";
 
 /**
  * PreviewProfilePage - Preview a Nostr profile from an npub identifier
- * Route: /npub...
+ * Route: /npub1*
  * This page shows a single profile view without affecting user's workspace layout
  */
 export default function PreviewProfilePage() {
-  const { identifier } = useParams<{ identifier: string }>();
+  const params = useParams<{ "*": string }>();
   const navigate = useNavigate();
 
-  // Reconstruct the full identifier (react-router splits on /)
-  const fullIdentifier = identifier ? `npub${identifier}` : undefined;
+  // Get the full npub from the URL (npub1 + captured part)
+  const fullIdentifier = params["*"] ? `npub1${params["*"]}` : undefined;
 
   // Decode the npub identifier (synchronous, memoized)
   const { decoded, error } = useNip19Decode(fullIdentifier, "npub");

--- a/src/components/pages/PreviewProfilePage.tsx
+++ b/src/components/pages/PreviewProfilePage.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router";
-import { nip19 } from "nostr-tools";
+import { useNip19Decode } from "@/hooks/useNip19Decode";
 import { ProfileViewer } from "../ProfileViewer";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useEffect } from "react";
 
 /**
  * PreviewProfilePage - Preview a Nostr profile from an npub identifier
@@ -13,36 +13,25 @@ import { toast } from "sonner";
 export default function PreviewProfilePage() {
   const { identifier } = useParams<{ identifier: string }>();
   const navigate = useNavigate();
-  const [pubkey, setPubkey] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
+  // Reconstruct the full identifier (react-router splits on /)
+  const fullIdentifier = identifier ? `npub${identifier}` : undefined;
+
+  // Decode the npub identifier
+  const { decoded, isLoading, error, retry } = useNip19Decode(
+    fullIdentifier,
+    "npub"
+  );
+
+  // Show error toast when error occurs
   useEffect(() => {
-    if (!identifier) {
-      setError("No identifier provided");
-      return;
-    }
-
-    // Reconstruct the full identifier (react-router splits on /)
-    const fullIdentifier = `npub${identifier}`;
-
-    try {
-      const decoded = nip19.decode(fullIdentifier);
-      if (decoded.type !== "npub") {
-        setError(`Invalid identifier type: expected npub, got ${decoded.type}`);
-        toast.error("Invalid npub identifier");
-        return;
-      }
-
-      setPubkey(decoded.data);
-    } catch (e) {
-      console.error("Failed to decode npub:", e);
-      setError(e instanceof Error ? e.message : "Failed to decode identifier");
+    if (error) {
       toast.error("Invalid npub identifier");
     }
-  }, [identifier]);
+  }, [error]);
 
   // Loading state
-  if (!pubkey && !error) {
+  if (isLoading) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
         <Loader2 className="size-8 animate-spin text-primary/50" />
@@ -58,22 +47,35 @@ export default function PreviewProfilePage() {
   if (error) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-4">
-        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md">
+        <div className="text-destructive text-sm bg-destructive/10 px-4 py-2 rounded-md max-w-md text-center">
           {error}
         </div>
-        <button
-          onClick={() => navigate("/")}
-          className="text-sm text-muted-foreground hover:text-foreground underline"
-        >
-          Return to dashboard
-        </button>
+        <div className="flex gap-3">
+          <button
+            onClick={retry}
+            className="text-sm text-primary hover:text-primary/80 underline"
+          >
+            Retry
+          </button>
+          <button
+            onClick={() => navigate("/")}
+            className="text-sm text-muted-foreground hover:text-foreground underline"
+          >
+            Return to dashboard
+          </button>
+        </div>
       </div>
     );
   }
 
+  // Type guard to ensure we have the correct decoded type
+  if (!decoded || decoded.type !== "npub") {
+    return null;
+  }
+
   return (
     <div className="h-full overflow-auto">
-      <ProfileViewer pubkey={pubkey!} />
+      <ProfileViewer pubkey={decoded.data} />
     </div>
   );
 }

--- a/src/hooks/useNip19Decode.test.ts
+++ b/src/hooks/useNip19Decode.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useNip19Decode } from "./useNip19Decode";
+import { nip19 } from "nostr-tools";
+
+describe("useNip19Decode", () => {
+  // Test data
+  const testPubkey =
+    "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d";
+  const testEventId =
+    "d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027";
+
+  describe("npub decoding", () => {
+    it("should decode valid npub identifier", async () => {
+      const npub = nip19.npubEncode(testPubkey);
+      const { result } = renderHook(() => useNip19Decode(npub));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toEqual({
+        type: "npub",
+        data: testPubkey,
+      });
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should validate expected type for npub", async () => {
+      const npub = nip19.npubEncode(testPubkey);
+      const { result } = renderHook(() => useNip19Decode(npub, "npub"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toEqual({
+        type: "npub",
+        data: testPubkey,
+      });
+      expect(result.current.error).toBeNull();
+    });
+
+    it("should error when expected type doesn't match", async () => {
+      const npub = nip19.npubEncode(testPubkey);
+      const { result } = renderHook(() => useNip19Decode(npub, "note"));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toBeNull();
+      expect(result.current.error).toContain("expected note, got npub");
+    });
+  });
+
+  describe("note decoding", () => {
+    it("should decode valid note identifier", async () => {
+      const note = nip19.noteEncode(testEventId);
+      const { result } = renderHook(() => useNip19Decode(note));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toEqual({
+        type: "note",
+        data: testEventId,
+      });
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("nevent decoding", () => {
+    it("should decode valid nevent identifier", async () => {
+      const nevent = nip19.neventEncode({
+        id: testEventId,
+        relays: ["wss://relay.example.com"],
+      });
+      const { result } = renderHook(() => useNip19Decode(nevent));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded?.type).toBe("nevent");
+      expect(result.current.decoded?.data).toEqual({
+        id: testEventId,
+        relays: ["wss://relay.example.com"],
+      });
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("naddr decoding", () => {
+    it("should decode valid naddr identifier", async () => {
+      const naddr = nip19.naddrEncode({
+        kind: 30777,
+        pubkey: testPubkey,
+        identifier: "test-spellbook",
+        relays: ["wss://relay.example.com"],
+      });
+      const { result } = renderHook(() => useNip19Decode(naddr));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded?.type).toBe("naddr");
+      expect(result.current.decoded?.data).toEqual({
+        kind: 30777,
+        pubkey: testPubkey,
+        identifier: "test-spellbook",
+        relays: ["wss://relay.example.com"],
+      });
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle missing identifier", async () => {
+      const { result } = renderHook(() => useNip19Decode(undefined));
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toBeNull();
+      expect(result.current.error).toBe("No identifier provided");
+    });
+
+    it("should handle invalid identifier format", async () => {
+      const { result } = renderHook(() =>
+        useNip19Decode("invalid-identifier")
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toBeNull();
+      expect(result.current.error).toBeTruthy();
+    });
+
+    it("should handle corrupted bech32 string", async () => {
+      const { result } = renderHook(() =>
+        useNip19Decode("npub1invalidbech32string")
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded).toBeNull();
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe("retry functionality", () => {
+    it("should retry decoding when retry is called", async () => {
+      const { result } = renderHook(() =>
+        useNip19Decode("invalid-identifier")
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toBeTruthy();
+
+      // Call retry wrapped in act
+      act(() => {
+        result.current.retry();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should still have error since the identifier is still invalid
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe("identifier changes", () => {
+    it("should reset state when identifier changes", async () => {
+      const npub = nip19.npubEncode(testPubkey);
+      const { result, rerender } = renderHook(
+        ({ id }: { id: string | undefined }) => useNip19Decode(id),
+        {
+          initialProps: { id: npub as string },
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded?.type).toBe("npub");
+
+      // Change to note
+      const note = nip19.noteEncode(testEventId);
+      rerender({ id: note });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.decoded?.type).toBe("note");
+      expect(result.current.error).toBeNull();
+    });
+  });
+});

--- a/src/hooks/useNip19Decode.test.ts
+++ b/src/hooks/useNip19Decode.test.ts
@@ -105,9 +105,7 @@ describe("useNip19Decode", () => {
     });
 
     it("should handle invalid identifier format", () => {
-      const { result } = renderHook(() =>
-        useNip19Decode("invalid-identifier")
-      );
+      const { result } = renderHook(() => useNip19Decode("invalid-identifier"));
 
       expect(result.current.decoded).toBeNull();
       expect(result.current.error).toBeTruthy();
@@ -115,7 +113,7 @@ describe("useNip19Decode", () => {
 
     it("should handle corrupted bech32 string", () => {
       const { result } = renderHook(() =>
-        useNip19Decode("npub1invalidbech32string")
+        useNip19Decode("npub1invalidbech32string"),
       );
 
       expect(result.current.decoded).toBeNull();
@@ -130,7 +128,7 @@ describe("useNip19Decode", () => {
         ({ id }: { id: string | undefined }) => useNip19Decode(id),
         {
           initialProps: { id: npub as string },
-        }
+        },
       );
 
       const firstResult = result.current;
@@ -149,7 +147,7 @@ describe("useNip19Decode", () => {
         ({ id }: { id: string | undefined }) => useNip19Decode(id),
         {
           initialProps: { id: npub as string },
-        }
+        },
       );
 
       expect(result.current.decoded?.type).toBe("npub");

--- a/src/hooks/useNip19Decode.test.ts
+++ b/src/hooks/useNip19Decode.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import { useNip19Decode } from "./useNip19Decode";
 import { nip19 } from "nostr-tools";
 
@@ -14,14 +14,10 @@ describe("useNip19Decode", () => {
     "d7dd5eb3ab747e16f8d0212d53032ea2a7cadef53837e5a6c66d42849fcb9027";
 
   describe("npub decoding", () => {
-    it("should decode valid npub identifier", async () => {
+    it("should decode valid npub identifier", () => {
       const npub = nip19.npubEncode(testPubkey);
       const { result } = renderHook(() => useNip19Decode(npub));
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
       expect(result.current.decoded).toEqual({
         type: "npub",
         data: testPubkey,
@@ -29,14 +25,10 @@ describe("useNip19Decode", () => {
       expect(result.current.error).toBeNull();
     });
 
-    it("should validate expected type for npub", async () => {
+    it("should validate expected type for npub", () => {
       const npub = nip19.npubEncode(testPubkey);
       const { result } = renderHook(() => useNip19Decode(npub, "npub"));
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
       expect(result.current.decoded).toEqual({
         type: "npub",
         data: testPubkey,
@@ -44,13 +36,9 @@ describe("useNip19Decode", () => {
       expect(result.current.error).toBeNull();
     });
 
-    it("should error when expected type doesn't match", async () => {
+    it("should error when expected type doesn't match", () => {
       const npub = nip19.npubEncode(testPubkey);
       const { result } = renderHook(() => useNip19Decode(npub, "note"));
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded).toBeNull();
       expect(result.current.error).toContain("expected note, got npub");
@@ -58,13 +46,9 @@ describe("useNip19Decode", () => {
   });
 
   describe("note decoding", () => {
-    it("should decode valid note identifier", async () => {
+    it("should decode valid note identifier", () => {
       const note = nip19.noteEncode(testEventId);
       const { result } = renderHook(() => useNip19Decode(note));
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded).toEqual({
         type: "note",
@@ -75,16 +59,12 @@ describe("useNip19Decode", () => {
   });
 
   describe("nevent decoding", () => {
-    it("should decode valid nevent identifier", async () => {
+    it("should decode valid nevent identifier", () => {
       const nevent = nip19.neventEncode({
         id: testEventId,
         relays: ["wss://relay.example.com"],
       });
       const { result } = renderHook(() => useNip19Decode(nevent));
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded?.type).toBe("nevent");
       expect(result.current.decoded?.data).toEqual({
@@ -96,7 +76,7 @@ describe("useNip19Decode", () => {
   });
 
   describe("naddr decoding", () => {
-    it("should decode valid naddr identifier", async () => {
+    it("should decode valid naddr identifier", () => {
       const naddr = nip19.naddrEncode({
         kind: 30777,
         pubkey: testPubkey,
@@ -104,10 +84,6 @@ describe("useNip19Decode", () => {
         relays: ["wss://relay.example.com"],
       });
       const { result } = renderHook(() => useNip19Decode(naddr));
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded?.type).toBe("naddr");
       expect(result.current.decoded?.data).toEqual({
@@ -121,72 +97,34 @@ describe("useNip19Decode", () => {
   });
 
   describe("error handling", () => {
-    it("should handle missing identifier", async () => {
+    it("should handle missing identifier", () => {
       const { result } = renderHook(() => useNip19Decode(undefined));
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded).toBeNull();
       expect(result.current.error).toBe("No identifier provided");
     });
 
-    it("should handle invalid identifier format", async () => {
+    it("should handle invalid identifier format", () => {
       const { result } = renderHook(() =>
         useNip19Decode("invalid-identifier")
       );
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded).toBeNull();
       expect(result.current.error).toBeTruthy();
     });
 
-    it("should handle corrupted bech32 string", async () => {
+    it("should handle corrupted bech32 string", () => {
       const { result } = renderHook(() =>
         useNip19Decode("npub1invalidbech32string")
       );
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
       expect(result.current.decoded).toBeNull();
       expect(result.current.error).toBeTruthy();
     });
   });
 
-  describe("retry functionality", () => {
-    it("should retry decoding when retry is called", async () => {
-      const { result } = renderHook(() =>
-        useNip19Decode("invalid-identifier")
-      );
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.error).toBeTruthy();
-
-      // Call retry wrapped in act
-      act(() => {
-        result.current.retry();
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      // Should still have error since the identifier is still invalid
-      expect(result.current.error).toBeTruthy();
-    });
-  });
-
-  describe("identifier changes", () => {
-    it("should reset state when identifier changes", async () => {
+  describe("memoization", () => {
+    it("should memoize results for same identifier", () => {
       const npub = nip19.npubEncode(testPubkey);
       const { result, rerender } = renderHook(
         ({ id }: { id: string | undefined }) => useNip19Decode(id),
@@ -195,19 +133,30 @@ describe("useNip19Decode", () => {
         }
       );
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
+      const firstResult = result.current;
+      expect(firstResult.decoded?.type).toBe("npub");
+
+      // Rerender with same identifier
+      rerender({ id: npub as string });
+
+      // Should return exact same object reference (memoized)
+      expect(result.current).toBe(firstResult);
+    });
+
+    it("should recompute when identifier changes", () => {
+      const npub = nip19.npubEncode(testPubkey);
+      const { result, rerender } = renderHook(
+        ({ id }: { id: string | undefined }) => useNip19Decode(id),
+        {
+          initialProps: { id: npub as string },
+        }
+      );
 
       expect(result.current.decoded?.type).toBe("npub");
 
       // Change to note
       const note = nip19.noteEncode(testEventId);
       rerender({ id: note });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
 
       expect(result.current.decoded?.type).toBe("note");
       expect(result.current.error).toBeNull();

--- a/src/hooks/useNip19Decode.ts
+++ b/src/hooks/useNip19Decode.ts
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { nip19 } from "nostr-tools";
+import type {
+  EventPointer,
+  AddressPointer,
+  ProfilePointer,
+} from "nostr-tools/nip19";
+
+/**
+ * Supported NIP-19 entity types for decoding
+ */
+export type Nip19EntityType = "npub" | "note" | "nevent" | "naddr" | "nprofile";
+
+/**
+ * Decoded entity result with discriminated union for type safety
+ */
+export type DecodedEntity =
+  | { type: "npub"; data: string }
+  | { type: "note"; data: string }
+  | { type: "nevent"; data: EventPointer }
+  | { type: "naddr"; data: AddressPointer }
+  | { type: "nprofile"; data: ProfilePointer };
+
+/**
+ * Hook result containing decoded data, loading, and error states
+ */
+export interface UseNip19DecodeResult {
+  /** Decoded entity (null while loading or on error) */
+  decoded: DecodedEntity | null;
+  /** Loading state */
+  isLoading: boolean;
+  /** Error message (null if no error) */
+  error: string | null;
+  /** Retry the decode operation */
+  retry: () => void;
+}
+
+/**
+ * Hook to decode NIP-19 encoded entities (npub, note, nevent, naddr, nprofile)
+ *
+ * @param identifier - The NIP-19 encoded string (e.g., "npub1...")
+ * @param expectedType - Optional expected type for validation
+ * @returns Decoded entity with loading and error states
+ *
+ * @example
+ * ```tsx
+ * const { decoded, isLoading, error } = useNip19Decode(identifier, "npub");
+ * if (isLoading) return <Loading />;
+ * if (error) return <Error message={error} />;
+ * if (decoded?.type === "npub") {
+ *   return <Profile pubkey={decoded.data} />;
+ * }
+ * ```
+ */
+export function useNip19Decode(
+  identifier: string | undefined,
+  expectedType?: Nip19EntityType
+): UseNip19DecodeResult {
+  const [decoded, setDecoded] = useState<DecodedEntity | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    // Reset state when identifier changes
+    setDecoded(null);
+    setError(null);
+    setIsLoading(true);
+
+    if (!identifier) {
+      setError("No identifier provided");
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const result = nip19.decode(identifier);
+
+      // Validate expected type if provided
+      if (expectedType && result.type !== expectedType) {
+        setError(
+          `Invalid identifier type: expected ${expectedType}, got ${result.type}`
+        );
+        setIsLoading(false);
+        return;
+      }
+
+      // Map decoded result to typed entity
+      let entity: DecodedEntity;
+
+      switch (result.type) {
+        case "npub":
+          entity = { type: "npub", data: result.data };
+          break;
+        case "note":
+          entity = { type: "note", data: result.data };
+          break;
+        case "nevent":
+          entity = { type: "nevent", data: result.data };
+          break;
+        case "naddr":
+          entity = { type: "naddr", data: result.data };
+          break;
+        case "nprofile":
+          entity = { type: "nprofile", data: result.data };
+          break;
+        default:
+          setError(`Unsupported entity type: ${result.type}`);
+          setIsLoading(false);
+          return;
+      }
+
+      setDecoded(entity);
+      setIsLoading(false);
+    } catch (e) {
+      console.error("Failed to decode NIP-19 identifier:", identifier, e);
+      const errorMessage =
+        e instanceof Error ? e.message : "Failed to decode identifier";
+      setError(errorMessage);
+      setIsLoading(false);
+    }
+  }, [identifier, expectedType, retryCount]);
+
+  const retry = () => {
+    setRetryCount((prev) => prev + 1);
+  };
+
+  return {
+    decoded,
+    isLoading,
+    error,
+    retry,
+  };
+}

--- a/src/hooks/useNip19Decode.ts
+++ b/src/hooks/useNip19Decode.ts
@@ -50,7 +50,7 @@ export interface UseNip19DecodeResult {
  */
 export function useNip19Decode(
   identifier: string | undefined,
-  expectedType?: Nip19EntityType
+  expectedType?: Nip19EntityType,
 ): UseNip19DecodeResult {
   return useMemo(() => {
     if (!identifier) {

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -16,7 +16,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "/npub:identifier",
+    path: "/npub1*",
     element: (
       <AppShell hideBottomBar>
         <PreviewProfilePage />
@@ -24,7 +24,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "/nevent:identifier",
+    path: "/nevent1*",
     element: (
       <AppShell hideBottomBar>
         <PreviewEventPage />
@@ -32,7 +32,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "/note:identifier",
+    path: "/note1*",
     element: (
       <AppShell hideBottomBar>
         <PreviewEventPage />
@@ -40,7 +40,7 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "/naddr:identifier",
+    path: "/naddr1*",
     element: (
       <AppShell hideBottomBar>
         <PreviewAddressPage />

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -2,6 +2,9 @@ import { createBrowserRouter, RouterProvider } from "react-router";
 import { AppShell } from "./components/layouts/AppShell";
 import DashboardPage from "./components/pages/DashboardPage";
 import SpellbookPage from "./components/pages/SpellbookPage";
+import PreviewProfilePage from "./components/pages/PreviewProfilePage";
+import PreviewEventPage from "./components/pages/PreviewEventPage";
+import PreviewAddressPage from "./components/pages/PreviewAddressPage";
 
 const router = createBrowserRouter([
   {
@@ -9,6 +12,38 @@ const router = createBrowserRouter([
     element: (
       <AppShell>
         <DashboardPage />
+      </AppShell>
+    ),
+  },
+  {
+    path: "/npub:identifier",
+    element: (
+      <AppShell hideBottomBar>
+        <PreviewProfilePage />
+      </AppShell>
+    ),
+  },
+  {
+    path: "/nevent:identifier",
+    element: (
+      <AppShell hideBottomBar>
+        <PreviewEventPage />
+      </AppShell>
+    ),
+  },
+  {
+    path: "/note:identifier",
+    element: (
+      <AppShell hideBottomBar>
+        <PreviewEventPage />
+      </AppShell>
+    ),
+  },
+  {
+    path: "/naddr:identifier",
+    element: (
+      <AppShell hideBottomBar>
+        <PreviewAddressPage />
       </AppShell>
     ),
   },

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -2,9 +2,7 @@ import { createBrowserRouter, RouterProvider } from "react-router";
 import { AppShell } from "./components/layouts/AppShell";
 import DashboardPage from "./components/pages/DashboardPage";
 import SpellbookPage from "./components/pages/SpellbookPage";
-import PreviewProfilePage from "./components/pages/PreviewProfilePage";
-import PreviewEventPage from "./components/pages/PreviewEventPage";
-import PreviewAddressPage from "./components/pages/PreviewAddressPage";
+import Nip19PreviewRouter from "./components/pages/Nip19PreviewRouter";
 
 const router = createBrowserRouter([
   {
@@ -16,38 +14,6 @@ const router = createBrowserRouter([
     ),
   },
   {
-    path: "/npub1*",
-    element: (
-      <AppShell hideBottomBar>
-        <PreviewProfilePage />
-      </AppShell>
-    ),
-  },
-  {
-    path: "/nevent1*",
-    element: (
-      <AppShell hideBottomBar>
-        <PreviewEventPage />
-      </AppShell>
-    ),
-  },
-  {
-    path: "/note1*",
-    element: (
-      <AppShell hideBottomBar>
-        <PreviewEventPage />
-      </AppShell>
-    ),
-  },
-  {
-    path: "/naddr1*",
-    element: (
-      <AppShell hideBottomBar>
-        <PreviewAddressPage />
-      </AppShell>
-    ),
-  },
-  {
     path: "/preview/:actor/:identifier",
     element: (
       <AppShell>
@@ -55,6 +21,32 @@ const router = createBrowserRouter([
       </AppShell>
     ),
   },
+  // NIP-19 identifier preview route - must come before /:actor/:identifier catch-all
+  {
+    path: "/:identifier",
+    element: (
+      <AppShell hideBottomBar>
+        <Nip19PreviewRouter />
+      </AppShell>
+    ),
+    // Only match single-segment paths that look like NIP-19 identifiers
+    loader: ({ params }) => {
+      const id = params.identifier;
+      if (
+        !id ||
+        !(
+          id.startsWith("npub1") ||
+          id.startsWith("note1") ||
+          id.startsWith("nevent1") ||
+          id.startsWith("naddr1")
+        )
+      ) {
+        throw new Response("Not Found", { status: 404 });
+      }
+      return null;
+    },
+  },
+  // Catch-all for two-segment paths (spellbooks, etc.)
   {
     path: "/:actor/:identifier",
     element: (


### PR DESCRIPTION
This commit adds dedicated preview routes for Nostr identifiers at the root level:
- /npub... - Shows a single profile view for npub identifiers
- /nevent... - Shows a single event detail view for nevent identifiers
- /note... - Shows a single event detail view for note identifiers
- /naddr... - Redirects spellbooks (kind 30777) to /:actor/:identifier route

Key changes:
- Created PreviewProfilePage component for npub identifiers
- Created PreviewEventPage component for nevent/note identifiers
- Created PreviewAddressPage component for naddr redirects
- Added hideBottomBar prop to AppShell to hide tabs in preview mode
- Added routes to root.tsx for all identifier types

Preview pages don't show bottom tabs and don't affect user's workspace layout.