### PR TITLE
Use npub instead of NIP-05 in sharing URLs

### DIFF
--- a/src/components/ShareSpellbookDialog.tsx
+++ b/src/components/ShareSpellbookDialog.tsx
@@ -13,7 +13,6 @@ import { toast } from "sonner";
 import { nip19 } from "nostr-tools";
 import type { NostrEvent } from "@/types/nostr";
 import type { ParsedSpellbook } from "@/types/spell";
-import { useProfile } from "@/hooks/useProfile";
 import { relayListCache } from "@/services/relay-list-cache";
 
 interface ShareSpellbookDialogProps {
@@ -29,11 +28,10 @@ export function ShareSpellbookDialog({
   event,
   spellbook,
 }: ShareSpellbookDialogProps) {
-  const profile = useProfile(event.pubkey);
   const [copiedLink, setCopiedLink] = useState<string | null>(null);
   const [naddr, setNaddr] = useState<string>("");
 
-  const actor = profile?.nip05 || nip19.npubEncode(event.pubkey);
+  const actor = nip19.npubEncode(event.pubkey);
   const webLink = `${window.location.origin}/${actor}/${spellbook.slug}`;
 
   useEffect(() => {

--- a/src/components/nostr/kinds/SpellbookRenderer.tsx
+++ b/src/components/nostr/kinds/SpellbookRenderer.tsx
@@ -9,7 +9,6 @@ import { SpellbookEvent, ParsedSpellbook } from "@/types/spell";
 import { NostrEvent } from "@/types/nostr";
 import { Layout, ExternalLink, Eye, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useProfile } from "@/hooks/useProfile";
 import { nip19 } from "nostr-tools";
 import { useNavigate } from "react-router";
 import { KindBadge } from "@/components/KindBadge";
@@ -33,7 +32,7 @@ function getSpellbookKinds(spellbook: ParsedSpellbook): number[] {
 
 /**
  * Preview Button Component
- * Navigates to /<npub|nip05>/<identifier>
+ * Navigates to /<npub>/<identifier>
  */
 function PreviewButton({
   event,
@@ -46,12 +45,11 @@ function PreviewButton({
   size?: "default" | "sm" | "lg" | "icon";
   className?: string;
 }) {
-  const profile = useProfile(event.pubkey);
   const navigate = useNavigate();
 
   const handlePreview = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const actor = profile?.nip05 || nip19.npubEncode(event.pubkey);
+    const actor = nip19.npubEncode(event.pubkey);
     navigate(`/preview/${actor}/${identifier}`, { state: { fromApp: true } });
   };
 


### PR DESCRIPTION
- Replace NIP-05 preference with npub in ShareSpellbookDialog
- Replace NIP-05 preference with npub in SpellbookRenderer preview
- Remove unused useProfile imports from both components
- Update comment to reflect npub-only URL format

This ensures more reliable URL sharing since npub is always available
while NIP-05 may not be set or verified. The routing system still
supports both formats for backwards compatibility.