### PR TITLE
Fix slash command autocomplete and add bookmark commands

### DIFF
--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -345,6 +345,7 @@ export const MentionEditor = forwardRef<
     );
 
     // Create slash command suggestion configuration for / commands
+    // Only triggers when / is at the very beginning of the input
     const slashCommandSuggestion: Omit<SuggestionOptions, "editor"> | null =
       useMemo(
         () =>
@@ -352,6 +353,8 @@ export const MentionEditor = forwardRef<
             ? {
                 char: "/",
                 allowSpaces: false,
+                // Only allow slash commands at the start of input (position 1 in TipTap = first char)
+                allow: ({ range }) => range.from === 1,
                 items: async ({ query }) => {
                   return await searchCommands(query);
                 },


### PR DESCRIPTION
- Fix slash command autocomplete to only trigger when / is at the beginning of input text (position 1 in TipTap), not in the middle of messages
- Add /bookmark command to add NIP-29 group to user's kind 10009 list
- Add /unbookmark command to remove group from user's kind 10009 list