### PR TITLE
Fix command launcher in event preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/shell-quote": "^1.7.5",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/ui": "^4.0.15",
         "autoprefixer": "^10.4.20",
@@ -4388,6 +4389,16 @@
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.48.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/shell-quote": "^1.7.5",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/ui": "^4.0.15",
     "autoprefixer": "^10.4.20",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,5 +9,4 @@ import "fake-indexeddb/auto";
 
 // Polyfill WebSocket - required by nostr-tools relay code
 import { WebSocket } from "ws";
-// @ts-expect-error - polyfilling global WebSocket for Node.js
-globalThis.WebSocket = WebSocket;
+globalThis.WebSocket = WebSocket as unknown as typeof globalThis.WebSocket;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,13 @@
 /**
  * Vitest setup file
  *
- * Polyfills IndexedDB for Node.js test environment.
- * This allows Dexie to work in tests without a browser.
+ * Polyfills browser APIs for Node.js test environment.
  */
+
+// Polyfill IndexedDB - allows Dexie to work in tests
 import "fake-indexeddb/auto";
+
+// Polyfill WebSocket - required by nostr-tools relay code
+import { WebSocket } from "ws";
+// @ts-expect-error - polyfilling global WebSocket for Node.js
+globalThis.WebSocket = WebSocket;


### PR DESCRIPTION
NIP-19 preview routes (/nevent..., /npub..., etc.) don't render the window system, so commands executed there appeared to do nothing. Now detects preview routes and navigates to the dashboard before creating the window, so the command actually takes effect.