### PR TITLE
feat: render highlight comments with RichText component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "grimoire",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/src/components/nostr/kinds/HighlightDetailRenderer.tsx
+++ b/src/components/nostr/kinds/HighlightDetailRenderer.tsx
@@ -39,6 +39,14 @@ export function Kind9802DetailRenderer({ event }: { event: NostrEvent }) {
     },
   );
 
+  // Create synthetic event for comment rendering (preserves emoji tags)
+  const commentEvent = comment
+    ? {
+        ...event,
+        content: comment,
+      }
+    : undefined;
+
   return (
     <div className="flex flex-col gap-6 p-6 max-w-3xl mx-auto">
       {/* Highlight Header */}
@@ -76,13 +84,13 @@ export function Kind9802DetailRenderer({ event }: { event: NostrEvent }) {
       )}
 
       {/* Comment */}
-      {comment && (
+      {commentEvent && (
         <div className="flex flex-col gap-2">
           <div className="text-xs text-muted-foreground uppercase tracking-wide">
             Comment
           </div>
           <RichText
-            content={comment}
+            event={commentEvent}
             className="text-sm leading-relaxed"
             options={{ showMedia: false, showEventEmbeds: false }}
           />

--- a/src/components/nostr/kinds/HighlightDetailRenderer.tsx
+++ b/src/components/nostr/kinds/HighlightDetailRenderer.tsx
@@ -11,6 +11,7 @@ import {
 import { EmbeddedEvent } from "../EmbeddedEvent";
 import { UserName } from "../UserName";
 import { useGrimoire } from "@/core/state";
+import { RichText } from "../RichText";
 
 /**
  * Detail renderer for Kind 9802 - Highlight
@@ -80,7 +81,11 @@ export function Kind9802DetailRenderer({ event }: { event: NostrEvent }) {
           <div className="text-xs text-muted-foreground uppercase tracking-wide">
             Comment
           </div>
-          <p className="text-sm leading-relaxed">{comment}</p>
+          <RichText
+            content={comment}
+            className="text-sm leading-relaxed"
+            options={{ showMedia: false, showEventEmbeds: false }}
+          />
         </div>
       )}
 

--- a/src/components/nostr/kinds/HighlightRenderer.tsx
+++ b/src/components/nostr/kinds/HighlightRenderer.tsx
@@ -53,7 +53,13 @@ export function Kind9802Renderer({ event }: BaseEventProps) {
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
         {/* Comment */}
-        {comment && <p className="text-sm text-foreground">{comment}</p>}
+        {comment && (
+          <RichText
+            content={comment}
+            className="text-sm text-foreground"
+            options={{ showMedia: false, showEventEmbeds: false }}
+          />
+        )}
 
         {/* Highlighted text */}
         {highlightText && (

--- a/src/components/nostr/kinds/HighlightRenderer.tsx
+++ b/src/components/nostr/kinds/HighlightRenderer.tsx
@@ -49,13 +49,21 @@ export function Kind9802Renderer({ event }: BaseEventProps) {
     }
   };
 
+  // Create synthetic event for comment rendering (preserves emoji tags)
+  const commentEvent = comment
+    ? {
+        ...event,
+        content: comment,
+      }
+    : undefined;
+
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
         {/* Comment */}
-        {comment && (
+        {commentEvent && (
           <RichText
-            content={comment}
+            event={commentEvent}
             className="text-sm text-foreground"
             options={{ showMedia: false, showEventEmbeds: false }}
           />


### PR DESCRIPTION
Enable support for custom emoji, mentions, hashtags, and other rich text features in highlight comments by using the RichText component instead of plain text rendering.

Changes:
- HighlightRenderer: Use RichText for comment rendering with media/embeds disabled
- HighlightDetailRenderer: Add RichText import and use it for comment rendering