### PR TITLE
Fix chat composer placeholder and text placement

### DIFF
--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -809,7 +809,7 @@ export const MentionEditor = forwardRef<
       editorProps: {
         attributes: {
           class:
-            "prose prose-sm max-w-none focus:outline-none min-h-[1.25rem] px-2 py-1 whitespace-nowrap text-sm",
+            "prose prose-sm max-w-none focus:outline-none min-h-[1.25rem] px-2 py-1 text-sm",
         },
       },
       autofocus: autoFocus,

--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -875,12 +875,9 @@ export const MentionEditor = forwardRef<
 
     return (
       <div
-        className={`rounded border bg-background transition-colors focus-within:border-primary h-7 flex items-center overflow-hidden ${className}`}
+        className={`rounded border bg-background transition-colors focus-within:border-primary min-h-7 max-h-32 flex items-start overflow-y-auto overflow-x-hidden ${className}`}
       >
-        <EditorContent
-          editor={editor}
-          className="flex-1 min-w-0 overflow-x-auto"
-        />
+        <EditorContent editor={editor} className="flex-1 min-w-0" />
       </div>
     );
   },

--- a/src/index.css
+++ b/src/index.css
@@ -281,7 +281,8 @@ body.animating-layout
 
 /* TipTap Editor Styles */
 .ProseMirror {
-  min-height: 2rem;
+  min-height: 1.25rem;
+  line-height: 1.25rem;
 }
 
 .ProseMirror:focus {
@@ -290,11 +291,11 @@ body.animating-layout
 
 .ProseMirror p {
   margin: 0;
+  line-height: 1.25rem;
 }
 
 .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
-  float: left;
   color: hsl(var(--muted-foreground));
   pointer-events: none;
   height: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -283,6 +283,7 @@ body.animating-layout
 .ProseMirror {
   min-height: 1.25rem;
   line-height: 1.25rem;
+  width: 100%;
 }
 
 .ProseMirror:focus {
@@ -292,6 +293,8 @@ body.animating-layout
 .ProseMirror p {
   margin: 0;
   line-height: 1.25rem;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .ProseMirror p.is-editor-empty:first-child::before {

--- a/src/index.css
+++ b/src/index.css
@@ -302,6 +302,7 @@ body.animating-layout
   color: hsl(var(--muted-foreground));
   pointer-events: none;
   height: 0;
+  position: absolute;
 }
 
 /* Mention styles */


### PR DESCRIPTION
- Reduced ProseMirror min-height from 2rem to 1.25rem to match container height
- Added consistent line-height of 1.25rem for proper vertical alignment
- Removed float: left from placeholder pseudo-element (incompatible with flexbox)
- Removed whitespace-nowrap from editor to allow proper text wrapping

Fixes issue where placeholder and text were misaligned in chat composer