### PR TITLE
Add Enter shortcut to send messages

### DIFF
--- a/src/components/editor/EmojiSuggestionList.tsx
+++ b/src/components/editor/EmojiSuggestionList.tsx
@@ -58,7 +58,7 @@ export const EmojiSuggestionList = forwardRef<
         return true;
       }
 
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.ctrlKey && !event.metaKey) {
         if (items[selectedIndex]) {
           command(items[selectedIndex]);
         }

--- a/src/components/editor/ProfileSuggestionList.tsx
+++ b/src/components/editor/ProfileSuggestionList.tsx
@@ -38,7 +38,7 @@ export const ProfileSuggestionList = forwardRef<
         return true;
       }
 
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.ctrlKey && !event.metaKey) {
         if (items[selectedIndex]) {
           command(items[selectedIndex]);
         }


### PR DESCRIPTION
… open

The suggestion list components were intercepting all Enter key presses, including Ctrl+Enter and Cmd+Enter, preventing message submission when the autocomplete popup was visible. Now these modifier combinations pass through to the editor's submit handler.