### PR TITLE
feat: Add gift wrap infrastructure and inbox command

### DIFF
--- a/src/components/InboxViewer.tsx
+++ b/src/components/InboxViewer.tsx
@@ -48,19 +48,22 @@ export default function InboxViewer({ action }: InboxViewerProps) {
     const syncGiftWraps = async () => {
       setLoading(true);
       try {
-        // Get inbox relays from user's kind 10002 relay list event
-        const relayListEvent = await firstValueFrom(
-          eventStore.replaceable({ kind: 10002, pubkey }),
+        // Get DM relays from user's kind 10050 relay list (NIP-17)
+        const dmRelayListEvent = await firstValueFrom(
+          eventStore.replaceable({ kind: 10050, pubkey }),
         );
 
-        const inboxRelays = relayListEvent
-          ? Array.from(getInboxes(relayListEvent))
+        // Kind 10050 uses read/write relay tags
+        const dmRelays = dmRelayListEvent
+          ? dmRelayListEvent.tags
+              .filter((t) => t[0] === "relay" && (!t[2] || t[2] === "read"))
+              .map((t) => t[1])
           : [];
 
-        // Fallback to default relays if no inbox relays
+        // Fallback to default relays if no DM relays configured
         const relays =
-          inboxRelays.length > 0
-            ? inboxRelays
+          dmRelays.length > 0
+            ? dmRelays
             : [
                 "wss://relay.damus.io",
                 "wss://nos.lol",

--- a/src/components/InboxViewer.tsx
+++ b/src/components/InboxViewer.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useState } from "react";
+import { use$ } from "applesauce-react/hooks";
+import {
+  Package,
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  Trash2,
+} from "lucide-react";
+import giftWrapManager from "@/services/gift-wrap";
+import accountManager from "@/services/accounts";
+import db, { DecryptedGiftWrap } from "@/services/db";
+import { getInboxes } from "applesauce-core/helpers";
+
+interface InboxViewerProps {
+  action?: "decrypt-pending" | "clear-failed" | null;
+}
+
+export default function InboxViewer({ action }: InboxViewerProps) {
+  const account = use$(accountManager.active$);
+  const syncState = use$(giftWrapManager.state);
+  const [decrypted, setDecrypted] = useState<DecryptedGiftWrap[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [decrypting, setDecrypting] = useState(false);
+
+  const pubkey = account?.pubkey;
+
+  // Load decrypted gift wraps from Dexie
+  useEffect(() => {
+    if (!pubkey) return;
+
+    db.decryptedGiftWraps
+      .orderBy("receivedAt")
+      .reverse()
+      .offset(page * 50)
+      .limit(50)
+      .toArray()
+      .then(setDecrypted);
+  }, [pubkey, page, syncState.decryptedCount]);
+
+  // Initial sync on mount
+  useEffect(() => {
+    if (!pubkey) return;
+
+    const syncGiftWraps = async () => {
+      setLoading(true);
+      try {
+        // Get inbox relays from user's relay list
+        const inboxRelays = Array.from(
+          await getInboxes(pubkey).then((set) => set || new Set()),
+        );
+
+        // Fallback to default relays if no inbox relays
+        const relays =
+          inboxRelays.length > 0
+            ? inboxRelays
+            : [
+                "wss://relay.damus.io",
+                "wss://nos.lol",
+                "wss://relay.nostr.band",
+              ];
+
+        await giftWrapManager.syncAll(pubkey, relays);
+
+        // Subscribe to new gift wraps
+        giftWrapManager.subscribeToNew(pubkey, relays);
+      } catch (error) {
+        console.error("[InboxViewer] Sync error:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    syncGiftWraps();
+
+    return () => {
+      giftWrapManager.unsubscribe(pubkey);
+    };
+  }, [pubkey]);
+
+  // Handle action flags
+  useEffect(() => {
+    if (!action || !pubkey || !account) return;
+
+    const handleAction = async () => {
+      if (action === "decrypt-pending") {
+        await handleDecryptAll();
+      } else if (action === "clear-failed") {
+        await giftWrapManager.clearErrors();
+        await giftWrapManager.updateCounts(pubkey);
+      }
+    };
+
+    handleAction();
+  }, [action, pubkey, account]);
+
+  const handleDecryptAll = async () => {
+    if (!pubkey || !account) return;
+
+    setDecrypting(true);
+    try {
+      // Get pending gift wrap IDs
+      const pending = await new Promise<string[]>((resolve) => {
+        giftWrapManager.getPendingCount(pubkey).subscribe((set) => {
+          // Get IDs from EventStore
+          const ids = Array.from(set as any).map((e: any) => e.id);
+          resolve(ids);
+        });
+      });
+
+      if (pending.length === 0) {
+        console.log("[InboxViewer] No pending gift wraps to decrypt");
+        setDecrypting(false);
+        return;
+      }
+
+      console.log(`[InboxViewer] Decrypting ${pending.length} gift wraps...`);
+
+      // Decrypt batch
+      for await (const result of giftWrapManager.decryptBatch(
+        pending,
+        account,
+      )) {
+        if (result.status === "success") {
+          // Refresh decrypted list
+          const updated = await db.decryptedGiftWraps
+            .orderBy("receivedAt")
+            .reverse()
+            .offset(page * 50)
+            .limit(50)
+            .toArray();
+          setDecrypted(updated);
+        }
+      }
+
+      // Update counts
+      await giftWrapManager.updateCounts(pubkey);
+      console.log("[InboxViewer] Batch decrypt complete");
+    } catch (error) {
+      console.error("[InboxViewer] Decrypt error:", error);
+    } finally {
+      setDecrypting(false);
+    }
+  };
+
+  const handleClearAll = async () => {
+    if (!confirm("Clear all decrypted gift wraps? This cannot be undone.")) {
+      return;
+    }
+
+    await giftWrapManager.clearDecrypted();
+    setDecrypted([]);
+
+    if (pubkey) {
+      await giftWrapManager.updateCounts(pubkey);
+    }
+  };
+
+  if (!account || !pubkey) {
+    return (
+      <div className="flex items-center justify-center h-full text-base-content/50">
+        <div className="text-center space-y-4">
+          <Package className="w-12 h-12 mx-auto opacity-50" />
+          <p>No active account. Please login to view gift wraps.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header with status */}
+      <div className="flex flex-col gap-4 p-4 border-b border-base-300">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            <Package className="w-5 h-5" />
+            Gift Wrap Inbox
+          </h2>
+
+          {loading && (
+            <div className="flex items-center gap-2 text-sm text-base-content/60">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Syncing...
+            </div>
+          )}
+        </div>
+
+        {/* Stats */}
+        <div className="flex gap-4 flex-wrap">
+          <div className="flex items-center gap-2 px-3 py-2 bg-warning/10 text-warning rounded-lg">
+            <Package className="w-4 h-4" />
+            <span className="font-medium">{syncState.pendingCount}</span>
+            <span className="text-sm">Pending</span>
+          </div>
+
+          <div className="flex items-center gap-2 px-3 py-2 bg-success/10 text-success rounded-lg">
+            <CheckCircle2 className="w-4 h-4" />
+            <span className="font-medium">{syncState.decryptedCount}</span>
+            <span className="text-sm">Decrypted</span>
+          </div>
+
+          {syncState.failedCount > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error rounded-lg">
+              <AlertCircle className="w-4 h-4" />
+              <span className="font-medium">{syncState.failedCount}</span>
+              <span className="text-sm">Failed</span>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 flex-wrap">
+          <button
+            onClick={handleDecryptAll}
+            disabled={decrypting || syncState.pendingCount === 0}
+            className="btn btn-sm btn-primary"
+          >
+            {decrypting ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Decrypting...
+              </>
+            ) : (
+              <>Decrypt All Pending ({syncState.pendingCount})</>
+            )}
+          </button>
+
+          {syncState.failedCount > 0 && (
+            <button
+              onClick={() => giftWrapManager.clearErrors()}
+              className="btn btn-sm btn-ghost"
+            >
+              Clear Failed Attempts
+            </button>
+          )}
+
+          {syncState.decryptedCount > 0 && (
+            <button
+              onClick={handleClearAll}
+              className="btn btn-sm btn-ghost text-error"
+            >
+              <Trash2 className="w-4 h-4" />
+              Clear All Decrypted
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Decrypted gift wraps list */}
+      <div className="flex-1 overflow-y-auto">
+        {decrypted.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-base-content/50">
+            <div className="text-center space-y-4">
+              <Package className="w-12 h-12 mx-auto opacity-50" />
+              <p>No decrypted gift wraps yet.</p>
+              {syncState.pendingCount > 0 && (
+                <button
+                  onClick={handleDecryptAll}
+                  disabled={decrypting}
+                  className="btn btn-primary btn-sm"
+                >
+                  Decrypt {syncState.pendingCount} Pending
+                </button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="divide-y divide-base-300">
+            {decrypted.map((wrap) => (
+              <div key={wrap.giftWrapId} className="p-4 hover:bg-base-200/50">
+                <div className="flex items-start gap-3">
+                  <Package className="w-5 h-5 text-base-content/40 mt-1" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-sm font-medium">
+                        Kind {wrap.rumor.kind}
+                      </span>
+                      {wrap.sealPubkey && (
+                        <span className="text-xs text-base-content/60 font-mono">
+                          from {wrap.sealPubkey.slice(0, 8)}...
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-base-content/80 line-clamp-2">
+                      {wrap.rumor.content.slice(0, 200)}
+                      {wrap.rumor.content.length > 200 && "..."}
+                    </p>
+                    <div className="flex items-center gap-4 mt-2 text-xs text-base-content/60">
+                      <span>
+                        Received:{" "}
+                        {new Date(wrap.receivedAt * 1000).toLocaleString()}
+                      </span>
+                      <span>
+                        Decrypted:{" "}
+                        {new Date(wrap.decryptedAt * 1000).toLocaleString()}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Load more button */}
+        {decrypted.length >= 50 && (
+          <div className="p-4 text-center">
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              className="btn btn-sm btn-ghost"
+            >
+              Load More
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Footer with sync info */}
+      {syncState.lastSyncAt > 0 && (
+        <div className="p-2 text-xs text-center text-base-content/50 border-t border-base-300">
+          Last synced: {new Date(syncState.lastSyncAt).toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/InboxViewer.tsx
+++ b/src/components/InboxViewer.tsx
@@ -12,7 +12,6 @@ import giftWrapManager from "@/services/gift-wrap";
 import accountManager from "@/services/accounts";
 import eventStore from "@/services/event-store";
 import db, { DecryptedGiftWrap } from "@/services/db";
-import { getInboxes } from "applesauce-core/helpers";
 
 interface InboxViewerProps {
   action?: "decrypt-pending" | "clear-failed" | null;

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -33,6 +33,9 @@ const ChatViewer = lazy(() =>
 const GroupListViewer = lazy(() =>
   import("./GroupListViewer").then((m) => ({ default: m.GroupListViewer })),
 );
+const InboxViewer = lazy(() =>
+  import("./InboxViewer").then((m) => ({ default: m.default })),
+);
 const SpellsViewer = lazy(() =>
   import("./SpellsViewer").then((m) => ({ default: m.SpellsViewer })),
 );
@@ -191,6 +194,9 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
             />
           );
         }
+        break;
+      case "inbox":
+        content = <InboxViewer action={window.props.action} />;
         break;
       case "spells":
         content = <SpellsViewer />;

--- a/src/lib/chat-parser.ts
+++ b/src/lib/chat-parser.ts
@@ -1,10 +1,10 @@
 import type { ChatCommandResult, GroupListIdentifier } from "@/types/chat";
 // import { NipC7Adapter } from "./chat/adapters/nip-c7-adapter";
+import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 import { Nip29Adapter } from "./chat/adapters/nip-29-adapter";
 import { Nip53Adapter } from "./chat/adapters/nip-53-adapter";
 import { nip19 } from "nostr-tools";
 // Import other adapters as they're implemented
-// import { Nip17Adapter } from "./chat/adapters/nip-17-adapter";
 // import { Nip28Adapter } from "./chat/adapters/nip-28-adapter";
 
 /**
@@ -62,7 +62,7 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
 
   // Try each adapter in priority order
   const adapters = [
-    // new Nip17Adapter(),  // Phase 2
+    new Nip17Adapter(), // Phase 2 - Private DMs (prioritized for pubkeys)
     // new Nip28Adapter(),  // Phase 3
     new Nip29Adapter(), // Phase 4 - Relay groups
     new Nip53Adapter(), // Phase 5 - Live activity chat
@@ -84,6 +84,11 @@ export function parseChatCommand(args: string[]): ChatCommandResult {
     `Unable to determine chat protocol from identifier: ${identifier}
 
 Currently supported formats:
+  - npub1.../nprofile1.../hex pubkey (NIP-17 private DMs, encrypted)
+    Examples:
+      chat npub1...
+      chat nprofile1...
+      chat abc123... (64 hex chars)
   - relay.com'group-id (NIP-29 relay group, wss:// prefix optional)
     Examples:
       chat relay.example.com'bitcoin-dev
@@ -99,7 +104,6 @@ Currently supported formats:
       chat naddr1... (group list address)
 
 More formats coming soon:
-  - npub/nprofile/hex pubkey (NIP-C7/NIP-17 direct messages)
   - note/nevent (NIP-28 public channels)`,
   );
 }

--- a/src/lib/chat/adapters/nip-17-adapter.ts
+++ b/src/lib/chat/adapters/nip-17-adapter.ts
@@ -1,0 +1,342 @@
+import { Observable, firstValueFrom, map } from "rxjs";
+import { nip19 } from "nostr-tools";
+import { ChatProtocolAdapter, type SendMessageOptions } from "./base-adapter";
+import type {
+  Conversation,
+  Message,
+  ProtocolIdentifier,
+  ChatCapabilities,
+  LoadMessagesOptions,
+} from "@/types/chat";
+import type { NostrEvent } from "@/types/nostr";
+import eventStore from "@/services/event-store";
+import accountManager from "@/services/accounts";
+import db from "@/services/db";
+import { WrappedMessagesModel } from "applesauce-common/models";
+import { SendWrappedMessage } from "applesauce-actions/actions";
+import type { Rumor } from "applesauce-common/helpers/gift-wrap";
+import { hub } from "@/services/hub";
+
+/**
+ * NIP-17 Adapter - Private Direct Messages via Gift Wrap
+ *
+ * Features:
+ * - End-to-end encryption using NIP-44
+ * - Sender/receiver anonymity via gift wrap (NIP-59)
+ * - Uses kind 10050 (DM relay list) for sending/receiving
+ * - Messages are kind 14 (chat message) wrapped as rumors
+ *
+ * Identifier format: npub/nprofile/hex pubkey of recipient
+ */
+export class Nip17Adapter extends ChatProtocolAdapter {
+  readonly protocol = "nip-17" as const;
+  readonly type = "dm" as const;
+
+  /**
+   * Parse identifier - accepts npub, nprofile, or hex pubkey
+   * Examples:
+   *   - npub1...
+   *   - nprofile1...
+   *   - hex pubkey (64 chars)
+   */
+  parseIdentifier(input: string): ProtocolIdentifier | null {
+    // Try npub format
+    if (input.startsWith("npub1")) {
+      try {
+        const decoded = nip19.decode(input);
+        if (decoded.type === "npub") {
+          return {
+            type: "dm-recipient",
+            value: decoded.data,
+            relays: [],
+          };
+        }
+      } catch {
+        return null;
+      }
+    }
+
+    // Try nprofile format
+    if (input.startsWith("nprofile1")) {
+      try {
+        const decoded = nip19.decode(input);
+        if (decoded.type === "nprofile") {
+          return {
+            type: "dm-recipient",
+            value: decoded.data.pubkey,
+            relays: decoded.data.relays || [],
+          };
+        }
+      } catch {
+        return null;
+      }
+    }
+
+    // Try hex pubkey (64 hex chars)
+    if (/^[0-9a-f]{64}$/i.test(input)) {
+      return {
+        type: "dm-recipient",
+        value: input.toLowerCase(),
+        relays: [],
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve conversation from recipient identifier
+   */
+  async resolveConversation(
+    identifier: ProtocolIdentifier,
+  ): Promise<Conversation> {
+    if (identifier.type !== "dm-recipient") {
+      throw new Error(
+        `NIP-17 adapter cannot handle identifier type: ${identifier.type}`,
+      );
+    }
+
+    const recipientPubkey = identifier.value;
+    const activePubkey = accountManager.active$.value?.pubkey;
+
+    if (!activePubkey) {
+      throw new Error("No active account");
+    }
+
+    console.log(`[NIP-17] Resolving DM conversation with ${recipientPubkey}`);
+
+    // Fetch recipient's profile for display name
+    const profile = await firstValueFrom(
+      eventStore.replaceable({ kind: 0, pubkey: recipientPubkey }),
+    );
+
+    let title = recipientPubkey.slice(0, 8) + "...";
+    if (profile) {
+      try {
+        const metadata = JSON.parse(profile.content);
+        title = metadata.name || metadata.display_name || title;
+      } catch {
+        // Invalid profile content, use pubkey
+      }
+    }
+
+    return {
+      id: `nip-17:${recipientPubkey}`,
+      type: "dm",
+      protocol: "nip-17",
+      title,
+      participants: [{ pubkey: activePubkey }, { pubkey: recipientPubkey }],
+      metadata: {
+        encrypted: true,
+        giftWrapped: true,
+      },
+      unreadCount: 0,
+    };
+  }
+
+  /**
+   * Load messages for a DM conversation
+   * Uses WrappedMessagesModel to get decrypted rumors from EventStore
+   */
+  loadMessages(
+    conversation: Conversation,
+    _options?: LoadMessagesOptions,
+  ): Observable<Message[]> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+    if (!activePubkey) {
+      throw new Error("No active account");
+    }
+
+    const recipientPubkey = conversation.participants.find(
+      (p) => p.pubkey !== activePubkey,
+    )?.pubkey;
+
+    if (!recipientPubkey) {
+      throw new Error("Recipient pubkey not found in conversation");
+    }
+
+    console.log(
+      `[NIP-17] Loading messages with ${recipientPubkey} for ${activePubkey}`,
+    );
+
+    // WrappedMessagesModel returns ALL decrypted rumors for the user
+    // We need to filter for this specific conversation
+    return eventStore.model(WrappedMessagesModel, activePubkey).pipe(
+      map((rumors) => {
+        // rumors is an array of decrypted kind 14 events
+        if (!Array.isArray(rumors)) {
+          console.warn("[NIP-17] WrappedMessagesModel returned non-array");
+          return [];
+        }
+
+        // Filter for messages with the specific conversation partner
+        const conversationRumors = rumors.filter((rumor) => {
+          // Message is in this conversation if:
+          // 1. We sent it to the recipient (rumor.pubkey === activePubkey, p-tag === recipientPubkey)
+          // 2. Recipient sent it to us (rumor.pubkey === recipientPubkey)
+          const pTags = rumor.tags.filter((t) => t[0] === "p");
+          const hasRecipient = pTags.some((t) => t[1] === recipientPubkey);
+
+          return (
+            (rumor.pubkey === activePubkey && hasRecipient) ||
+            rumor.pubkey === recipientPubkey
+          );
+        });
+
+        console.log(
+          `[NIP-17] Got ${conversationRumors.length} messages for conversation (out of ${rumors.length} total)`,
+        );
+
+        const messages = conversationRumors.map((rumor) =>
+          this.rumorToMessage(rumor, conversation.id),
+        );
+
+        // Sort by timestamp ascending (chat order)
+        return messages.sort((a, b) => a.timestamp - b.timestamp);
+      }),
+    );
+  }
+
+  /**
+   * Load more historical messages (pagination)
+   * For NIP-17, we rely on gift wrap sync to fetch all messages
+   * This method returns empty array as pagination is handled by gift wrap manager
+   */
+  async loadMoreMessages(
+    _conversation: Conversation,
+    _before: number,
+  ): Promise<Message[]> {
+    console.log(
+      `[NIP-17] loadMoreMessages called - pagination handled by gift wrap sync`,
+    );
+    // Gift wrap manager syncs all messages, so we don't need additional fetching
+    return [];
+  }
+
+  /**
+   * Send a message to the recipient
+   * Uses SendWrappedMessage action to create and publish gift wrap
+   */
+  async sendMessage(
+    conversation: Conversation,
+    content: string,
+    options?: SendMessageOptions,
+  ): Promise<void> {
+    const activePubkey = accountManager.active$.value?.pubkey;
+
+    if (!activePubkey) {
+      throw new Error("No active account");
+    }
+
+    const recipientPubkey = conversation.participants.find(
+      (p) => p.pubkey !== activePubkey,
+    )?.pubkey;
+
+    if (!recipientPubkey) {
+      throw new Error("Recipient pubkey not found");
+    }
+
+    console.log(`[NIP-17] Sending message to ${recipientPubkey}`);
+
+    // Build wrapped message options
+    const wrappedOpts: { emojis?: Array<{ shortcode: string; url: string }> } =
+      {};
+
+    // Add NIP-30 emoji tags if provided
+    if (options?.emojiTags) {
+      wrappedOpts.emojis = options.emojiTags.map((e) => ({
+        shortcode: e.shortcode,
+        url: e.url,
+      }));
+    }
+
+    // TODO: SendWrappedMessage doesn't currently support reply tags or attachments
+    // We may need to use lower-level blueprint API for full feature support
+    if (options?.replyTo) {
+      console.warn(
+        "[NIP-17] Reply tags not yet supported in SendWrappedMessage action",
+      );
+    }
+    if (options?.blobAttachments) {
+      console.warn(
+        "[NIP-17] Blob attachments not yet supported in SendWrappedMessage action",
+      );
+    }
+
+    // Use SendWrappedMessage action to wrap and publish
+    // It will automatically fetch recipient's inbox relays and send the gift wrap
+    await hub.run(SendWrappedMessage, recipientPubkey, content, wrappedOpts);
+
+    console.log(`[NIP-17] Message sent successfully`);
+  }
+
+  /**
+   * Get protocol capabilities
+   */
+  getCapabilities(): ChatCapabilities {
+    return {
+      supportsEncryption: true, // NIP-44 encryption
+      supportsThreading: true, // e-tag replies
+      supportsModeration: false, // No moderation in DMs
+      supportsRoles: false, // No roles in DMs
+      supportsGroupManagement: false, // No group management
+      canCreateConversations: true, // Can DM any pubkey
+      requiresRelay: false, // Uses user's DM relay list
+    };
+  }
+
+  /**
+   * Load a replied-to message by ID
+   * First checks EventStore (decrypted rumors), then gift wrap cache
+   */
+  async loadReplyMessage(
+    _conversation: Conversation,
+    eventId: string,
+  ): Promise<NostrEvent | null> {
+    // Check EventStore for decrypted rumor
+    const cachedRumor = await firstValueFrom(eventStore.event(eventId));
+    if (cachedRumor) {
+      return cachedRumor;
+    }
+
+    // Check Dexie cache for decrypted gift wrap by rumor ID
+    const decryptedWraps = await db.decryptedGiftWraps
+      .where("rumorId")
+      .equals(eventId)
+      .toArray();
+
+    if (decryptedWraps.length > 0) {
+      return decryptedWraps[0].rumor;
+    }
+
+    console.warn(`[NIP-17] Reply message ${eventId} not found`);
+    return null;
+  }
+
+  /**
+   * Helper: Convert rumor (kind 14) to Message
+   * Rumor is an unsigned event, so we cast it to NostrEvent for storage
+   */
+  private rumorToMessage(rumor: Rumor, conversationId: string): Message {
+    // Extract reply target from e-tags with marker "reply"
+    const eTags = rumor.tags.filter((t) => t[0] === "e");
+    const replyTag = eTags.find((t) => t[3] === "reply");
+    const replyTo = replyTag?.[1];
+
+    return {
+      id: rumor.id,
+      conversationId,
+      author: rumor.pubkey,
+      content: rumor.content,
+      timestamp: rumor.created_at,
+      type: "user",
+      replyTo,
+      protocol: "nip-17",
+      metadata: {
+        encrypted: true,
+      },
+      // Cast Rumor to NostrEvent - it's missing sig field but that's okay for display
+      event: rumor as unknown as NostrEvent,
+    };
+  }
+}

--- a/src/lib/command-reconstructor.ts
+++ b/src/lib/command-reconstructor.ts
@@ -139,6 +139,19 @@ export function reconstructCommand(window: WindowInstance): string {
         return "chat";
       }
 
+      case "inbox": {
+        // Reconstruct inbox command with action flags
+        const { action } = props;
+
+        if (action === "decrypt-pending") {
+          return "inbox --decrypt-pending";
+        } else if (action === "clear-failed") {
+          return "inbox --clear-failed";
+        }
+
+        return "inbox";
+      }
+
       default:
         return appId; // Fallback to just the command name
     }

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -87,6 +87,22 @@ export interface LocalSpellbook {
   deletedAt?: number;
 }
 
+export interface DecryptedGiftWrap {
+  giftWrapId: string; // kind 1059 event ID (primary key)
+  rumorId: string; // Unwrapped rumor ID
+  rumor: NostrEvent; // Actual unsigned event (JSON)
+  sealPubkey: string; // Who sent it (from seal)
+  decryptedAt: number; // When we decrypted
+  receivedAt: number; // Gift wrap created_at (for sorting)
+}
+
+export interface GiftWrapDecryptionError {
+  giftWrapId: string; // kind 1059 event ID (primary key)
+  attemptCount: number; // Number of failed decrypt attempts
+  lastAttempt: number; // Timestamp of last attempt
+  errorMessage: string; // Error message from last attempt
+}
+
 class GrimoireDb extends Dexie {
   profiles!: Table<Profile>;
   nip05!: Table<Nip05>;
@@ -98,6 +114,8 @@ class GrimoireDb extends Dexie {
   blossomServers!: Table<CachedBlossomServerList>;
   spells!: Table<LocalSpell>;
   spellbooks!: Table<LocalSpellbook>;
+  decryptedGiftWraps!: Table<DecryptedGiftWrap>;
+  giftWrapErrors!: Table<GiftWrapDecryptionError>;
 
   constructor(name: string) {
     super(name);
@@ -332,6 +350,22 @@ class GrimoireDb extends Dexie {
       blossomServers: "&pubkey, updatedAt",
       spells: "&id, alias, createdAt, isPublished, deletedAt",
       spellbooks: "&id, slug, title, createdAt, isPublished, deletedAt",
+    });
+
+    // Version 16: Add gift wrap storage
+    this.version(16).stores({
+      profiles: "&pubkey",
+      nip05: "&nip05",
+      nips: "&id",
+      relayInfo: "&url",
+      relayAuthPreferences: "&url",
+      relayLists: "&pubkey, updatedAt",
+      relayLiveness: "&url",
+      blossomServers: "&pubkey, updatedAt",
+      spells: "&id, alias, createdAt, isPublished, deletedAt",
+      spellbooks: "&id, slug, title, createdAt, isPublished, deletedAt",
+      decryptedGiftWraps: "&giftWrapId, sealPubkey, receivedAt, decryptedAt",
+      giftWrapErrors: "&giftWrapId, lastAttempt",
     });
   }
 }

--- a/src/services/gift-wrap.ts
+++ b/src/services/gift-wrap.ts
@@ -1,0 +1,313 @@
+import { BehaviorSubject, map, Subscription } from "rxjs";
+import { createTimelineLoader } from "applesauce-loaders/loaders";
+import { onlyEvents, mapEventsToStore } from "applesauce-core";
+import { unlockGiftWrap, getGiftWrapSeal } from "applesauce-common/helpers";
+import { GiftWrapsModel } from "applesauce-common/models";
+import type { Signer } from "applesauce-signers";
+import type { NostrEvent } from "@/types/nostr";
+import eventStore from "./event-store";
+import pool from "./relay-pool";
+import db from "./db";
+import { getEventsForFilters } from "nostr-idb";
+
+/**
+ * Gift wrap sync state
+ */
+export interface GiftWrapSyncState {
+  syncing: boolean;
+  pendingCount: number;
+  decryptedCount: number;
+  failedCount: number;
+  totalCount: number;
+  lastSyncAt: number;
+}
+
+/**
+ * Manager for gift wrap syncing and decryption
+ *
+ * Simple strategy:
+ * 1. Load all gift wraps using paginated timeline loader
+ * 2. Subscribe to new gift wraps in real-time
+ * 3. Decrypt on demand and cache in Dexie
+ * 4. Track counts and state
+ */
+class GiftWrapManager {
+  private state$ = new BehaviorSubject<GiftWrapSyncState>({
+    syncing: false,
+    pendingCount: 0,
+    decryptedCount: 0,
+    failedCount: 0,
+    totalCount: 0,
+    lastSyncAt: 0,
+  });
+
+  private subscriptions = new Map<string, Subscription>();
+
+  /**
+   * Get observable of gift wrap sync state
+   */
+  get state() {
+    return this.state$.asObservable();
+  }
+
+  /**
+   * Sync all gift wraps for a pubkey from relays
+   * Loads all pages until timeline is exhausted
+   */
+  async syncAll(pubkey: string, relays: string[]): Promise<void> {
+    if (this.state$.value.syncing) {
+      console.log("[GiftWrap] Already syncing, skipping...");
+      return;
+    }
+
+    this.updateState({ syncing: true });
+    console.log(
+      `[GiftWrap] Starting sync for ${pubkey} on ${relays.length} relays`,
+    );
+
+    try {
+      // Create timeline loader with cache fallback
+      const timeline = createTimelineLoader(
+        pool,
+        relays,
+        { kinds: [1059], "#p": [pubkey], limit: 100 },
+        {
+          eventStore,
+          cache: (filters) => getEventsForFilters(await db.open(), filters),
+        },
+      );
+
+      // Load pages until no more events
+      let page = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const result = await new Promise<NostrEvent[]>((resolve) => {
+          const events: NostrEvent[] = [];
+          timeline().subscribe({
+            next: (event) => events.push(event),
+            complete: () => resolve(events),
+            error: (err) => {
+              console.error("[GiftWrap] Timeline error:", err);
+              resolve(events);
+            },
+          });
+        });
+
+        page++;
+        hasMore = result.length > 0;
+
+        if (hasMore) {
+          console.log(
+            `[GiftWrap] Loaded page ${page}: ${result.length} events`,
+          );
+        }
+      }
+
+      console.log(`[GiftWrap] Sync complete: loaded ${page} pages`);
+      await this.updateCounts(pubkey);
+      this.updateState({ lastSyncAt: Date.now() });
+    } catch (error) {
+      console.error("[GiftWrap] Sync error:", error);
+    } finally {
+      this.updateState({ syncing: false });
+    }
+  }
+
+  /**
+   * Subscribe to new gift wraps in real-time
+   */
+  subscribeToNew(pubkey: string, relays: string[]): void {
+    const key = pubkey;
+
+    // Cleanup existing subscription
+    this.subscriptions.get(key)?.unsubscribe();
+
+    console.log(`[GiftWrap] Subscribing to new gift wraps for ${pubkey}`);
+
+    // Subscribe to each relay
+    const subs = relays.map((relay) =>
+      pool
+        .relay(relay)
+        .subscription({
+          kinds: [1059],
+          "#p": [pubkey],
+          since: Math.floor(Date.now() / 1000),
+        })
+        .pipe(onlyEvents(), mapEventsToStore(eventStore))
+        .subscribe({
+          next: (event) => {
+            console.log("[GiftWrap] New gift wrap received:", event.id);
+            this.updateCounts(pubkey);
+          },
+          error: (err) => console.error("[GiftWrap] Subscription error:", err),
+        }),
+    );
+
+    // Store combined subscription
+    const combined = new Subscription();
+    subs.forEach((sub) => combined.add(sub));
+    this.subscriptions.set(key, combined);
+  }
+
+  /**
+   * Unsubscribe from gift wrap updates
+   */
+  unsubscribe(pubkey: string): void {
+    this.subscriptions.get(pubkey)?.unsubscribe();
+    this.subscriptions.delete(pubkey);
+  }
+
+  /**
+   * Update counts from EventStore and Dexie
+   */
+  async updateCounts(pubkey: string): Promise<void> {
+    // Get pending count from applesauce model
+    const pending = await new Promise<number>((resolve) => {
+      eventStore
+        .model(GiftWrapsModel, pubkey, true)
+        .pipe(map((set) => set.size))
+        .subscribe(resolve);
+    });
+
+    // Get decrypted count from Dexie
+    const decrypted = await db.decryptedGiftWraps.count();
+
+    // Get failed count from Dexie
+    const failed = await db.giftWrapErrors.count();
+
+    // Total is pending + decrypted
+    const total = pending + decrypted;
+
+    this.updateState({
+      pendingCount: pending,
+      decryptedCount: decrypted,
+      failedCount: failed,
+      totalCount: total,
+    });
+  }
+
+  /**
+   * Get observable of pending gift wrap count
+   */
+  getPendingCount(pubkey: string) {
+    return eventStore
+      .model(GiftWrapsModel, pubkey, true)
+      .pipe(map((set) => set.size));
+  }
+
+  /**
+   * Decrypt a single gift wrap
+   * Returns cached result if already decrypted
+   */
+  async decryptOne(giftWrapId: string, signer: Signer): Promise<NostrEvent> {
+    // Check cache first
+    const cached = await db.decryptedGiftWraps.get(giftWrapId);
+    if (cached) {
+      console.log("[GiftWrap] Using cached decryption:", giftWrapId);
+      return cached.rumor;
+    }
+
+    // Check if previously failed
+    const error = await db.giftWrapErrors.get(giftWrapId);
+    if (error && error.attemptCount >= 3) {
+      throw new Error(
+        `Max decrypt attempts exceeded (${error.attemptCount}): ${error.errorMessage}`,
+      );
+    }
+
+    // Get gift wrap from EventStore
+    const gift = eventStore.event(giftWrapId);
+    if (!gift) {
+      throw new Error(`Gift wrap not found: ${giftWrapId}`);
+    }
+
+    try {
+      console.log("[GiftWrap] Decrypting:", giftWrapId);
+      const rumor = await unlockGiftWrap(gift, signer);
+
+      // Cache decrypted rumor
+      await db.decryptedGiftWraps.add({
+        giftWrapId: gift.id,
+        rumorId: rumor.id,
+        rumor,
+        sealPubkey: getGiftWrapSeal(gift)?.pubkey || "",
+        decryptedAt: Math.floor(Date.now() / 1000),
+        receivedAt: gift.created_at,
+      });
+
+      console.log("[GiftWrap] Decrypted successfully:", giftWrapId);
+      return rumor;
+    } catch (err) {
+      const errorMessage = String(err);
+      console.error("[GiftWrap] Decryption failed:", giftWrapId, errorMessage);
+
+      // Track error
+      await db.giftWrapErrors.put({
+        giftWrapId,
+        attemptCount: (error?.attemptCount || 0) + 1,
+        lastAttempt: Math.floor(Date.now() / 1000),
+        errorMessage,
+      });
+
+      throw err;
+    }
+  }
+
+  /**
+   * Batch decrypt gift wraps with progress tracking
+   */
+  async *decryptBatch(
+    giftWrapIds: string[],
+    signer: Signer,
+  ): AsyncGenerator<{
+    id: string;
+    status: "success" | "error";
+    rumor?: NostrEvent;
+    error?: string;
+  }> {
+    console.log(`[GiftWrap] Batch decrypting ${giftWrapIds.length} gift wraps`);
+
+    for (const id of giftWrapIds) {
+      try {
+        const rumor = await this.decryptOne(id, signer);
+        yield { id, status: "success", rumor };
+      } catch (err) {
+        yield { id, status: "error", error: String(err) };
+      }
+
+      // Small delay to avoid blocking UI
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    console.log("[GiftWrap] Batch decrypt complete");
+  }
+
+  /**
+   * Clear all failed decryption errors
+   */
+  async clearErrors(): Promise<void> {
+    await db.giftWrapErrors.clear();
+    console.log("[GiftWrap] Cleared all decryption errors");
+  }
+
+  /**
+   * Clear all decrypted gift wraps from cache
+   */
+  async clearDecrypted(): Promise<void> {
+    await db.decryptedGiftWraps.clear();
+    await db.giftWrapErrors.clear();
+    console.log("[GiftWrap] Cleared all decrypted gift wraps");
+  }
+
+  /**
+   * Update state (partial update)
+   */
+  private updateState(partial: Partial<GiftWrapSyncState>): void {
+    this.state$.next({ ...this.state$.value, ...partial });
+  }
+}
+
+// Export singleton instance
+const giftWrapManager = new GiftWrapManager();
+export default giftWrapManager;

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -17,6 +17,7 @@ export type AppId =
   | "debug"
   | "conn"
   | "chat"
+  | "inbox"
   | "spells"
   | "spellbooks"
   | "blossom"

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -351,21 +351,22 @@ export const manPages: Record<string, ManPageEntry> = {
     section: "1",
     synopsis: "chat <identifier>",
     description:
-      "Join and participate in Nostr chat conversations. Supports NIP-29 relay-based groups, NIP-53 live activity chat, and multi-room group list interface. For NIP-29 groups, use format 'relay'group-id' where relay is the WebSocket URL (wss:// prefix optional). For NIP-53 live activities, pass the naddr of a kind 30311 live event. For multi-room interface, pass the naddr of a kind 10009 group list event.",
+      "Join and participate in Nostr chat conversations. Supports NIP-17 private DMs, NIP-29 relay-based groups, NIP-53 live activity chat, and multi-room group list interface. For private DMs, provide npub/nprofile/hex pubkey. For NIP-29 groups, use format 'relay'group-id' where relay is the WebSocket URL (wss:// prefix optional). For NIP-53 live activities, pass the naddr of a kind 30311 live event. For multi-room interface, pass the naddr of a kind 10009 group list event.",
     options: [
       {
         flag: "<identifier>",
         description:
-          "NIP-29 group (relay'group-id), NIP-53 live activity (naddr1... kind 30311), or group list (naddr1... kind 10009)",
+          "npub/nprofile/hex (NIP-17), NIP-29 group (relay'group-id), NIP-53 live activity (naddr1... kind 30311), or group list (naddr1... kind 10009)",
       },
     ],
     examples: [
+      "chat npub1...                             Open NIP-17 private DM",
       "chat relay.example.com'bitcoin-dev        Join NIP-29 relay group",
       "chat wss://nos.lol'welcome                Join NIP-29 group with explicit protocol",
       "chat naddr1...30311...                    Join NIP-53 live activity chat",
       "chat naddr1...10009...                    Open multi-room group list interface",
     ],
-    seeAlso: ["profile", "open", "req", "live"],
+    seeAlso: ["inbox", "profile", "open", "req", "live"],
     appId: "chat",
     category: "Nostr",
     argParser: async (args: string[]) => {
@@ -375,6 +376,40 @@ export const manPages: Record<string, ManPageEntry> = {
         identifier: result.identifier,
       };
     },
+  },
+  inbox: {
+    name: "inbox",
+    section: "1",
+    synopsis: "inbox [--decrypt-pending | --clear-failed]",
+    description:
+      "View and manage encrypted gift wrap messages (NIP-59). Shows pending, decrypted, and failed gift wraps. Gift wraps are used for private messages (NIP-17) and other private events. Use --decrypt-pending to decrypt all pending gift wraps, or --clear-failed to reset failed decryption attempts.",
+    options: [
+      {
+        flag: "--decrypt-pending",
+        description: "Decrypt all pending gift wraps",
+      },
+      {
+        flag: "--clear-failed",
+        description: "Clear failed decryption attempts",
+      },
+    ],
+    examples: [
+      "inbox                     Open inbox viewer",
+      "inbox --decrypt-pending   Decrypt all pending gift wraps",
+      "inbox --clear-failed      Clear failed decryption attempts",
+    ],
+    seeAlso: ["chat", "profile"],
+    appId: "inbox",
+    category: "Nostr",
+    argParser: (args: string[]) => {
+      const action = args.includes("--decrypt-pending")
+        ? "decrypt-pending"
+        : args.includes("--clear-failed")
+          ? "clear-failed"
+          : null;
+      return { action };
+    },
+    defaultProps: { action: null },
   },
   profile: {
     name: "profile",

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"errors":true,"version":"5.9.3"}
+{"root":["./vite.config.ts"],"version":"5.6.3"}

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"version":"5.6.3"}
+{"root":["./vite.config.ts"],"errors":true,"version":"5.9.3"}


### PR DESCRIPTION
Core infrastructure for NIP-59 gift wrap support:

**Database Schema (v16):**
- Add decryptedGiftWraps table with indexed fields
- Add giftWrapErrors table for tracking failed decrypts
- Indexes: giftWrapId, sealPubkey, receivedAt, decryptedAt

**Gift Wrap Service (`gift-wrap.ts`):**
- Simple sync strategy: paginated loading + real-time subscription
- Uses createTimelineLoader for initial sync (loads all pages)
- Subscribes to new gift wraps via relay subscriptions
- On-demand decryption with Dexie caching
- Batch decrypt with progress tracking and error handling
- Integrates with applesauce GiftWrapsModel and unlockGiftWrap

**Inbox Command & Viewer:**
- `inbox` - View pending/decrypted/failed gift wraps
- `inbox --decrypt-pending` - Decrypt all pending
- `inbox --clear-failed` - Reset failed attempts
- Auto-syncs on mount using user's inbox relays (NIP-65)
- Shows stats: pending/decrypted/failed counts
- Paginated list of decrypted gift wraps with metadata
- Real-time updates via giftWrapManager state observable

**Integration:**
- Added "inbox" to AppId type
- Wired up InboxViewer in WindowRenderer (lazy loaded)
- Added command reconstructor for inbox commands
- Updated chat command description to mention NIP-17

No password/encryption layer yet - decrypted content stored in
plain Dexie tables. NIP-17 adapter implementation next.