### PR TITLE
Explore NIP-44 and NIP-59 in Applesauce

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -14,6 +14,7 @@ import type {
   LiveActivityMetadata,
 } from "@/types/chat";
 // import { NipC7Adapter } from "@/lib/chat/adapters/nip-c7-adapter";  // Coming soon
+import { Nip17Adapter } from "@/lib/chat/adapters/nip-17-adapter";
 import { Nip29Adapter } from "@/lib/chat/adapters/nip-29-adapter";
 import { Nip53Adapter } from "@/lib/chat/adapters/nip-53-adapter";
 import type { ChatProtocolAdapter } from "@/lib/chat/adapters/base-adapter";
@@ -508,7 +509,9 @@ export function ChatViewer({
 
   // Handle NIP badge click
   const handleNipClick = useCallback(() => {
-    if (conversation?.protocol === "nip-29") {
+    if (conversation?.protocol === "nip-17") {
+      addWindow("nip", { number: 17 });
+    } else if (conversation?.protocol === "nip-29") {
       addWindow("nip", { number: 29 });
     } else if (conversation?.protocol === "nip-53") {
       addWindow("nip", { number: 53 });
@@ -631,22 +634,16 @@ export function ChatViewer({
                     )}
                     {/* Protocol Type - Clickable */}
                     <div className="flex items-center gap-1.5 text-xs">
-                      {(conversation.type === "group" ||
-                        conversation.type === "live-chat") && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleNipClick();
-                          }}
-                          className="rounded bg-primary-foreground/20 px-1.5 py-0.5 font-mono hover:bg-primary-foreground/30 transition-colors cursor-pointer text-primary-foreground"
-                        >
-                          {conversation.protocol.toUpperCase()}
-                        </button>
-                      )}
-                      {(conversation.type === "group" ||
-                        conversation.type === "live-chat") && (
-                        <span className="text-primary-foreground/60">•</span>
-                      )}
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleNipClick();
+                        }}
+                        className="rounded bg-primary-foreground/20 px-1.5 py-0.5 font-mono hover:bg-primary-foreground/30 transition-colors cursor-pointer text-primary-foreground"
+                      >
+                        {conversation.protocol.toUpperCase()}
+                      </button>
+                      <span className="text-primary-foreground/60">•</span>
                       <span className="capitalize text-primary-foreground/80">
                         {conversation.type}
                       </span>
@@ -678,15 +675,12 @@ export function ChatViewer({
           <div className="flex items-center gap-2 text-xs text-muted-foreground p-1">
             <MembersDropdown participants={derivedParticipants} />
             <RelaysDropdown conversation={conversation} />
-            {(conversation.type === "group" ||
-              conversation.type === "live-chat") && (
-              <button
-                onClick={handleNipClick}
-                className="rounded bg-muted px-1.5 py-0.5 font-mono hover:bg-muted/80 transition-colors cursor-pointer"
-              >
-                {conversation.protocol.toUpperCase()}
-              </button>
-            )}
+            <button
+              onClick={handleNipClick}
+              className="rounded bg-muted px-1.5 py-0.5 font-mono hover:bg-muted/80 transition-colors cursor-pointer"
+            >
+              {conversation.protocol.toUpperCase()}
+            </button>
           </div>
         </div>
       </div>
@@ -800,18 +794,17 @@ export function ChatViewer({
 
 /**
  * Get the appropriate adapter for a protocol
- * Currently NIP-29 (relay-based groups) and NIP-53 (live activity chat) are supported
- * Other protocols will be enabled in future phases
+ * Currently NIP-17, NIP-29, and NIP-53 are supported
  */
 function getAdapter(protocol: ChatProtocol): ChatProtocolAdapter {
   switch (protocol) {
-    // case "nip-c7":  // Phase 1 - Simple chat (coming soon)
+    // case "nip-c7":  // Simple chat (disabled - NIP-17 preferred)
     //   return new NipC7Adapter();
+    case "nip-17":
+      return new Nip17Adapter();
     case "nip-29":
       return new Nip29Adapter();
-    // case "nip-17":  // Phase 2 - Encrypted DMs (coming soon)
-    //   return new Nip17Adapter();
-    // case "nip-28":  // Phase 3 - Public channels (coming soon)
+    // case "nip-28":  // Public channels (coming soon)
     //   return new Nip28Adapter();
     case "nip-53":
       return new Nip53Adapter();

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -25,6 +25,7 @@ import Timestamp from "./Timestamp";
 import { ReplyPreview } from "./chat/ReplyPreview";
 import { MembersDropdown } from "./chat/MembersDropdown";
 import { RelaysDropdown } from "./chat/RelaysDropdown";
+import { ConversationList } from "./chat/ConversationList";
 import { StatusBadge } from "./live/StatusBadge";
 import { useGrimoire } from "@/core/state";
 import { Button } from "./ui/button";
@@ -318,6 +319,23 @@ export function ChatViewer({
   customTitle,
 }: ChatViewerProps) {
   const { addWindow } = useGrimoire();
+
+  // Handle conversation list mode
+  const handleSelectConversation = useCallback(
+    (pubkey: string) => {
+      // Open a new chat window with the selected conversation
+      addWindow("chat", {
+        protocol: "nip-17",
+        identifier: { type: "chat-partner", value: pubkey },
+      });
+    },
+    [addWindow],
+  );
+
+  // Show conversation list if identifier is conversation-list type
+  if (identifier.type === "conversation-list") {
+    return <ConversationList onSelectConversation={handleSelectConversation} />;
+  }
 
   // Get active account
   const activeAccount = use$(accountManager.active$);

--- a/src/components/chat/ConversationList.tsx
+++ b/src/components/chat/ConversationList.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useState, useCallback } from "react";
+import { MessageSquare, Lock, RefreshCw, User } from "lucide-react";
+import db, { type DecryptedRumor } from "@/services/db";
+import { useProfile } from "@/hooks/useProfile";
+import { getDisplayName } from "@/lib/nostr-utils";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import accountManager from "@/services/accounts";
+import { use$ } from "applesauce-react/hooks";
+
+/**
+ * Format a timestamp as relative time (e.g., "2h ago", "3d ago")
+ */
+function formatRelativeTime(timestamp: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diff = now - timestamp;
+
+  if (diff < 60) return "now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d`;
+  if (diff < 2592000) return `${Math.floor(diff / 604800)}w`;
+  return `${Math.floor(diff / 2592000)}mo`;
+}
+
+interface ConversationSummary {
+  conversationId: string;
+  partnerPubkey: string;
+  lastMessage: DecryptedRumor;
+  messageCount: number;
+}
+
+interface ConversationItemProps {
+  summary: ConversationSummary;
+  onClick: () => void;
+}
+
+function ConversationItem({ summary, onClick }: ConversationItemProps) {
+  const profile = useProfile(summary.partnerPubkey);
+  const displayName = getDisplayName(summary.partnerPubkey, profile);
+  const isSelfChat =
+    summary.partnerPubkey === accountManager.active$.value?.pubkey;
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors border-b border-border last:border-b-0 text-left"
+    >
+      <Avatar className="size-10 flex-shrink-0">
+        <AvatarImage src={profile?.picture} alt={displayName} />
+        <AvatarFallback>
+          {isSelfChat ? (
+            <User className="size-5" />
+          ) : (
+            displayName.slice(0, 2).toUpperCase()
+          )}
+        </AvatarFallback>
+      </Avatar>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">
+            {isSelfChat ? "Notes to Self" : displayName}
+          </span>
+          <Lock className="size-3 text-muted-foreground flex-shrink-0" />
+        </div>
+        <p className="text-sm text-muted-foreground truncate">
+          {summary.lastMessage.content.slice(0, 100)}
+          {summary.lastMessage.content.length > 100 ? "..." : ""}
+        </p>
+      </div>
+
+      <div className="flex flex-col items-end gap-1 flex-shrink-0">
+        <span className="text-xs text-muted-foreground">
+          {formatRelativeTime(summary.lastMessage.createdAt)}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {summary.messageCount} message{summary.messageCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+interface ConversationListProps {
+  onSelectConversation: (pubkey: string) => void;
+}
+
+export function ConversationList({
+  onSelectConversation,
+}: ConversationListProps) {
+  const account = use$(accountManager.active$);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadConversations = useCallback(async () => {
+    if (!account?.pubkey) {
+      setConversations([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Get all kind 14 (DM) rumors from DB
+      const allRumors = await db.decryptedRumors
+        .where("kind")
+        .equals(14)
+        .toArray();
+
+      // Group by conversation ID
+      const conversationMap = new Map<string, DecryptedRumor[]>();
+
+      for (const rumor of allRumors) {
+        if (!rumor.conversationId) continue;
+
+        const existing = conversationMap.get(rumor.conversationId);
+        if (existing) {
+          existing.push(rumor);
+        } else {
+          conversationMap.set(rumor.conversationId, [rumor]);
+        }
+      }
+
+      // Build summaries
+      const summaries: ConversationSummary[] = [];
+
+      for (const [conversationId, rumors] of conversationMap) {
+        // Sort by timestamp to get latest
+        rumors.sort((a, b) => b.createdAt - a.createdAt);
+        const lastMessage = rumors[0];
+
+        // Extract partner pubkey from conversation ID (nip-17:pubkey)
+        const partnerPubkey = conversationId.replace("nip-17:", "");
+
+        summaries.push({
+          conversationId,
+          partnerPubkey,
+          lastMessage,
+          messageCount: rumors.length,
+        });
+      }
+
+      // Sort by most recent message
+      summaries.sort(
+        (a, b) => b.lastMessage.createdAt - a.lastMessage.createdAt,
+      );
+
+      setConversations(summaries);
+    } catch (err) {
+      console.error("[ConversationList] Failed to load conversations:", err);
+      setError("Failed to load conversations");
+    } finally {
+      setLoading(false);
+    }
+  }, [account?.pubkey]);
+
+  useEffect(() => {
+    loadConversations();
+  }, [loadConversations]);
+
+  const handleSelectConversation = useCallback(
+    (pubkey: string) => {
+      onSelectConversation(pubkey);
+    },
+    [onSelectConversation],
+  );
+
+  if (!account) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+        <Lock className="size-12 text-muted-foreground mb-4" />
+        <h3 className="text-lg font-medium mb-2">Login Required</h3>
+        <p className="text-sm text-muted-foreground">
+          Log in to view your encrypted DM conversations.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8">
+        <RefreshCw className="size-8 text-muted-foreground animate-spin mb-4" />
+        <p className="text-sm text-muted-foreground">
+          Loading conversations...
+        </p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+        <p className="text-sm text-destructive mb-4">{error}</p>
+        <Button variant="outline" size="sm" onClick={loadConversations}>
+          <RefreshCw className="size-4 mr-2" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+        <MessageSquare className="size-12 text-muted-foreground mb-4" />
+        <h3 className="text-lg font-medium mb-2">No Conversations Yet</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          Start a new encrypted DM by running:
+        </p>
+        <code className="px-3 py-2 bg-muted rounded text-sm font-mono">
+          chat npub1... or chat user@domain.com
+        </code>
+        <p className="text-xs text-muted-foreground mt-4">
+          Conversations are cached locally after decryption.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between p-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Lock className="size-4 text-muted-foreground" />
+          <h2 className="font-medium">Encrypted DMs</h2>
+          <span className="text-xs text-muted-foreground">
+            ({conversations.length})
+          </span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={loadConversations}>
+          <RefreshCw className="size-4" />
+        </Button>
+      </div>
+
+      {/* Conversation list */}
+      <div className="flex-1 overflow-y-auto">
+        {conversations.map((summary) => (
+          <ConversationItem
+            key={summary.conversationId}
+            summary={summary}
+            onClick={() => handleSelectConversation(summary.partnerPubkey)}
+          />
+        ))}
+      </div>
+
+      {/* Footer hint */}
+      <div className="p-2 border-t border-border text-center">
+        <p className="text-xs text-muted-foreground">
+          Click a conversation to open it, or use{" "}
+          <code className="px-1 py-0.5 bg-muted rounded">chat npub...</code> for
+          new chats
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/RelaysDropdown.tsx
+++ b/src/components/chat/RelaysDropdown.tsx
@@ -22,13 +22,17 @@ export function RelaysDropdown({ conversation }: RelaysDropdownProps) {
   const { relays: relayStates } = useRelayState();
 
   // Get relays for this conversation (immutable pattern)
+  // Priority: liveActivity relays > dmRelays > single relayUrl
   const liveActivityRelays = conversation.metadata?.liveActivity?.relays;
+  const dmRelays = conversation.metadata?.dmRelays;
   const relays: string[] =
     Array.isArray(liveActivityRelays) && liveActivityRelays.length > 0
       ? liveActivityRelays
-      : conversation.metadata?.relayUrl
-        ? [conversation.metadata.relayUrl]
-        : [];
+      : Array.isArray(dmRelays) && dmRelays.length > 0
+        ? dmRelays
+        : conversation.metadata?.relayUrl
+          ? [conversation.metadata.relayUrl]
+          : [];
 
   // Pre-compute normalized URLs and state lookups in a single pass (O(n))
   const relayData = relays.map((url) => {

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -20,6 +20,8 @@ import { RelayLink } from "./RelayLink";
 import SettingsDialog from "@/components/SettingsDialog";
 import LoginDialog from "./LoginDialog";
 import { useState } from "react";
+import eventStore from "@/services/event-store";
+import { getRelaysFromList } from "applesauce-common/helpers";
 
 function UserAvatar({ pubkey }: { pubkey: string }) {
   const profile = useProfile(pubkey);
@@ -56,6 +58,16 @@ export default function UserMenu() {
   const relays = state.activeAccount?.relays;
   const [showSettings, setShowSettings] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
+
+  // Get DM relays (kind 10050) for the active user
+  const dmRelayListEvent = use$(
+    () =>
+      account?.pubkey
+        ? eventStore.replaceable(10050, account.pubkey)
+        : undefined,
+    [account?.pubkey],
+  );
+  const dmRelays = dmRelayListEvent ? getRelaysFromList(dmRelayListEvent) : [];
 
   function openProfile() {
     if (!account?.pubkey) return;
@@ -117,6 +129,26 @@ export default function UserMenu() {
                         url={relay.url}
                         read={relay.read}
                         write={relay.write}
+                      />
+                    ))}
+                  </DropdownMenuGroup>
+                </>
+              )}
+
+              {dmRelays.length > 0 && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                      DM Relays (NIP-17)
+                    </DropdownMenuLabel>
+                    {dmRelays.map((url) => (
+                      <RelayLink
+                        className="px-2 py-1"
+                        urlClassname="text-sm"
+                        iconClassname="size-4"
+                        key={url}
+                        url={url}
                       />
                     ))}
                   </DropdownMenuGroup>

--- a/src/lib/chat-parser.test.ts
+++ b/src/lib/chat-parser.test.ts
@@ -55,24 +55,33 @@ describe("parseChatCommand", () => {
       const result = parseChatCommand(["relay.example.com'bitcoin-dev"]);
 
       expect(result.protocol).toBe("nip-29");
-      expect(result.identifier.value).toBe("bitcoin-dev");
-      expect(result.identifier.relays).toEqual(["wss://relay.example.com"]);
+      expect(result.identifier.type).toBe("group");
+      if (result.identifier.type === "group") {
+        expect(result.identifier.value).toBe("bitcoin-dev");
+        expect(result.identifier.relays).toEqual(["wss://relay.example.com"]);
+      }
     });
 
     it("should parse NIP-29 group with different relay when split", () => {
       const result = parseChatCommand(["relay.example.com", "bitcoin-dev"]);
 
       expect(result.protocol).toBe("nip-29");
-      expect(result.identifier.value).toBe("bitcoin-dev");
-      expect(result.identifier.relays).toEqual(["wss://relay.example.com"]);
+      expect(result.identifier.type).toBe("group");
+      if (result.identifier.type === "group") {
+        expect(result.identifier.value).toBe("bitcoin-dev");
+        expect(result.identifier.relays).toEqual(["wss://relay.example.com"]);
+      }
     });
 
     it("should parse NIP-29 group from nos.lol", () => {
       const result = parseChatCommand(["nos.lol'welcome"]);
 
       expect(result.protocol).toBe("nip-29");
-      expect(result.identifier.value).toBe("welcome");
-      expect(result.identifier.relays).toEqual(["wss://nos.lol"]);
+      expect(result.identifier.type).toBe("group");
+      if (result.identifier.type === "group") {
+        expect(result.identifier.value).toBe("welcome");
+        expect(result.identifier.relays).toEqual(["wss://nos.lol"]);
+      }
     });
   });
 
@@ -146,16 +155,19 @@ describe("parseChatCommand", () => {
       const result = parseChatCommand([naddr]);
 
       expect(result.protocol).toBe("nip-53");
-      expect(result.identifier.value).toEqual({
-        kind: 30311,
-        pubkey:
-          "0000000000000000000000000000000000000000000000000000000000000001",
-        identifier: "podcast-episode-42",
-      });
-      expect(result.identifier.relays).toEqual([
-        "wss://relay1.example.com",
-        "wss://relay2.example.com",
-      ]);
+      expect(result.identifier.type).toBe("live-activity");
+      if (result.identifier.type === "live-activity") {
+        expect(result.identifier.value).toEqual({
+          kind: 30311,
+          pubkey:
+            "0000000000000000000000000000000000000000000000000000000000000001",
+          identifier: "podcast-episode-42",
+        });
+        expect(result.identifier.relays).toEqual([
+          "wss://relay1.example.com",
+          "wss://relay2.example.com",
+        ]);
+      }
     });
 
     it("should not parse NIP-29 group naddr as NIP-53", () => {

--- a/src/lib/chat-parser.ts
+++ b/src/lib/chat-parser.ts
@@ -1,9 +1,9 @@
 import type { ChatCommandResult } from "@/types/chat";
 // import { NipC7Adapter } from "./chat/adapters/nip-c7-adapter";
+import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 import { Nip29Adapter } from "./chat/adapters/nip-29-adapter";
 import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 // Import other adapters as they're implemented
-// import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 // import { Nip28Adapter } from "./chat/adapters/nip-28-adapter";
 
 /**
@@ -36,11 +36,11 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
 
   // Try each adapter in priority order
   const adapters = [
-    // new Nip17Adapter(),  // Phase 2
     // new Nip28Adapter(),  // Phase 3
-    new Nip29Adapter(), // Phase 4 - Relay groups
-    new Nip53Adapter(), // Phase 5 - Live activity chat
-    // new NipC7Adapter(), // Phase 1 - Simple chat (disabled for now)
+    new Nip29Adapter(), // Relay groups (NIP-29)
+    new Nip53Adapter(), // Live activity chat (NIP-53)
+    new Nip17Adapter(), // Encrypted DMs (NIP-17) - checked after group/live formats
+    // new NipC7Adapter(), // Simple chat (disabled - NIP-17 preferred)
   ];
 
   for (const adapter of adapters) {
@@ -57,20 +57,18 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
   throw new Error(
     `Unable to determine chat protocol from identifier: ${identifier}
 
-Currently supported formats:
-  - relay.com'group-id (NIP-29 relay group, wss:// prefix optional)
-    Examples:
-      chat relay.example.com'bitcoin-dev
-      chat wss://relay.example.com'nostr-dev
-  - naddr1... (NIP-29 group metadata, kind 39000)
-    Example:
-      chat naddr1qqxnzdesxqmnxvpexqmny...
-  - naddr1... (NIP-53 live activity chat, kind 30311)
-    Example:
-      chat naddr1... (live stream address)
+Supported formats:
+  - npub1... / nprofile1... (NIP-17 encrypted DM)
+  - hex pubkey (NIP-17 encrypted DM)
+  - user@domain.com (NIP-05 → NIP-17 encrypted DM)
+  - relay.com'group-id (NIP-29 relay group)
+  - naddr1... kind 39000 (NIP-29 group metadata)
+  - naddr1... kind 30311 (NIP-53 live activity chat)
 
-More formats coming soon:
-  - npub/nprofile/hex pubkey (NIP-C7/NIP-17 direct messages)
-  - note/nevent (NIP-28 public channels)`,
+Examples:
+  chat npub1abc123...              # DM with user
+  chat alice@example.com           # DM via NIP-05
+  chat relay.example.com'bitcoin   # Join relay group
+  chat naddr1...                   # Live stream chat`,
   );
 }

--- a/src/lib/chat-parser.ts
+++ b/src/lib/chat-parser.ts
@@ -1,10 +1,15 @@
-import type { ChatCommandResult } from "@/types/chat";
+import type { ChatCommandResult, ChatProtocol } from "@/types/chat";
 // import { NipC7Adapter } from "./chat/adapters/nip-c7-adapter";
 import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 import { Nip29Adapter } from "./chat/adapters/nip-29-adapter";
 import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 // Import other adapters as they're implemented
 // import { Nip28Adapter } from "./chat/adapters/nip-28-adapter";
+
+/**
+ * Protocols that support conversation list view
+ */
+const LISTABLE_PROTOCOLS: ChatProtocol[] = ["nip-17"];
 
 /**
  * Parse a chat command identifier and auto-detect the protocol
@@ -16,6 +21,8 @@ import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
  * 4. NIP-53 (live chat) - specific addressable format (kind 30311)
  * 5. NIP-C7 (simple chat) - fallback for generic pubkeys
  *
+ * Special case: `chat nip-17` shows conversation list
+ *
  * @param args - Command arguments (first arg is the identifier)
  * @returns Parsed result with protocol and identifier
  * @throws Error if no adapter can parse the identifier
@@ -23,6 +30,19 @@ import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 export function parseChatCommand(args: string[]): ChatCommandResult {
   if (args.length === 0) {
     throw new Error("Chat identifier required. Usage: chat <identifier>");
+  }
+
+  // Check for conversation list mode: `chat nip-17`
+  const protocolArg = args[0].toLowerCase();
+  if (LISTABLE_PROTOCOLS.includes(protocolArg as ChatProtocol)) {
+    return {
+      protocol: protocolArg as ChatProtocol,
+      identifier: {
+        type: "conversation-list",
+        protocol: protocolArg as ChatProtocol,
+      },
+      adapter: protocolArg === "nip-17" ? new Nip17Adapter() : null,
+    };
   }
 
   // Handle NIP-29 format that may be split by shell-quote
@@ -58,6 +78,7 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
     `Unable to determine chat protocol from identifier: ${identifier}
 
 Supported formats:
+  - nip-17 (show all encrypted DM conversations)
   - npub1... / nprofile1... (NIP-17 encrypted DM)
   - hex pubkey (NIP-17 encrypted DM)
   - user@domain.com (NIP-05 → NIP-17 encrypted DM)
@@ -66,6 +87,7 @@ Supported formats:
   - naddr1... kind 30311 (NIP-53 live activity chat)
 
 Examples:
+  chat nip-17                      # List all DM conversations
   chat npub1abc123...              # DM with user
   chat alice@example.com           # DM via NIP-05
   chat relay.example.com'bitcoin   # Join relay group

--- a/src/lib/chat/adapters/nip-17-adapter.ts
+++ b/src/lib/chat/adapters/nip-17-adapter.ts
@@ -163,10 +163,13 @@ export class Nip17Adapter extends ChatProtocolAdapter {
 
     // Fetch DM relays for both parties in parallel
     // (for self-chat, this fetches the same relays twice but that's fine)
-    await Promise.all([
+    const [ownRelays, partnerRelays] = await Promise.all([
       this.fetchDmRelays(activePubkey),
       this.fetchDmRelays(partnerPubkey),
     ]);
+
+    // Combine and deduplicate relays from both parties
+    const allRelays = [...new Set([...ownRelays, ...partnerRelays])];
 
     // Get display name for partner (the person we're chatting with)
     const metadataEvent = await this.getMetadata(partnerPubkey);
@@ -187,6 +190,7 @@ export class Nip17Adapter extends ChatProtocolAdapter {
       metadata: {
         encrypted: true,
         giftWrapped: true,
+        dmRelays: allRelays,
       },
       unreadCount: 0,
     };

--- a/src/lib/chat/adapters/nip-17-adapter.ts
+++ b/src/lib/chat/adapters/nip-17-adapter.ts
@@ -410,7 +410,7 @@ export class Nip17Adapter extends ChatProtocolAdapter {
         }
 
         // Convert rumor to message
-        const message = this.rumorToMessage(rumor, conversationId, giftWrap);
+        const message = this.rumorToMessage(rumor, conversationId);
         messages.push(message);
       } catch (err) {
         // Decryption failed - might not be for us or corrupted
@@ -663,11 +663,7 @@ export class Nip17Adapter extends ChatProtocolAdapter {
   /**
    * Helper: Convert Rumor to Message
    */
-  private rumorToMessage(
-    rumor: Rumor,
-    conversationId: string,
-    giftWrap: NostrEvent,
-  ): Message {
+  private rumorToMessage(rumor: Rumor, conversationId: string): Message {
     const sender = getWrappedMessageSender(rumor);
     const replyTo = getWrappedMessageParent(rumor);
 
@@ -693,9 +689,10 @@ export class Nip17Adapter extends ChatProtocolAdapter {
       metadata: {
         encrypted: true,
       },
-      // Store the gift wrap as the "event" for reference
-      // (the actual rumor is unsigned so we reference the wrapper)
-      event: giftWrap,
+      // Use the rumor as the event for rendering (has decrypted content + tags)
+      // Cast to NostrEvent since RichText only needs content/tags/pubkey for rendering
+      // The rumor is unsigned but has all fields needed for display
+      event: rumor as unknown as NostrEvent,
     };
   }
 

--- a/src/lib/chat/adapters/nip-17-adapter.ts
+++ b/src/lib/chat/adapters/nip-17-adapter.ts
@@ -319,10 +319,10 @@ export class Nip17Adapter extends ChatProtocolAdapter {
         );
 
         // Subscribe to kind 1059 (gift wraps) addressed to us
+        // No limit - fetch all gift wraps to ensure we don't miss any
         const filter: Filter = {
           kinds: [1059],
           "#p": [activePubkey],
-          limit: options?.limit || 100,
         };
 
         if (options?.before) {

--- a/src/lib/chat/adapters/nip-17-adapter.ts
+++ b/src/lib/chat/adapters/nip-17-adapter.ts
@@ -1,0 +1,710 @@
+import { Observable, firstValueFrom, from, of } from "rxjs";
+import { map, first, switchMap, catchError } from "rxjs/operators";
+import { nip19 } from "nostr-tools";
+import type { Filter } from "nostr-tools";
+import { ChatProtocolAdapter, type SendMessageOptions } from "./base-adapter";
+import type {
+  Conversation,
+  Message,
+  ProtocolIdentifier,
+  ChatCapabilities,
+  LoadMessagesOptions,
+} from "@/types/chat";
+import type { NostrEvent } from "@/types/nostr";
+import eventStore from "@/services/event-store";
+import pool from "@/services/relay-pool";
+import { publishEventToRelays } from "@/services/hub";
+import accountManager from "@/services/accounts";
+import { isNip05, resolveNip05 } from "@/lib/nip05";
+import { getDisplayName, getTagValues } from "@/lib/nostr-utils";
+import { isValidHexPubkey } from "@/lib/nostr-validation";
+import { getProfileContent } from "applesauce-core/helpers";
+import { getRelaysFromList } from "applesauce-common/helpers";
+import { EventFactory } from "applesauce-core/event-factory";
+import { addressLoader, AGGREGATOR_RELAYS } from "@/services/loaders";
+import {
+  unlockGiftWrap,
+  isGiftWrapUnlocked,
+  getGiftWrapRumor,
+  type Rumor,
+} from "applesauce-common/helpers/gift-wrap";
+import { getConversationParticipants } from "applesauce-common/helpers/messages";
+import {
+  getWrappedMessageSender,
+  getWrappedMessageParent,
+} from "applesauce-common/helpers/wrapped-messages";
+import { GiftWrapBlueprint } from "applesauce-common/blueprints/gift-wrap";
+import { WrappedMessageBlueprint } from "applesauce-common/blueprints/wrapped-message";
+
+/**
+ * NIP-17 Adapter - Private Direct Messages
+ *
+ * Features:
+ * - End-to-end encrypted messaging using NIP-44
+ * - Gift-wrapped messages (NIP-59) for metadata privacy
+ * - Uses DM inbox relays (kind 10050) for delivery
+ * - Caches decrypted rumors to avoid repeated decryption
+ *
+ * Message flow:
+ * 1. Create Rumor (kind 14, unsigned)
+ * 2. Seal rumor (kind 13, encrypted to recipient)
+ * 3. Gift wrap seal (kind 1059, encrypted with ephemeral key)
+ * 4. Publish to recipient's DM inbox relays
+ */
+export class Nip17Adapter extends ChatProtocolAdapter {
+  readonly protocol = "nip-17" as const;
+  readonly type = "dm" as const;
+
+  /** Cache of DM inbox relays by pubkey */
+  private dmRelayCache = new Map<string, string[]>();
+
+  /**
+   * Parse identifier - accepts npub, nprofile, hex pubkey, or NIP-05
+   */
+  parseIdentifier(input: string): ProtocolIdentifier | null {
+    // Try bech32 decoding (npub/nprofile)
+    try {
+      const decoded = nip19.decode(input);
+      if (decoded.type === "npub") {
+        return {
+          type: "dm-recipient",
+          value: decoded.data,
+        };
+      }
+      if (decoded.type === "nprofile") {
+        return {
+          type: "dm-recipient",
+          value: decoded.data.pubkey,
+          relays: decoded.data.relays,
+        };
+      }
+    } catch {
+      // Not bech32, try other formats
+    }
+
+    // Try hex pubkey
+    if (isValidHexPubkey(input)) {
+      return {
+        type: "dm-recipient",
+        value: input,
+      };
+    }
+
+    // Try NIP-05
+    if (isNip05(input)) {
+      return {
+        type: "chat-partner-nip05",
+        value: input,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve conversation from identifier
+   */
+  async resolveConversation(
+    identifier: ProtocolIdentifier,
+  ): Promise<Conversation> {
+    let pubkey: string;
+
+    // Resolve NIP-05 if needed
+    if (identifier.type === "chat-partner-nip05") {
+      const resolved = await resolveNip05(identifier.value);
+      if (!resolved) {
+        throw new Error(`Failed to resolve NIP-05: ${identifier.value}`);
+      }
+      pubkey = resolved;
+    } else if (
+      identifier.type === "dm-recipient" ||
+      identifier.type === "chat-partner"
+    ) {
+      pubkey = identifier.value;
+    } else {
+      throw new Error(
+        `NIP-17 adapter cannot handle identifier type: ${identifier.type}`,
+      );
+    }
+
+    const activePubkey = accountManager.active$.value?.pubkey;
+    if (!activePubkey) {
+      throw new Error("No active account");
+    }
+
+    console.log(
+      `[NIP-17] Resolving conversation with ${pubkey.slice(0, 8)}...`,
+    );
+
+    // Fetch DM relays for both parties in parallel
+    await Promise.all([
+      this.fetchDmRelays(activePubkey),
+      this.fetchDmRelays(pubkey),
+    ]);
+
+    // Get display name for partner
+    const metadataEvent = await this.getMetadata(pubkey);
+    const metadata = metadataEvent
+      ? getProfileContent(metadataEvent)
+      : undefined;
+    const title = getDisplayName(pubkey, metadata);
+
+    return {
+      id: `nip-17:${pubkey}`,
+      type: "dm",
+      protocol: "nip-17",
+      title,
+      participants: [
+        { pubkey: activePubkey, role: "member" },
+        { pubkey, role: "member" },
+      ],
+      metadata: {
+        encrypted: true,
+        giftWrapped: true,
+      },
+      unreadCount: 0,
+    };
+  }
+
+  /**
+   * Fetch DM inbox relays (kind 10050) for a pubkey
+   */
+  private async fetchDmRelays(pubkey: string): Promise<string[]> {
+    // Check cache first
+    const cached = this.dmRelayCache.get(pubkey);
+    if (cached) {
+      return cached;
+    }
+
+    console.log(`[NIP-17] Fetching DM relays for ${pubkey.slice(0, 8)}...`);
+
+    try {
+      // Try to load kind 10050 from relays
+      const event = await firstValueFrom(
+        addressLoader({ kind: 10050, pubkey, identifier: "" }).pipe(
+          catchError(() => of(null)),
+        ),
+        { defaultValue: null },
+      );
+
+      if (event) {
+        // Parse relay URLs from the event using getRelaysFromList
+        const relays = getRelaysFromList(event);
+        if (relays.length > 0) {
+          console.log(
+            `[NIP-17] Found ${relays.length} DM relays for ${pubkey.slice(0, 8)}`,
+          );
+          this.dmRelayCache.set(pubkey, relays);
+          return relays;
+        }
+      }
+
+      // Fallback: Try to get inbox relays from kind 10002 (NIP-65)
+      const relayListEvent = await firstValueFrom(
+        addressLoader({ kind: 10002, pubkey, identifier: "" }).pipe(
+          catchError(() => of(null)),
+        ),
+        { defaultValue: null },
+      );
+
+      if (relayListEvent) {
+        // Get inbox (read) relays as fallback
+        const { getInboxes } = await import("applesauce-core/helpers");
+        const inboxRelays = getInboxes(relayListEvent);
+        if (inboxRelays.length > 0) {
+          console.log(
+            `[NIP-17] Using ${inboxRelays.length} inbox relays as fallback for ${pubkey.slice(0, 8)}`,
+          );
+          this.dmRelayCache.set(pubkey, inboxRelays);
+          return inboxRelays;
+        }
+      }
+
+      // Final fallback: use aggregator relays
+      console.log(
+        `[NIP-17] No DM relays found for ${pubkey.slice(0, 8)}, using fallback`,
+      );
+      this.dmRelayCache.set(pubkey, AGGREGATOR_RELAYS);
+      return AGGREGATOR_RELAYS;
+    } catch (err) {
+      console.error(
+        `[NIP-17] Error fetching DM relays for ${pubkey.slice(0, 8)}:`,
+        err,
+      );
+      return AGGREGATOR_RELAYS;
+    }
+  }
+
+  /**
+   * Get DM relays for sending to a recipient
+   * Uses recipient's DM inbox relays
+   */
+  private async getRecipientDmRelays(
+    recipientPubkey: string,
+  ): Promise<string[]> {
+    return this.fetchDmRelays(recipientPubkey);
+  }
+
+  /**
+   * Get DM relays for receiving messages
+   * Uses our own DM inbox relays
+   */
+  private async getOwnDmRelays(): Promise<string[]> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    if (!activePubkey) {
+      return AGGREGATOR_RELAYS;
+    }
+    return this.fetchDmRelays(activePubkey);
+  }
+
+  /**
+   * Load messages for a conversation
+   * Subscribes to gift wraps addressed to us, decrypts them, and filters by conversation
+   */
+  loadMessages(
+    conversation: Conversation,
+    options?: LoadMessagesOptions,
+  ): Observable<Message[]> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    const activeSigner = accountManager.active$.value?.signer;
+
+    if (!activePubkey || !activeSigner) {
+      throw new Error("No active account or signer");
+    }
+
+    const partner = conversation.participants.find(
+      (p) => p.pubkey !== activePubkey,
+    );
+    if (!partner) {
+      throw new Error("No conversation partner found");
+    }
+
+    console.log(
+      `[NIP-17] Loading messages for conversation with ${partner.pubkey.slice(0, 8)}...`,
+    );
+
+    // Start async process to set up subscription
+    const setupSubscription = async () => {
+      // Get DM relays for receiving
+      const dmRelays = await this.getOwnDmRelays();
+
+      console.log(`[NIP-17] Subscribing to ${dmRelays.length} DM relays`);
+
+      // Subscribe to kind 1059 (gift wraps) addressed to us
+      const filter: Filter = {
+        kinds: [1059],
+        "#p": [activePubkey],
+        limit: options?.limit || 100,
+      };
+
+      if (options?.before) {
+        filter.until = options.before;
+      }
+      if (options?.after) {
+        filter.since = options.after;
+      }
+
+      // Clean up any existing subscription for this conversation
+      this.cleanup(conversation.id);
+
+      // Start a persistent subscription to DM relays
+      const subscription = pool
+        .subscription(dmRelays, [filter], {
+          eventStore,
+        })
+        .subscribe({
+          next: (response) => {
+            if (typeof response === "string") {
+              console.log("[NIP-17] EOSE received");
+            } else {
+              console.log(
+                `[NIP-17] Received gift wrap: ${response.id.slice(0, 8)}...`,
+              );
+            }
+          },
+        });
+
+      // Store subscription for cleanup
+      this.subscriptions.set(conversation.id, subscription);
+    };
+
+    // Start subscription setup
+    setupSubscription().catch((err) => {
+      console.error("[NIP-17] Error setting up subscription:", err);
+    });
+
+    // Return observable from EventStore that decrypts gift wraps
+    const giftWrapFilter: Filter = {
+      kinds: [1059],
+      "#p": [activePubkey],
+    };
+
+    return eventStore.timeline(giftWrapFilter).pipe(
+      switchMap((giftWraps) => {
+        // Decrypt all gift wraps and filter for this conversation
+        return from(
+          this.decryptAndFilterMessages(
+            giftWraps,
+            activePubkey,
+            partner.pubkey,
+            conversation.id,
+          ),
+        );
+      }),
+      map((messages) => {
+        console.log(
+          `[NIP-17] Decrypted ${messages.length} messages for conversation`,
+        );
+        // Sort by timestamp ascending
+        return messages.sort((a, b) => a.timestamp - b.timestamp);
+      }),
+    );
+  }
+
+  /**
+   * Decrypt gift wraps and filter messages for a specific conversation
+   */
+  private async decryptAndFilterMessages(
+    giftWraps: NostrEvent[],
+    selfPubkey: string,
+    partnerPubkey: string,
+    conversationId: string,
+  ): Promise<Message[]> {
+    const signer = accountManager.active$.value?.signer;
+    if (!signer) {
+      console.error("[NIP-17] No signer available for decryption");
+      return [];
+    }
+
+    const messages: Message[] = [];
+    const expectedParticipants = [selfPubkey, partnerPubkey].sort().join(":");
+
+    for (const giftWrap of giftWraps) {
+      try {
+        let rumor: Rumor | undefined;
+
+        // Check if already unlocked (cached)
+        if (isGiftWrapUnlocked(giftWrap)) {
+          rumor = getGiftWrapRumor(giftWrap);
+        } else {
+          // Decrypt - this will cache the result
+          rumor = await unlockGiftWrap(giftWrap, signer);
+        }
+
+        if (!rumor) {
+          continue;
+        }
+
+        // Only process kind 14 (NIP-17 direct messages)
+        if (rumor.kind !== 14) {
+          continue;
+        }
+
+        // Check if this message belongs to this conversation
+        const messageParticipants = getConversationParticipants(rumor);
+        const participantKey = messageParticipants.sort().join(":");
+
+        if (participantKey !== expectedParticipants) {
+          // Message is for a different conversation
+          continue;
+        }
+
+        // Convert rumor to message
+        const message = this.rumorToMessage(rumor, conversationId, giftWrap);
+        messages.push(message);
+      } catch (err) {
+        // Decryption failed - might not be for us or corrupted
+        console.debug(
+          `[NIP-17] Failed to decrypt gift wrap ${giftWrap.id.slice(0, 8)}:`,
+          err,
+        );
+      }
+    }
+
+    return messages;
+  }
+
+  /**
+   * Load more historical messages (pagination)
+   */
+  async loadMoreMessages(
+    conversation: Conversation,
+    before: number,
+  ): Promise<Message[]> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    const activeSigner = accountManager.active$.value?.signer;
+
+    if (!activePubkey || !activeSigner) {
+      throw new Error("No active account or signer");
+    }
+
+    const partner = conversation.participants.find(
+      (p) => p.pubkey !== activePubkey,
+    );
+    if (!partner) {
+      throw new Error("No conversation partner found");
+    }
+
+    console.log(
+      `[NIP-17] Loading older messages before ${before} for ${partner.pubkey.slice(0, 8)}`,
+    );
+
+    // Get DM relays
+    const dmRelays = await this.getOwnDmRelays();
+
+    // Fetch older gift wraps
+    const filter: Filter = {
+      kinds: [1059],
+      "#p": [activePubkey],
+      until: before,
+      limit: 50,
+    };
+
+    const giftWraps: NostrEvent[] = [];
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        console.log("[NIP-17] Pagination fetch timeout");
+        resolve();
+      }, 10000);
+
+      const obs = pool.subscription(dmRelays, [filter], { eventStore });
+      const sub = obs.subscribe({
+        next: (response) => {
+          if (typeof response === "string") {
+            clearTimeout(timeout);
+            sub.unsubscribe();
+            resolve();
+          } else {
+            giftWraps.push(response);
+          }
+        },
+        error: (err) => {
+          clearTimeout(timeout);
+          console.error("[NIP-17] Pagination fetch error:", err);
+          sub.unsubscribe();
+          resolve();
+        },
+      });
+    });
+
+    console.log(`[NIP-17] Fetched ${giftWraps.length} older gift wraps`);
+
+    // Decrypt and filter
+    const messages = await this.decryptAndFilterMessages(
+      giftWraps,
+      activePubkey,
+      partner.pubkey,
+      conversation.id,
+    );
+
+    return messages.sort((a, b) => a.timestamp - b.timestamp);
+  }
+
+  /**
+   * Send a message
+   */
+  async sendMessage(
+    conversation: Conversation,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<void> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    const activeSigner = accountManager.active$.value?.signer;
+
+    if (!activePubkey || !activeSigner) {
+      throw new Error("No active account or signer");
+    }
+
+    const partner = conversation.participants.find(
+      (p) => p.pubkey !== activePubkey,
+    );
+    if (!partner) {
+      throw new Error("No conversation partner found");
+    }
+
+    console.log(`[NIP-17] Sending message to ${partner.pubkey.slice(0, 8)}...`);
+
+    // Create event factory and sign
+    const factory = new EventFactory();
+    factory.setSigner(activeSigner);
+
+    // Build the wrapped message rumor using applesauce blueprint
+    const participants = [activePubkey, partner.pubkey];
+
+    // Create the message rumor using factory.create with blueprint
+    let rumor = await factory.create(
+      WrappedMessageBlueprint,
+      participants,
+      content,
+    );
+
+    // Add reply tag if replying
+    if (options?.replyTo) {
+      rumor = {
+        ...rumor,
+        tags: [...rumor.tags, ["e", options.replyTo, "", "reply"]],
+      };
+    }
+
+    // Add emoji tags
+    if (options?.emojiTags) {
+      const emojiTags = options.emojiTags.map((e) => [
+        "emoji",
+        e.shortcode,
+        e.url,
+      ]);
+      rumor = {
+        ...rumor,
+        tags: [...rumor.tags, ...emojiTags],
+      };
+    }
+
+    // Get recipient's DM relays
+    const recipientRelays = await this.getRecipientDmRelays(partner.pubkey);
+    const ownRelays = await this.getOwnDmRelays();
+
+    // Send gift-wrapped copy to recipient
+    const recipientGiftWrap = await factory.create(
+      GiftWrapBlueprint,
+      partner.pubkey,
+      rumor,
+    );
+    const signedRecipientWrap = await factory.sign(recipientGiftWrap);
+
+    console.log(
+      `[NIP-17] Publishing to ${recipientRelays.length} recipient relays`,
+    );
+    await publishEventToRelays(signedRecipientWrap, recipientRelays);
+
+    // Send gift-wrapped copy to ourselves (for syncing across devices)
+    const selfGiftWrap = await factory.create(
+      GiftWrapBlueprint,
+      activePubkey,
+      rumor,
+    );
+    const signedSelfWrap = await factory.sign(selfGiftWrap);
+
+    console.log(`[NIP-17] Publishing self-copy to ${ownRelays.length} relays`);
+    await publishEventToRelays(signedSelfWrap, ownRelays);
+
+    console.log("[NIP-17] Message sent successfully");
+  }
+
+  /**
+   * Get protocol capabilities
+   */
+  getCapabilities(): ChatCapabilities {
+    return {
+      supportsEncryption: true,
+      supportsThreading: true, // e-tag replies
+      supportsModeration: false,
+      supportsRoles: false,
+      supportsGroupManagement: false,
+      canCreateConversations: true,
+      requiresRelay: false,
+    };
+  }
+
+  /**
+   * Load a replied-to message
+   * For NIP-17, we need to search through decrypted rumors
+   */
+  async loadReplyMessage(
+    _conversation: Conversation,
+    eventId: string,
+  ): Promise<NostrEvent | null> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    const activeSigner = accountManager.active$.value?.signer;
+
+    if (!activePubkey || !activeSigner) {
+      return null;
+    }
+
+    // First check if we have this event in our decrypted messages
+    // The eventId for NIP-17 refers to the rumor ID, not the gift wrap ID
+    const giftWrapFilter: Filter = {
+      kinds: [1059],
+      "#p": [activePubkey],
+    };
+
+    // Get all gift wraps from store
+    const giftWraps = await firstValueFrom(
+      eventStore.timeline(giftWrapFilter).pipe(first()),
+      { defaultValue: [] as NostrEvent[] },
+    );
+
+    // Try to find the rumor with matching ID
+    for (const giftWrap of giftWraps) {
+      try {
+        let rumor: Rumor | undefined;
+
+        if (isGiftWrapUnlocked(giftWrap)) {
+          rumor = getGiftWrapRumor(giftWrap);
+        } else {
+          rumor = await unlockGiftWrap(giftWrap, activeSigner);
+        }
+
+        if (rumor && rumor.id === eventId) {
+          // Found it - return as NostrEvent (rumors are structurally similar)
+          return rumor as unknown as NostrEvent;
+        }
+      } catch {
+        // Decryption failed, continue
+      }
+    }
+
+    console.log(
+      `[NIP-17] Reply message ${eventId.slice(0, 8)} not found in decrypted messages`,
+    );
+    return null;
+  }
+
+  /**
+   * Helper: Convert Rumor to Message
+   */
+  private rumorToMessage(
+    rumor: Rumor,
+    conversationId: string,
+    giftWrap: NostrEvent,
+  ): Message {
+    const sender = getWrappedMessageSender(rumor);
+    const replyTo = getWrappedMessageParent(rumor);
+
+    // Also check for e-tag replies
+    const eTags = getTagValues(rumor as unknown as NostrEvent, "e");
+    const eTagReply = eTags.find((_, i, arr) => {
+      // Look for e-tag with "reply" marker
+      const tag = rumor.tags.find(
+        (t) => t[0] === "e" && t[1] === arr[i] && t[3] === "reply",
+      );
+      return !!tag;
+    });
+
+    return {
+      id: rumor.id,
+      conversationId,
+      author: sender,
+      content: rumor.content,
+      timestamp: rumor.created_at,
+      type: "user",
+      replyTo: replyTo || eTagReply,
+      protocol: "nip-17",
+      metadata: {
+        encrypted: true,
+      },
+      // Store the gift wrap as the "event" for reference
+      // (the actual rumor is unsigned so we reference the wrapper)
+      event: giftWrap,
+    };
+  }
+
+  /**
+   * Helper: Get user metadata
+   */
+  private async getMetadata(pubkey: string): Promise<NostrEvent | undefined> {
+    return firstValueFrom(eventStore.replaceable(0, pubkey), {
+      defaultValue: undefined,
+    });
+  }
+}

--- a/src/lib/chat/adapters/nip-29-adapter.test.ts
+++ b/src/lib/chat/adapters/nip-29-adapter.test.ts
@@ -35,16 +35,25 @@ describe("Nip29Adapter", () => {
 
     it("should parse various group-id formats", () => {
       const result1 = adapter.parseIdentifier("relay.example.com'bitcoin-dev");
-      expect(result1?.value).toBe("bitcoin-dev");
-      expect(result1?.relays).toEqual(["wss://relay.example.com"]);
+      expect(result1?.type).toBe("group");
+      if (result1?.type === "group") {
+        expect(result1.value).toBe("bitcoin-dev");
+        expect(result1.relays).toEqual(["wss://relay.example.com"]);
+      }
 
       const result2 = adapter.parseIdentifier("nos.lol'welcome");
-      expect(result2?.value).toBe("welcome");
-      expect(result2?.relays).toEqual(["wss://nos.lol"]);
+      expect(result2?.type).toBe("group");
+      if (result2?.type === "group") {
+        expect(result2.value).toBe("welcome");
+        expect(result2.relays).toEqual(["wss://nos.lol"]);
+      }
 
       const result3 = adapter.parseIdentifier("relay.test.com'my_group_123");
-      expect(result3?.value).toBe("my_group_123");
-      expect(result3?.relays).toEqual(["wss://relay.test.com"]);
+      expect(result3?.type).toBe("group");
+      if (result3?.type === "group") {
+        expect(result3.value).toBe("my_group_123");
+        expect(result3.relays).toEqual(["wss://relay.test.com"]);
+      }
     });
 
     it("should handle relay URLs with ports", () => {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -80,6 +80,21 @@ export interface LocalSpellbook {
   deletedAt?: number;
 }
 
+/**
+ * Decrypted NIP-17 DM message (rumor from gift wrap)
+ * Stored to avoid re-decrypting the same messages
+ */
+export interface DecryptedMessage {
+  id: string; // Rumor ID
+  giftWrapId: string; // Original gift wrap event ID
+  conversationId: string; // nip-17:pubkey format
+  senderPubkey: string; // Who sent the message
+  content: string; // Decrypted message content
+  tags: string[][]; // Rumor tags (for reply references, etc.)
+  createdAt: number; // Message timestamp
+  decryptedAt: number; // When we decrypted it
+}
+
 class GrimoireDb extends Dexie {
   profiles!: Table<Profile>;
   nip05!: Table<Nip05>;
@@ -90,6 +105,7 @@ class GrimoireDb extends Dexie {
   relayLiveness!: Table<RelayLivenessEntry>;
   spells!: Table<LocalSpell>;
   spellbooks!: Table<LocalSpellbook>;
+  decryptedMessages!: Table<DecryptedMessage>;
 
   constructor(name: string) {
     super(name);
@@ -310,6 +326,22 @@ class GrimoireDb extends Dexie {
       relayLiveness: "&url",
       spells: "&id, alias, createdAt, isPublished, deletedAt",
       spellbooks: "&id, slug, title, createdAt, isPublished, deletedAt",
+    });
+
+    // Version 15: Add decrypted NIP-17 messages cache
+    this.version(15).stores({
+      profiles: "&pubkey",
+      nip05: "&nip05",
+      nips: "&id",
+      relayInfo: "&url",
+      relayAuthPreferences: "&url",
+      relayLists: "&pubkey, updatedAt",
+      relayLiveness: "&url",
+      spells: "&id, alias, createdAt, isPublished, deletedAt",
+      spellbooks: "&id, slug, title, createdAt, isPublished, deletedAt",
+      // Index by giftWrapId (for dedup), conversationId (for queries), senderPubkey (for filtering)
+      decryptedMessages:
+        "&id, giftWrapId, conversationId, senderPubkey, createdAt",
     });
   }
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -180,6 +180,15 @@ export interface ChannelIdentifier {
 }
 
 /**
+ * Conversation list identifier - shows all conversations for a protocol
+ */
+export interface ConversationListIdentifier {
+  type: "conversation-list";
+  /** Protocol to show conversations for */
+  protocol: ChatProtocol;
+}
+
+/**
  * Protocol-specific identifier - discriminated union
  * Returned by adapter parseIdentifier()
  */
@@ -188,7 +197,8 @@ export type ProtocolIdentifier =
   | LiveActivityIdentifier
   | DMIdentifier
   | NIP05Identifier
-  | ChannelIdentifier;
+  | ChannelIdentifier
+  | ConversationListIdentifier;
 
 /**
  * Chat command parsing result

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -64,6 +64,7 @@ export interface ConversationMetadata {
   // NIP-17 DM
   encrypted?: boolean;
   giftWrapped?: boolean;
+  dmRelays?: string[]; // DM inbox relays for the conversation
 }
 
 /**


### PR DESCRIPTION
Add NIP-17 private direct messaging support using NIP-44 encryption and NIP-59 gift wrapping for metadata privacy.

Key features:
- End-to-end encrypted messaging with NIP-44
- Gift-wrapped messages (kind 1059) for metadata privacy
- Fetches DM inbox relays (kind 10050) with fallback to NIP-65
- Caches decrypted rumors via applesauce's unlockGiftWrap()
- Sends copies to both recipient and self for device sync
- Supports replies via e-tag markers

The adapter is registered in chat-parser.ts and ChatViewer now supports the nip-17 protocol. Users can start DMs with:
  chat npub1...
  chat alice@example.com
  chat <hex-pubkey>