### PR TITLE
feat: disable pointer events on group message preview

### DIFF
--- a/src/components/GroupListViewer.tsx
+++ b/src/components/GroupListViewer.tsx
@@ -94,7 +94,7 @@ const GroupListItem = memo(function GroupListItem({
       </div>
       {/* Last message preview - hide images and event embeds */}
       {lastMessageAuthor && lastMessageContent && (
-        <div className="text-xs text-muted-foreground truncate line-clamp-1">
+        <div className="text-xs text-muted-foreground truncate line-clamp-1 pointer-events-none">
           <UserName
             pubkey={lastMessageAuthor}
             className="text-xs font-medium"


### PR DESCRIPTION
Add pointer-events-none to the message preview div in GroupListViewer
to ensure clicks always pass through to the parent group item's onClick
handler. This prevents issues where clicks on the preview text (UserName
or RichText components) might not trigger group selection.