### PR TITLE
ui: add timestamp to chat join/leave status messages

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -172,7 +172,7 @@ const MessageItem = memo(function MessageItem({
       <div className="flex items-center px-3 py-1">
         <span className="text-xs text-muted-foreground">
           * <UserName pubkey={message.author} className="text-xs" />{" "}
-          {message.content}
+          {message.content} <Timestamp timestamp={message.timestamp} />
         </span>
       </div>
     );


### PR DESCRIPTION
Show xs timestamp after system messages (join/leave) in chat for
consistency with regular messages and zap messages.