### PR TITLE
Add NIP-53 live event chat adapter

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -174,9 +174,6 @@ const MessageItem = memo(function MessageItem({
 
   // Zap messages have special styling with gradient border
   if (message.type === "zap") {
-    const zapAmount = message.metadata?.zapAmount || 0;
-    const zapRecipient = message.metadata?.zapRecipient;
-    // Get the zap request event for RichText (contains emoji tags)
     const zapRequest = message.event ? getZapRequest(message.event) : null;
 
     return (
@@ -189,34 +186,34 @@ const MessageItem = memo(function MessageItem({
           }}
         >
           <div className="rounded-lg bg-background px-3 py-1.5">
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-2">
               <UserName
                 pubkey={message.author}
                 className="font-semibold text-sm"
               />
               <Zap className="size-4 fill-yellow-500 text-yellow-500" />
               <span className="text-yellow-500 font-bold">
-                {zapAmount.toLocaleString("en", { notation: "compact" })}
+                {(message.metadata?.zapAmount || 0).toLocaleString("en", {
+                  notation: "compact",
+                })}
               </span>
-              {zapRecipient && (
-                <UserName pubkey={zapRecipient} className="text-sm" />
+              {message.metadata?.zapRecipient && (
+                <UserName
+                  pubkey={message.metadata.zapRecipient}
+                  className="text-sm"
+                />
               )}
-              <span className="text-xs text-muted-foreground ml-auto">
+              <span className="text-xs text-muted-foreground">
                 <Timestamp timestamp={message.timestamp} />
               </span>
             </div>
             {message.content && (
-              <div className="mt-1 text-sm break-words">
-                {zapRequest ? (
-                  <RichText
-                    event={zapRequest}
-                    className="text-sm leading-tight"
-                    options={{ showMedia: false, showEventEmbeds: false }}
-                  />
-                ) : (
-                  message.content
-                )}
-              </div>
+              <RichText
+                content={message.content}
+                event={zapRequest || undefined}
+                className="mt-1 text-sm leading-tight break-words"
+                options={{ showMedia: false, showEventEmbeds: false }}
+              />
             )}
           </div>
         </div>

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, memo, useCallback, useRef } from "react";
 import { use$ } from "applesauce-react/hooks";
 import { from } from "rxjs";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
-import { Reply } from "lucide-react";
+import { Reply, Zap } from "lucide-react";
 import accountManager from "@/services/accounts";
 import eventStore from "@/services/event-store";
 import type {
@@ -167,6 +167,49 @@ const MessageItem = memo(function MessageItem({
           * <UserName pubkey={message.author} className="text-xs" />{" "}
           {message.content}
         </span>
+      </div>
+    );
+  }
+
+  // Zap messages have special styling with gradient border
+  if (message.type === "zap") {
+    const zapAmount = message.metadata?.zapAmount || 0;
+    const zapRecipient = message.metadata?.zapRecipient;
+
+    return (
+      <div className="px-3 py-1">
+        <div
+          className="rounded-lg p-[1px]"
+          style={{
+            background:
+              "linear-gradient(to right, rgb(250 204 21), rgb(251 146 60), rgb(168 85 247), rgb(34 211 238))",
+          }}
+        >
+          <div className="rounded-lg bg-background px-3 py-1.5">
+            <div className="flex items-center gap-2 flex-wrap">
+              <UserName
+                pubkey={message.author}
+                className="font-semibold text-sm"
+              />
+              <Zap className="size-4 fill-yellow-500 text-yellow-500" />
+              <span className="text-yellow-500 font-bold">
+                {zapAmount.toLocaleString("en", { notation: "compact" })}
+              </span>
+              {zapRecipient && (
+                <>
+                  <span className="text-muted-foreground text-xs">→</span>
+                  <UserName pubkey={zapRecipient} className="text-sm" />
+                </>
+              )}
+              <span className="text-xs text-muted-foreground ml-auto">
+                <Timestamp timestamp={message.timestamp} />
+              </span>
+            </div>
+            {message.content && (
+              <div className="mt-1 text-sm break-words">{message.content}</div>
+            )}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -3,6 +3,7 @@ import { use$ } from "applesauce-react/hooks";
 import { from } from "rxjs";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { Reply, Zap } from "lucide-react";
+import { getZapRequest } from "applesauce-common/helpers/zap";
 import accountManager from "@/services/accounts";
 import eventStore from "@/services/event-store";
 import type {
@@ -175,6 +176,8 @@ const MessageItem = memo(function MessageItem({
   if (message.type === "zap") {
     const zapAmount = message.metadata?.zapAmount || 0;
     const zapRecipient = message.metadata?.zapRecipient;
+    // Get the zap request event for RichText (contains emoji tags)
+    const zapRequest = message.event ? getZapRequest(message.event) : null;
 
     return (
       <div className="px-3 py-1">
@@ -196,17 +199,24 @@ const MessageItem = memo(function MessageItem({
                 {zapAmount.toLocaleString("en", { notation: "compact" })}
               </span>
               {zapRecipient && (
-                <>
-                  <span className="text-muted-foreground text-xs">→</span>
-                  <UserName pubkey={zapRecipient} className="text-sm" />
-                </>
+                <UserName pubkey={zapRecipient} className="text-sm" />
               )}
               <span className="text-xs text-muted-foreground ml-auto">
                 <Timestamp timestamp={message.timestamp} />
               </span>
             </div>
             {message.content && (
-              <div className="mt-1 text-sm break-words">{message.content}</div>
+              <div className="mt-1 text-sm break-words">
+                {zapRequest ? (
+                  <RichText
+                    event={zapRequest}
+                    className="text-sm leading-tight"
+                    options={{ showMedia: false, showEventEmbeds: false }}
+                  />
+                ) : (
+                  message.content
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/src/components/chat/RelaysDropdown.tsx
+++ b/src/components/chat/RelaysDropdown.tsx
@@ -24,8 +24,15 @@ export function RelaysDropdown({ conversation }: RelaysDropdownProps) {
   // Get relays for this conversation
   const relays: string[] = [];
 
-  // NIP-29: Single group relay
-  if (conversation.metadata?.relayUrl) {
+  // NIP-53: Multiple relays from liveActivity
+  const liveActivityRelays = conversation.metadata?.liveActivity?.relays as
+    | string[]
+    | undefined;
+  if (liveActivityRelays?.length) {
+    relays.push(...liveActivityRelays);
+  }
+  // NIP-29: Single group relay (fallback)
+  else if (conversation.metadata?.relayUrl) {
     relays.push(conversation.metadata.relayUrl);
   }
 

--- a/src/lib/chat-parser.ts
+++ b/src/lib/chat-parser.ts
@@ -1,10 +1,10 @@
 import type { ChatCommandResult } from "@/types/chat";
 // import { NipC7Adapter } from "./chat/adapters/nip-c7-adapter";
 import { Nip29Adapter } from "./chat/adapters/nip-29-adapter";
+import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 // Import other adapters as they're implemented
 // import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 // import { Nip28Adapter } from "./chat/adapters/nip-28-adapter";
-// import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 
 /**
  * Parse a chat command identifier and auto-detect the protocol
@@ -38,8 +38,8 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
   const adapters = [
     // new Nip17Adapter(),  // Phase 2
     // new Nip28Adapter(),  // Phase 3
-    new Nip29Adapter(), // Phase 4 - Relay groups (currently only enabled)
-    // new Nip53Adapter(),  // Phase 5
+    new Nip29Adapter(), // Phase 4 - Relay groups
+    new Nip53Adapter(), // Phase 5 - Live activity chat
     // new NipC7Adapter(), // Phase 1 - Simple chat (disabled for now)
   ];
 
@@ -65,10 +65,12 @@ Currently supported formats:
   - naddr1... (NIP-29 group metadata, kind 39000)
     Example:
       chat naddr1qqxnzdesxqmnxvpexqmny...
+  - naddr1... (NIP-53 live activity chat, kind 30311)
+    Example:
+      chat naddr1... (live stream address)
 
 More formats coming soon:
   - npub/nprofile/hex pubkey (NIP-C7/NIP-17 direct messages)
-  - note/nevent (NIP-28 public channels)
-  - naddr (NIP-53 live activity chat)`,
+  - note/nevent (NIP-28 public channels)`,
   );
 }

--- a/src/lib/chat/adapters/nip-53-adapter.test.ts
+++ b/src/lib/chat/adapters/nip-53-adapter.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { nip19 } from "nostr-tools";
+import { Nip53Adapter } from "./nip-53-adapter";
+
+describe("Nip53Adapter", () => {
+  const adapter = new Nip53Adapter();
+
+  describe("parseIdentifier", () => {
+    it("should parse kind 30311 naddr (live activity)", () => {
+      const naddr = nip19.naddrEncode({
+        kind: 30311,
+        pubkey:
+          "0000000000000000000000000000000000000000000000000000000000000001",
+        identifier: "my-live-stream",
+        relays: ["wss://relay.example.com"],
+      });
+
+      const result = adapter.parseIdentifier(naddr);
+      expect(result).toEqual({
+        type: "live-activity",
+        value: {
+          kind: 30311,
+          pubkey:
+            "0000000000000000000000000000000000000000000000000000000000000001",
+          identifier: "my-live-stream",
+        },
+        relays: ["wss://relay.example.com"],
+      });
+    });
+
+    it("should handle naddr with multiple relays", () => {
+      const naddr = nip19.naddrEncode({
+        kind: 30311,
+        pubkey:
+          "0000000000000000000000000000000000000000000000000000000000000001",
+        identifier: "podcast-episode",
+        relays: [
+          "wss://relay1.example.com",
+          "wss://relay2.example.com",
+          "wss://relay3.example.com",
+        ],
+      });
+
+      const result = adapter.parseIdentifier(naddr);
+      expect(result).toEqual({
+        type: "live-activity",
+        value: {
+          kind: 30311,
+          pubkey:
+            "0000000000000000000000000000000000000000000000000000000000000001",
+          identifier: "podcast-episode",
+        },
+        relays: [
+          "wss://relay1.example.com",
+          "wss://relay2.example.com",
+          "wss://relay3.example.com",
+        ],
+      });
+    });
+
+    it("should handle naddr without relay hints", () => {
+      const naddr = nip19.naddrEncode({
+        kind: 30311,
+        pubkey:
+          "0000000000000000000000000000000000000000000000000000000000000001",
+        identifier: "stream-id",
+        relays: [],
+      });
+
+      const result = adapter.parseIdentifier(naddr);
+      expect(result).toEqual({
+        type: "live-activity",
+        value: {
+          kind: 30311,
+          pubkey:
+            "0000000000000000000000000000000000000000000000000000000000000001",
+          identifier: "stream-id",
+        },
+        relays: [],
+      });
+    });
+
+    it("should return null for non-30311 kind naddr", () => {
+      // kind 39000 (NIP-29 group) should not work for NIP-53
+      const naddr = nip19.naddrEncode({
+        kind: 39000,
+        pubkey:
+          "0000000000000000000000000000000000000000000000000000000000000001",
+        identifier: "some-group",
+        relays: ["wss://relay.example.com"],
+      });
+
+      expect(adapter.parseIdentifier(naddr)).toBeNull();
+    });
+
+    it("should return null for other naddr kinds", () => {
+      // kind 30023 (long-form article) should not work
+      const naddr = nip19.naddrEncode({
+        kind: 30023,
+        pubkey:
+          "0000000000000000000000000000000000000000000000000000000000000001",
+        identifier: "article-slug",
+        relays: ["wss://relay.example.com"],
+      });
+
+      expect(adapter.parseIdentifier(naddr)).toBeNull();
+    });
+
+    it("should return null for malformed naddr", () => {
+      expect(adapter.parseIdentifier("naddr1invaliddata")).toBeNull();
+    });
+
+    it("should return null for non-naddr formats", () => {
+      // These should not match NIP-53 format
+      expect(adapter.parseIdentifier("")).toBeNull();
+      expect(adapter.parseIdentifier("npub1...")).toBeNull();
+      expect(adapter.parseIdentifier("note1...")).toBeNull();
+      expect(adapter.parseIdentifier("nevent1...")).toBeNull();
+      expect(adapter.parseIdentifier("relay.example.com'group")).toBeNull();
+      expect(adapter.parseIdentifier("alice@example.com")).toBeNull();
+    });
+
+    it("should return null for random strings", () => {
+      expect(adapter.parseIdentifier("just-a-string")).toBeNull();
+      expect(adapter.parseIdentifier("naddr")).toBeNull();
+      expect(adapter.parseIdentifier("naddr1")).toBeNull();
+    });
+  });
+
+  describe("protocol properties", () => {
+    it("should have correct protocol and type", () => {
+      expect(adapter.protocol).toBe("nip-53");
+      expect(adapter.type).toBe("live-chat");
+    });
+  });
+
+  describe("getCapabilities", () => {
+    it("should return correct capabilities", () => {
+      const capabilities = adapter.getCapabilities();
+
+      expect(capabilities.supportsEncryption).toBe(false);
+      expect(capabilities.supportsThreading).toBe(true);
+      expect(capabilities.supportsModeration).toBe(false);
+      expect(capabilities.supportsRoles).toBe(true);
+      expect(capabilities.supportsGroupManagement).toBe(false);
+      expect(capabilities.canCreateConversations).toBe(false);
+      expect(capabilities.requiresRelay).toBe(false);
+    });
+  });
+});

--- a/src/lib/chat/adapters/nip-53-adapter.ts
+++ b/src/lib/chat/adapters/nip-53-adapter.ts
@@ -1,0 +1,526 @@
+import { Observable } from "rxjs";
+import { map, first } from "rxjs/operators";
+import type { Filter } from "nostr-tools";
+import { nip19 } from "nostr-tools";
+import { ChatProtocolAdapter, type SendMessageOptions } from "./base-adapter";
+import type {
+  Conversation,
+  Message,
+  ProtocolIdentifier,
+  ChatCapabilities,
+  LoadMessagesOptions,
+  Participant,
+  ParticipantRole,
+} from "@/types/chat";
+import type { NostrEvent } from "@/types/nostr";
+import eventStore from "@/services/event-store";
+import pool from "@/services/relay-pool";
+import { publishEventToRelays } from "@/services/hub";
+import accountManager from "@/services/accounts";
+import {
+  parseLiveActivity,
+  getLiveStatus,
+  getLiveHost,
+} from "@/lib/live-activity";
+import { EventFactory } from "applesauce-core/event-factory";
+
+/**
+ * NIP-53 Adapter - Live Activity Chat
+ *
+ * Features:
+ * - Live streaming event chat (kind 1311)
+ * - Public, unencrypted messages
+ * - Host, speaker, and participant roles
+ * - Multi-relay support (from relays tag or naddr hints)
+ *
+ * Identifier format: naddr1... (kind 30311 live activity address)
+ * Messages reference activity via "a" tag
+ */
+export class Nip53Adapter extends ChatProtocolAdapter {
+  readonly protocol = "nip-53" as const;
+  readonly type = "live-chat" as const;
+
+  /**
+   * Parse identifier - accepts naddr format for kind 30311
+   * Examples:
+   *   - naddr1... (kind 30311 live activity address)
+   */
+  parseIdentifier(input: string): ProtocolIdentifier | null {
+    if (!input.startsWith("naddr1")) {
+      return null;
+    }
+
+    try {
+      const decoded = nip19.decode(input);
+      if (decoded.type === "naddr" && decoded.data.kind === 30311) {
+        const { pubkey, identifier, relays } = decoded.data;
+
+        return {
+          type: "live-activity",
+          value: {
+            kind: 30311,
+            pubkey,
+            identifier,
+          },
+          relays: relays || [],
+        };
+      }
+    } catch {
+      // Not a valid naddr
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve conversation from live activity address
+   */
+  async resolveConversation(
+    identifier: ProtocolIdentifier,
+  ): Promise<Conversation> {
+    const { pubkey, identifier: dTag } = identifier.value as {
+      kind: number;
+      pubkey: string;
+      identifier: string;
+    };
+    const relayHints = identifier.relays || [];
+
+    const activePubkey = accountManager.active$.value?.pubkey;
+    if (!activePubkey) {
+      throw new Error("No active account");
+    }
+
+    console.log(
+      `[NIP-53] Fetching live activity ${dTag} by ${pubkey.slice(0, 8)}...`,
+    );
+
+    // Use author's outbox relays plus any relay hints
+    const authorOutboxes = await this.getAuthorOutboxes(pubkey);
+    const relays = [...new Set([...relayHints, ...authorOutboxes])];
+
+    if (relays.length === 0) {
+      throw new Error("No relays available to fetch live activity");
+    }
+
+    console.log(`[NIP-53] Using relays: ${relays.join(", ")}`);
+
+    // Fetch the kind 30311 live activity event
+    const activityFilter: Filter = {
+      kinds: [30311],
+      authors: [pubkey],
+      "#d": [dTag],
+      limit: 1,
+    };
+
+    const activityEvents: NostrEvent[] = [];
+    const activityObs = pool.subscription(relays, [activityFilter], {
+      eventStore,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        console.log("[NIP-53] Activity fetch timeout");
+        resolve();
+      }, 5000);
+
+      const sub = activityObs.subscribe({
+        next: (response) => {
+          if (typeof response === "string") {
+            // EOSE received
+            clearTimeout(timeout);
+            console.log(
+              `[NIP-53] Got ${activityEvents.length} activity events`,
+            );
+            sub.unsubscribe();
+            resolve();
+          } else {
+            // Event received
+            activityEvents.push(response);
+          }
+        },
+        error: (err) => {
+          clearTimeout(timeout);
+          console.error("[NIP-53] Activity fetch error:", err);
+          sub.unsubscribe();
+          reject(err);
+        },
+      });
+    });
+
+    const activityEvent = activityEvents[0];
+
+    if (!activityEvent) {
+      throw new Error(`Live activity not found: ${pubkey.slice(0, 8)}:${dTag}`);
+    }
+
+    // Parse the live activity for rich metadata
+    const activity = parseLiveActivity(activityEvent);
+    const status = getLiveStatus(activityEvent);
+    const hostPubkey = getLiveHost(activityEvent);
+
+    // Map live activity roles to chat participant roles
+    const participants: Participant[] = activity.participants.map((p) => ({
+      pubkey: p.pubkey,
+      role: this.mapRole(p.role),
+    }));
+
+    // Ensure host is in participants list
+    if (!participants.some((p) => p.pubkey === hostPubkey)) {
+      participants.unshift({ pubkey: hostPubkey, role: "host" });
+    }
+
+    // Determine relays for chat - prefer activity's relays tag, fallback to relay hints
+    const chatRelays =
+      activity.relays.length > 0 ? activity.relays : relayHints;
+
+    console.log(
+      `[NIP-53] Resolved: "${activity.title}" (${status}), ${participants.length} participants, ${chatRelays.length} relays`,
+    );
+
+    return {
+      id: `nip-53:${pubkey}:${dTag}`,
+      type: "live-chat",
+      protocol: "nip-53",
+      title: activity.title || "Live Activity",
+      participants,
+      metadata: {
+        activityAddress: {
+          kind: 30311,
+          pubkey,
+          identifier: dTag,
+        },
+        // Live activity specific metadata
+        relayUrl: chatRelays[0], // Primary relay for compatibility
+        description: activity.summary,
+        icon: activity.image,
+        // Extended live activity metadata
+        liveActivity: {
+          status,
+          streaming: activity.streaming,
+          recording: activity.recording,
+          starts: activity.starts,
+          ends: activity.ends,
+          hostPubkey,
+          currentParticipants: activity.currentParticipants,
+          totalParticipants: activity.totalParticipants,
+          hashtags: activity.hashtags,
+          relays: chatRelays,
+        },
+      },
+      unreadCount: 0,
+    };
+  }
+
+  /**
+   * Load messages for a live activity
+   */
+  loadMessages(
+    conversation: Conversation,
+    options?: LoadMessagesOptions,
+  ): Observable<Message[]> {
+    const activityAddress = conversation.metadata?.activityAddress;
+    const liveActivity = conversation.metadata?.liveActivity as
+      | {
+          relays?: string[];
+        }
+      | undefined;
+
+    if (!activityAddress) {
+      throw new Error("Activity address required");
+    }
+
+    const { pubkey, identifier } = activityAddress;
+    const aTagValue = `30311:${pubkey}:${identifier}`;
+
+    // Get relays from live activity metadata or fall back to relayUrl
+    const relays = liveActivity?.relays || [];
+    if (relays.length === 0 && conversation.metadata?.relayUrl) {
+      relays.push(conversation.metadata.relayUrl);
+    }
+
+    if (relays.length === 0) {
+      throw new Error("No relays available for live chat");
+    }
+
+    console.log(
+      `[NIP-53] Loading messages for ${aTagValue} from ${relays.length} relays`,
+    );
+
+    // Subscribe to live chat messages (kind 1311)
+    const filter: Filter = {
+      kinds: [1311],
+      "#a": [aTagValue],
+      limit: options?.limit || 50,
+    };
+
+    if (options?.before) {
+      filter.until = options.before;
+    }
+    if (options?.after) {
+      filter.since = options.after;
+    }
+
+    // Start a persistent subscription to the relays
+    pool
+      .subscription(relays, [filter], {
+        eventStore,
+      })
+      .subscribe({
+        next: (response) => {
+          if (typeof response === "string") {
+            console.log("[NIP-53] EOSE received for messages");
+          } else {
+            console.log(
+              `[NIP-53] Received message: ${response.id.slice(0, 8)}...`,
+            );
+          }
+        },
+      });
+
+    // Return observable from EventStore which will update automatically
+    return eventStore.timeline(filter).pipe(
+      map((events) => {
+        console.log(`[NIP-53] Timeline has ${events.length} messages`);
+        return events
+          .map((event) => this.eventToMessage(event, conversation.id))
+          .sort((a, b) => a.timestamp - b.timestamp);
+      }),
+    );
+  }
+
+  /**
+   * Load more historical messages (pagination)
+   */
+  async loadMoreMessages(
+    _conversation: Conversation,
+    _before: number,
+  ): Promise<Message[]> {
+    // Pagination to be implemented later
+    return [];
+  }
+
+  /**
+   * Send a message to the live activity chat
+   */
+  async sendMessage(
+    conversation: Conversation,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<void> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    const activeSigner = accountManager.active$.value?.signer;
+
+    if (!activePubkey || !activeSigner) {
+      throw new Error("No active account or signer");
+    }
+
+    const activityAddress = conversation.metadata?.activityAddress;
+    const liveActivity = conversation.metadata?.liveActivity as
+      | {
+          relays?: string[];
+        }
+      | undefined;
+
+    if (!activityAddress) {
+      throw new Error("Activity address required");
+    }
+
+    const { pubkey, identifier } = activityAddress;
+    const aTagValue = `30311:${pubkey}:${identifier}`;
+
+    // Get relays
+    const relays = liveActivity?.relays || [];
+    if (relays.length === 0 && conversation.metadata?.relayUrl) {
+      relays.push(conversation.metadata.relayUrl);
+    }
+
+    if (relays.length === 0) {
+      throw new Error("No relays available for sending message");
+    }
+
+    // Create event factory and sign event
+    const factory = new EventFactory();
+    factory.setSigner(activeSigner);
+
+    // Build tags: a tag is required, e tag for replies
+    const tags: string[][] = [["a", aTagValue, relays[0] || ""]];
+
+    if (options?.replyTo) {
+      // NIP-53 uses e-tag for replies (NIP-10 style)
+      tags.push(["e", options.replyTo, relays[0] || "", "reply"]);
+    }
+
+    // Add NIP-30 emoji tags
+    if (options?.emojiTags) {
+      for (const emoji of options.emojiTags) {
+        tags.push(["emoji", emoji.shortcode, emoji.url]);
+      }
+    }
+
+    // Use kind 1311 for live chat messages
+    const draft = await factory.build({ kind: 1311, content, tags });
+    const event = await factory.sign(draft);
+
+    // Publish to all activity relays
+    await publishEventToRelays(event, relays);
+  }
+
+  /**
+   * Get protocol capabilities
+   */
+  getCapabilities(): ChatCapabilities {
+    return {
+      supportsEncryption: false, // kind 1311 messages are public
+      supportsThreading: true, // e-tag replies
+      supportsModeration: false, // No built-in moderation (host can pin)
+      supportsRoles: true, // Host, Speaker, Participant
+      supportsGroupManagement: false, // No join/leave semantics
+      canCreateConversations: false, // Activities created via streaming software
+      requiresRelay: false, // Works across multiple relays
+    };
+  }
+
+  /**
+   * Load a replied-to message
+   * First checks EventStore, then fetches from relays if needed
+   */
+  async loadReplyMessage(
+    conversation: Conversation,
+    eventId: string,
+  ): Promise<NostrEvent | null> {
+    // First check EventStore
+    const cachedEvent = await eventStore
+      .event(eventId)
+      .pipe(first())
+      .toPromise();
+    if (cachedEvent) {
+      return cachedEvent;
+    }
+
+    // Not in store, fetch from activity relays
+    const liveActivity = conversation.metadata?.liveActivity as
+      | {
+          relays?: string[];
+        }
+      | undefined;
+    const relays = liveActivity?.relays || [];
+    if (relays.length === 0 && conversation.metadata?.relayUrl) {
+      relays.push(conversation.metadata.relayUrl);
+    }
+
+    if (relays.length === 0) {
+      console.warn("[NIP-53] No relays for loading reply message");
+      return null;
+    }
+
+    console.log(
+      `[NIP-53] Fetching reply message ${eventId.slice(0, 8)}... from ${relays.length} relays`,
+    );
+
+    const filter: Filter = {
+      ids: [eventId],
+      limit: 1,
+    };
+
+    const events: NostrEvent[] = [];
+    const obs = pool.subscription(relays, [filter], { eventStore });
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        console.log(
+          `[NIP-53] Reply message fetch timeout for ${eventId.slice(0, 8)}...`,
+        );
+        resolve();
+      }, 3000);
+
+      const sub = obs.subscribe({
+        next: (response) => {
+          if (typeof response === "string") {
+            clearTimeout(timeout);
+            sub.unsubscribe();
+            resolve();
+          } else {
+            events.push(response);
+          }
+        },
+        error: (err) => {
+          clearTimeout(timeout);
+          console.error(`[NIP-53] Reply message fetch error:`, err);
+          sub.unsubscribe();
+          resolve();
+        },
+      });
+    });
+
+    return events[0] || null;
+  }
+
+  /**
+   * Helper: Get author's outbox relays via NIP-65
+   */
+  private async getAuthorOutboxes(pubkey: string): Promise<string[]> {
+    try {
+      // Try to get from EventStore first (kind 10002)
+      const relayListEvent = await eventStore
+        .replaceable(10002, pubkey)
+        .pipe(first())
+        .toPromise();
+
+      if (relayListEvent) {
+        // Extract write relays from r tags
+        const writeRelays = relayListEvent.tags
+          .filter((t) => t[0] === "r" && (!t[2] || t[2] === "write"))
+          .map((t) => t[1])
+          .filter(Boolean);
+
+        if (writeRelays.length > 0) {
+          return writeRelays.slice(0, 3); // Limit to 3 relays
+        }
+      }
+    } catch {
+      // Fall through to defaults
+    }
+
+    // Default fallback relays for live activities
+    return ["wss://relay.damus.io", "wss://nos.lol", "wss://relay.nostr.band"];
+  }
+
+  /**
+   * Helper: Map live activity role to chat participant role
+   */
+  private mapRole(role: string): ParticipantRole {
+    const lower = role.toLowerCase();
+    if (lower === "host") return "host";
+    if (lower === "speaker") return "moderator"; // Speakers get elevated display
+    if (lower === "moderator") return "moderator";
+    return "member";
+  }
+
+  /**
+   * Helper: Convert Nostr event to Message
+   */
+  private eventToMessage(event: NostrEvent, conversationId: string): Message {
+    // Look for reply e-tags (NIP-10 style)
+    const eTags = event.tags.filter((t) => t[0] === "e");
+    // Find the reply tag (has "reply" marker or is the last e-tag without marker)
+    const replyTag =
+      eTags.find((t) => t[3] === "reply") ||
+      eTags.find((t) => !t[3] && eTags.length === 1);
+    const replyTo = replyTag?.[1];
+
+    return {
+      id: event.id,
+      conversationId,
+      author: event.pubkey,
+      content: event.content,
+      timestamp: event.created_at,
+      type: "user",
+      replyTo,
+      protocol: "nip-53",
+      metadata: {
+        encrypted: false,
+      },
+      event,
+    };
+  }
+}

--- a/src/lib/chat/adapters/nip-53-adapter.ts
+++ b/src/lib/chat/adapters/nip-53-adapter.ts
@@ -175,9 +175,10 @@ export class Nip53Adapter extends ChatProtocolAdapter {
       participants.unshift({ pubkey: hostPubkey, role: "host" });
     }
 
-    // Determine relays for chat - prefer activity's relays tag, fallback to relay hints
-    const chatRelays =
-      activity.relays.length > 0 ? activity.relays : relayHints;
+    // Combine activity relays, relay hints, and host outboxes for comprehensive coverage
+    const chatRelays = [
+      ...new Set([...activity.relays, ...relayHints, ...authorOutboxes]),
+    ];
 
     console.log(
       `[NIP-53] Resolved: "${activity.title}" (${status}), ${participants.length} participants, ${chatRelays.length} relays`,

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -25,6 +25,22 @@ export interface Participant {
 }
 
 /**
+ * Live activity metadata for NIP-53
+ */
+export interface LiveActivityMetadata {
+  status: "planned" | "live" | "ended";
+  streaming?: string;
+  recording?: string;
+  starts?: number;
+  ends?: number;
+  hostPubkey: string;
+  currentParticipants?: number;
+  totalParticipants?: number;
+  hashtags: string[];
+  relays: string[];
+}
+
+/**
  * Protocol-specific conversation metadata
  */
 export interface ConversationMetadata {
@@ -43,6 +59,7 @@ export interface ConversationMetadata {
     pubkey: string;
     identifier: string;
   };
+  liveActivity?: LiveActivityMetadata;
 
   // NIP-17 DM
   encrypted?: boolean;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -90,12 +90,15 @@ export interface MessageMetadata {
   zaps?: NostrEvent[];
   deleted?: boolean;
   hidden?: boolean; // NIP-28 channel hide
+  // Zap-specific metadata (for type: "zap" messages)
+  zapAmount?: number; // Amount in sats
+  zapRecipient?: string; // Pubkey of zap recipient
 }
 
 /**
- * Message type - system messages for events like join/leave, user messages for chat
+ * Message type - system messages for events like join/leave, user messages for chat, zaps for stream tips
  */
-export type MessageType = "user" | "system";
+export type MessageType = "user" | "system" | "zap";
 
 /**
  * Generic message abstraction

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -348,22 +348,22 @@ export const manPages: Record<string, ManPageEntry> = {
   chat: {
     name: "chat",
     section: "1",
-    synopsis: "chat <group-identifier>",
+    synopsis: "chat <identifier>",
     description:
-      "Join and participate in NIP-29 relay-based group chats. Groups are hosted on a single relay that enforces membership and moderation rules. Use the format 'relay'group-id' where relay is the WebSocket URL (wss:// prefix optional) and group-id is the group identifier.",
+      "Join and participate in Nostr chat conversations. Supports NIP-29 relay-based groups and NIP-53 live activity chat. For NIP-29 groups, use format 'relay'group-id' where relay is the WebSocket URL (wss:// prefix optional). For NIP-53 live activities, pass the naddr of a kind 30311 live event to join its chat.",
     options: [
       {
-        flag: "<group-identifier>",
+        flag: "<identifier>",
         description:
-          "NIP-29 group identifier in format: relay'group-id (wss:// prefix optional)",
+          "NIP-29 group (relay'group-id) or NIP-53 live activity (naddr1...)",
       },
     ],
     examples: [
-      "chat relay.example.com'bitcoin-dev        Join relay group (wss:// prefix optional)",
-      "chat wss://relay.example.com'nostr-dev    Join relay group with explicit protocol",
-      "chat nos.lol'welcome                      Join welcome group on nos.lol",
+      "chat relay.example.com'bitcoin-dev        Join NIP-29 relay group",
+      "chat wss://nos.lol'welcome                Join NIP-29 group with explicit protocol",
+      "chat naddr1...                            Join NIP-53 live activity chat",
     ],
-    seeAlso: ["profile", "open", "req"],
+    seeAlso: ["profile", "open", "req", "live"],
     appId: "chat",
     category: "Nostr",
     argParser: async (args: string[]) => {


### PR DESCRIPTION
Add support for joining live stream chat via naddr (kind 30311):
- Create Nip53Adapter with parseIdentifier, resolveConversation, loadMessages, sendMessage
- Show live activity status badge (LIVE/UPCOMING/ENDED) in chat header
- Display host name and stream metadata from the live activity event
- Support kind 1311 live chat messages with a-tag references
- Use relays from activity's relays tag or naddr relay hints
- Add tests for adapter identifier parsing and chat-parser integration