### PR TITLE
feat: add NIP-61 nutzap support to NIP-29 groups

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -181,9 +181,15 @@ const MessageItem = memo(function MessageItem({
   // Zap messages have special styling with gradient border
   if (message.type === "zap") {
     const zapRequest = message.event ? getZapRequest(message.event) : null;
+    // For NIP-57 zaps, reply target is in the zap request's e-tag
+    // For NIP-61 nutzaps, reply target is already in message.replyTo
+    const zapReplyTo =
+      message.replyTo ||
+      zapRequest?.tags.find((t) => t[0] === "e")?.[1] ||
+      undefined;
 
     return (
-      <div className="pl-2">
+      <div className="pl-2 mb-1">
         <div
           className="p-[1px]"
           style={{
@@ -213,11 +219,19 @@ const MessageItem = memo(function MessageItem({
                 <Timestamp timestamp={message.timestamp} />
               </span>
             </div>
+            {zapReplyTo && (
+              <ReplyPreview
+                replyToId={zapReplyTo}
+                adapter={adapter}
+                conversation={conversation}
+                onScrollToMessage={onScrollToMessage}
+              />
+            )}
             {message.content && (
               <RichText
                 content={message.content}
-                event={zapRequest || undefined}
-                className="mt-1 text-sm leading-tight break-words"
+                event={zapRequest || message.event}
+                className="text-sm leading-tight break-words"
                 options={{ showMedia: false, showEventEmbeds: false }}
               />
             )}

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -229,7 +229,6 @@ const MessageItem = memo(function MessageItem({
             )}
             {message.content && (
               <RichText
-                content={message.content}
                 event={zapRequest || message.event}
                 className="text-sm leading-tight break-words"
                 options={{ showMedia: false, showEventEmbeds: false }}

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -191,13 +191,13 @@ const MessageItem = memo(function MessageItem({
     return (
       <div className="pl-2 mb-1">
         <div
-          className="p-[1px]"
+          className="p-[1px] rounded"
           style={{
             background:
               "linear-gradient(to right, rgb(250 204 21), rgb(251 146 60), rgb(168 85 247), rgb(34 211 238))",
           }}
         >
-          <div className="bg-background px-1">
+          <div className="bg-background px-1 rounded-sm">
             <div className="flex items-center gap-2">
               <UserName
                 pubkey={message.author}

--- a/src/lib/chat/adapters/nip-53-adapter.ts
+++ b/src/lib/chat/adapters/nip-53-adapter.ts
@@ -1,4 +1,4 @@
-import { Observable, combineLatest } from "rxjs";
+import { Observable } from "rxjs";
 import { map, first } from "rxjs/operators";
 import type { Filter } from "nostr-tools";
 import { nip19 } from "nostr-tools";
@@ -254,80 +254,55 @@ export class Nip53Adapter extends ChatProtocolAdapter {
       `[NIP-53] Loading messages for ${aTagValue} from ${relays.length} relays`,
     );
 
-    // Filter for live chat messages (kind 1311)
-    const chatFilter: Filter = {
-      kinds: [1311],
-      "#a": [aTagValue],
-      limit: options?.limit || 50,
-    };
-
-    // Filter for zaps (kind 9735) targeting this activity
-    const zapFilter: Filter = {
-      kinds: [9735],
+    // Single filter for live chat messages (kind 1311) and zaps (kind 9735)
+    const filter: Filter = {
+      kinds: [1311, 9735],
       "#a": [aTagValue],
       limit: options?.limit || 50,
     };
 
     if (options?.before) {
-      chatFilter.until = options.before;
-      zapFilter.until = options.before;
+      filter.until = options.before;
     }
     if (options?.after) {
-      chatFilter.since = options.after;
-      zapFilter.since = options.after;
+      filter.since = options.after;
     }
 
-    // Start persistent subscriptions to the relays for both chat and zaps
+    // Start a persistent subscription to the relays
     pool
-      .subscription(relays, [chatFilter], {
+      .subscription(relays, [filter], {
         eventStore,
       })
       .subscribe({
         next: (response) => {
           if (typeof response === "string") {
-            console.log("[NIP-53] EOSE received for messages");
+            console.log("[NIP-53] EOSE received");
           } else {
             console.log(
-              `[NIP-53] Received message: ${response.id.slice(0, 8)}...`,
+              `[NIP-53] Received event k${response.kind}: ${response.id.slice(0, 8)}...`,
             );
           }
         },
       });
 
-    pool
-      .subscription(relays, [zapFilter], {
-        eventStore,
-      })
-      .subscribe({
-        next: (response) => {
-          if (typeof response === "string") {
-            console.log("[NIP-53] EOSE received for zaps");
-          } else {
-            console.log(`[NIP-53] Received zap: ${response.id.slice(0, 8)}...`);
-          }
-        },
-      });
+    // Return observable from EventStore which will update automatically
+    return eventStore.timeline(filter).pipe(
+      map((events) => {
+        const messages = events
+          .map((event) => {
+            // Convert zaps (kind 9735) using zapToMessage
+            if (event.kind === 9735) {
+              // Only include valid zaps
+              if (!isValidZap(event)) return null;
+              return this.zapToMessage(event, conversation.id);
+            }
+            // All other events (kind 1311) use eventToMessage
+            return this.eventToMessage(event, conversation.id);
+          })
+          .filter((msg): msg is Message => msg !== null);
 
-    // Combine chat messages and zaps from EventStore
-    const chatMessages$ = eventStore.timeline(chatFilter);
-    const zapMessages$ = eventStore.timeline(zapFilter);
-
-    return combineLatest([chatMessages$, zapMessages$]).pipe(
-      map(([chatEvents, zapEvents]) => {
-        const chatMsgs = chatEvents.map((event) =>
-          this.eventToMessage(event, conversation.id),
-        );
-
-        const zapMsgs = zapEvents
-          .filter((event) => isValidZap(event))
-          .map((event) => this.zapToMessage(event, conversation.id));
-
-        const allMessages = [...chatMsgs, ...zapMsgs];
-        console.log(
-          `[NIP-53] Timeline has ${chatMsgs.length} messages, ${zapMsgs.length} zaps`,
-        );
-
-        return allMessages.sort((a, b) => a.timestamp - b.timestamp);
+        console.log(`[NIP-53] Timeline has ${messages.length} events`);
+        return messages.sort((a, b) => a.timestamp - b.timestamp);
       }),
     );
   }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -93,6 +93,8 @@ export interface MessageMetadata {
   // Zap-specific metadata (for type: "zap" messages)
   zapAmount?: number; // Amount in sats
   zapRecipient?: string; // Pubkey of zap recipient
+  // NIP-61 nutzap-specific metadata
+  nutzapUnit?: string; // Unit for nutzap amount (sat, usd, eur, etc.)
 }
 
 /**


### PR DESCRIPTION
Fetch and render nutzap events (kind 9321) in NIP-29 relay groups
using the same visual styling as lightning zaps. Nutzaps are P2PK
locked Cashu token transfers defined in NIP-61.

- Add nutzap filter subscription in loadMessages
- Combine chat and nutzap observables with RxJS combineLatest
- Add nutzapToMessage helper to parse NIP-61 event structure
- Extract amount by summing proof amounts from proof tag JSON
- Add nutzapUnit metadata field for future multi-currency support