### PR TITLE
feat: Add mobile tap support for chat name tooltip

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -481,6 +481,9 @@ export function ChatViewer({
   // State for send in progress (prevents double-sends)
   const [isSending, setIsSending] = useState(false);
 
+  // State for tooltip open (for mobile tap support)
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
   // Handle sending messages with error handling
   const handleSend = async (
     content: string,
@@ -710,9 +713,12 @@ export function ChatViewer({
           <div className="flex flex-1 min-w-0 items-center gap-2">
             {headerPrefix}
             <TooltipProvider>
-              <Tooltip>
+              <Tooltip open={tooltipOpen} onOpenChange={setTooltipOpen}>
                 <TooltipTrigger asChild>
-                  <button className="text-sm font-semibold truncate cursor-help text-left">
+                  <button
+                    className="text-sm font-semibold truncate cursor-help text-left"
+                    onClick={() => setTooltipOpen(!tooltipOpen)}
+                  >
                     {customTitle || conversation.title}
                   </button>
                 </TooltipTrigger>


### PR DESCRIPTION
- Add controlled state for tooltip open/close
- Enable tap/click to toggle tooltip on mobile devices
- Tooltip now shows conversation metadata on tap (icon, description, protocol type, status, host)
- Maintains existing hover behavior on desktop
- Improves mobile UX by making metadata accessible via tap