### PR TITLE
feat: COUNT

### DIFF
--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -244,34 +244,36 @@ function RelayResultRow({ result }: { result: RelayCountResult }) {
 function SingleRelayResult({ result }: { result: RelayCountResult }) {
   if (result.status === "loading") {
     return (
-      <div className="flex flex-col items-center justify-center py-16 gap-4">
-        <Loader2 className="size-8 animate-spin text-muted-foreground" />
-        <p className="text-muted-foreground">Counting events...</p>
+      <div className="flex flex-col items-center justify-center py-6 gap-2">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">Counting events...</p>
       </div>
     );
   }
 
   if (result.status === "unsupported") {
     return (
-      <div className="flex flex-col items-center justify-center py-16 gap-4">
-        <Ban className="size-8 text-yellow-500" />
-        <p className="text-yellow-600 dark:text-yellow-400">{result.error}</p>
+      <div className="flex flex-col items-center justify-center py-6 gap-2">
+        <Ban className="size-5 text-yellow-500" />
+        <p className="text-sm text-yellow-600 dark:text-yellow-400">
+          {result.error}
+        </p>
       </div>
     );
   }
 
   if (result.status === "error") {
     return (
-      <div className="flex flex-col items-center justify-center py-16 gap-4">
-        <AlertCircle className="size-8 text-destructive" />
-        <p className="text-destructive">{result.error}</p>
+      <div className="flex flex-col items-center justify-center py-6 gap-2">
+        <AlertCircle className="size-5 text-destructive" />
+        <p className="text-sm text-destructive">{result.error}</p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-16">
-      <span className="font-mono text-5xl font-bold tabular-nums">
+    <div className="flex flex-col items-center justify-center py-6">
+      <span className="font-mono text-3xl font-bold tabular-nums">
         {result.count?.toLocaleString()}
       </span>
     </div>

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -375,7 +375,6 @@ export default function CountViewer({
           {/* Mentions */}
           {pTagPubkeys.length > 0 && (
             <div className="flex items-center gap-1">
-              <span className="text-muted-foreground">@</span>
               {pTagPubkeys.slice(0, 2).map((pubkey) => (
                 <UserName
                   key={pubkey}
@@ -425,44 +424,23 @@ export default function CountViewer({
             )}
         </div>
 
-        {/* Right: Controls */}
+        {/* Right: Controls - refresh, relays, filter */}
         <div className="flex items-center gap-3 shrink-0">
-          {/* Filter Dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors">
-                <FilterIcon className="size-3" />
+          {/* Refresh Button */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={refresh}
+                disabled={loading}
+                className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+              >
+                <RefreshCw
+                  className={`size-3 ${loading ? "animate-spin" : ""}`}
+                />
               </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-80 p-0">
-              <div className="p-3 space-y-3">
-                <FilterSummaryBadges filter={filter} />
-                <Collapsible>
-                  <CollapsibleTrigger className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full">
-                    <Code className="size-3" />
-                    Raw Query JSON
-                    <ChevronDown className="size-3 ml-auto" />
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="relative mt-2">
-                      <SyntaxHighlight
-                        code={JSON.stringify(filter, null, 2)}
-                        language="json"
-                        className="bg-muted/50 p-3 pr-10 overflow-x-auto border border-border/40 rounded text-[11px]"
-                      />
-                      <CodeCopyButton
-                        onCopy={() =>
-                          handleCopy(JSON.stringify(filter, null, 2))
-                        }
-                        copied={copied}
-                        label="Copy query JSON"
-                      />
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              </div>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            </TooltipTrigger>
+            <TooltipContent>Refresh counts</TooltipContent>
+          </Tooltip>
 
           {/* Relay Dropdown with status */}
           <DropdownMenu>
@@ -542,21 +520,42 @@ export default function CountViewer({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Refresh Button */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={refresh}
-                disabled={loading}
-                className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-              >
-                <RefreshCw
-                  className={`size-3 ${loading ? "animate-spin" : ""}`}
-                />
+          {/* Filter Dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors">
+                <FilterIcon className="size-3" />
               </button>
-            </TooltipTrigger>
-            <TooltipContent>Refresh counts</TooltipContent>
-          </Tooltip>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-80 p-0">
+              <div className="p-3 space-y-3">
+                <FilterSummaryBadges filter={filter} />
+                <Collapsible>
+                  <CollapsibleTrigger className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors w-full">
+                    <Code className="size-3" />
+                    Raw Query JSON
+                    <ChevronDown className="size-3 ml-auto" />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="relative mt-2">
+                      <SyntaxHighlight
+                        code={JSON.stringify(filter, null, 2)}
+                        language="json"
+                        className="bg-muted/50 p-3 pr-10 overflow-x-auto border border-border/40 rounded text-[11px]"
+                      />
+                      <CodeCopyButton
+                        onCopy={() =>
+                          handleCopy(JSON.stringify(filter, null, 2))
+                        }
+                        copied={copied}
+                        label="Copy query JSON"
+                      />
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -291,7 +291,7 @@ function SingleRelayResult({ result }: { result: RelayCountResult }) {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-16 gap-2">
+    <div className="flex flex-col items-center justify-center py-16">
       <div className="flex items-baseline gap-2">
         <span className="font-mono text-5xl font-bold tabular-nums">
           {result.count?.toLocaleString()}
@@ -305,7 +305,6 @@ function SingleRelayResult({ result }: { result: RelayCountResult }) {
           </Tooltip>
         )}
       </div>
-      <p className="text-sm text-muted-foreground">events</p>
     </div>
   );
 }

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -14,11 +14,8 @@ import {
 import { firstValueFrom, timeout, catchError, of } from "rxjs";
 import { useGrimoire } from "@/core/state";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { useOutboxRelays } from "@/hooks/useOutboxRelays";
 import pool from "@/services/relay-pool";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
 import { getRelayInfo } from "@/lib/nip11";
-import { normalizeRelayURL } from "@/lib/relay-url";
 import { RelayLink } from "./nostr/RelayLink";
 import { FilterSummaryBadges } from "./nostr/FilterSummaryBadges";
 import { KindBadge } from "./KindBadge";
@@ -43,7 +40,7 @@ import type { Filter } from "nostr-tools";
 
 interface CountViewerProps {
   filter: NostrFilter;
-  relays?: string[]; // Optional - uses outbox model if not specified
+  relays: string[]; // Required - at least one relay
   needsAccount?: boolean;
 }
 
@@ -283,16 +280,12 @@ function SingleRelayResult({ result }: { result: RelayCountResult }) {
 
 export default function CountViewer({
   filter: rawFilter,
-  relays: explicitRelays,
+  relays,
   needsAccount,
 }: CountViewerProps) {
   const { state } = useGrimoire();
   const accountPubkey = state.activeAccount?.pubkey;
   const { copy: handleCopy, copied } = useCopy();
-  const [nip45FilteredRelays, setNip45FilteredRelays] = useState<string[]>([]);
-  const [nip45FilterPhase, setNip45FilterPhase] = useState<
-    "idle" | "filtering" | "ready"
-  >("idle");
 
   // Create pointer for contact list (kind 3) if we need to resolve $contacts
   const contactPointer = useMemo(
@@ -324,84 +317,7 @@ export default function CountViewer({
     [needsAccount, rawFilter, accountPubkey, contacts],
   );
 
-  // Fallback relays for outbox selection (user's read relays or aggregators)
-  const fallbackRelays = useMemo(
-    () =>
-      state.activeAccount?.relays?.filter((r) => r.read).map((r) => r.url) ||
-      AGGREGATOR_RELAYS,
-    [state.activeAccount?.relays],
-  );
-
-  // Outbox options for relay selection
-  const outboxOptions = useMemo(
-    () => ({
-      fallbackRelays,
-      timeout: 1000,
-      maxRelays: 20, // Fewer relays for COUNT since it's one-shot
-    }),
-    [fallbackRelays],
-  );
-
-  // Use outbox model for relay selection when no explicit relays
-  const { relays: selectedRelays, phase: relaySelectionPhase } =
-    useOutboxRelays(explicitRelays ? {} : filter, outboxOptions);
-
-  // Filter relays by NIP-45 support
-  useEffect(() => {
-    // Skip if explicit relays provided or selection not ready
-    if (explicitRelays) {
-      setNip45FilteredRelays(explicitRelays);
-      setNip45FilterPhase("ready");
-      return;
-    }
-
-    if (relaySelectionPhase !== "ready" || selectedRelays.length === 0) {
-      setNip45FilterPhase("idle");
-      return;
-    }
-
-    // Filter by NIP-45 support
-    setNip45FilterPhase("filtering");
-
-    const filterByNip45 = async () => {
-      const results = await Promise.all(
-        selectedRelays.map(async (url) => {
-          const supported = await checkNip45Support(url);
-          // Include if supported or unknown (will error at request time)
-          return { url, include: supported !== false };
-        }),
-      );
-
-      const filtered = results
-        .filter((r) => r.include)
-        .map((r) => {
-          try {
-            return normalizeRelayURL(r.url);
-          } catch {
-            return r.url;
-          }
-        });
-
-      // Use fallback aggregators if no NIP-45 relays found
-      setNip45FilteredRelays(
-        filtered.length > 0 ? filtered : AGGREGATOR_RELAYS.slice(0, 3),
-      );
-      setNip45FilterPhase("ready");
-    };
-
-    filterByNip45();
-  }, [explicitRelays, selectedRelays, relaySelectionPhase]);
-
-  // Final relays to use
-  const relays = nip45FilteredRelays;
-  const isSelectingRelays =
-    !explicitRelays &&
-    (relaySelectionPhase !== "ready" || nip45FilterPhase !== "ready");
-
-  const { results, loading, refresh } = useCount(
-    filter,
-    isSelectingRelays ? [] : relays,
-  );
+  const { results, loading, refresh } = useCount(filter, relays);
 
   const isSingleRelay = relays.length === 1;
   const singleResult = isSingleRelay ? results.get(relays[0]) : null;
@@ -659,22 +575,8 @@ export default function CountViewer({
         </div>
       )}
 
-      {/* Selecting Relays */}
-      {(!needsAccount || accountPubkey) && isSelectingRelays && (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-muted-foreground text-center">
-            <Loader2 className="size-8 mx-auto mb-3 animate-spin" />
-            <p className="text-sm">
-              {nip45FilterPhase === "filtering"
-                ? "Filtering relays by NIP-45 support..."
-                : "Selecting relays..."}
-            </p>
-          </div>
-        </div>
-      )}
-
       {/* Results */}
-      {(!needsAccount || accountPubkey) && !isSelectingRelays && (
+      {(!needsAccount || accountPubkey) && (
         <div className="flex-1 overflow-auto">
           {isSingleRelay && singleResult ? (
             <SingleRelayResult result={singleResult} />

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -1,19 +1,33 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import {
   Loader2,
   AlertCircle,
   CheckCircle2,
   RefreshCw,
   User,
+  Radio,
+  ChevronDown,
+  Filter as FilterIcon,
 } from "lucide-react";
 import { useGrimoire } from "@/core/state";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
+import pool from "@/services/relay-pool";
 import { RelayLink } from "./nostr/RelayLink";
 import { FilterSummaryBadges } from "./nostr/FilterSummaryBadges";
+import { KindBadge } from "./KindBadge";
+import { UserName } from "./nostr/UserName";
 import { Button } from "./ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import type { NostrFilter } from "@/types/nostr";
 import { resolveFilterAliases, getTagValues } from "@/lib/nostr-utils";
+import { formatTimeRange } from "@/lib/filter-formatters";
+import type { Subscription } from "rxjs";
+import type { Filter } from "nostr-tools";
 
 interface CountViewerProps {
   filter: NostrFilter;
@@ -32,168 +46,260 @@ interface RelayCountResult {
 }
 
 /**
- * Send a COUNT request to a relay and get the result
- */
-async function sendCountRequest(
-  relayUrl: string,
-  filter: NostrFilter,
-): Promise<RelayCountResult> {
-  const queryId = `count-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-  return new Promise((resolve) => {
-    let ws: WebSocket | null = null;
-    let resolved = false;
-
-    const cleanup = () => {
-      if (ws) {
-        ws.close();
-        ws = null;
-      }
-    };
-
-    // Timeout after 10 seconds
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        cleanup();
-        resolve({
-          url: relayUrl,
-          status: "error",
-          error: "Timeout - relay did not respond",
-        });
-      }
-    }, 10000);
-
-    try {
-      ws = new WebSocket(relayUrl);
-
-      ws.onopen = () => {
-        const countMsg = JSON.stringify(["COUNT", queryId, filter]);
-        ws?.send(countMsg);
-      };
-
-      ws.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          const [type, id, payload] = data;
-
-          if (id !== queryId) return;
-
-          if (type === "COUNT") {
-            resolved = true;
-            clearTimeout(timeout);
-            cleanup();
-            resolve({
-              url: relayUrl,
-              status: "success",
-              count: payload.count,
-              approximate: payload.approximate,
-            });
-          } else if (type === "CLOSED") {
-            resolved = true;
-            clearTimeout(timeout);
-            cleanup();
-            resolve({
-              url: relayUrl,
-              status: "error",
-              error: payload || "Request closed by relay",
-            });
-          } else if (type === "NOTICE") {
-            if (
-              payload?.toLowerCase().includes("count") ||
-              payload?.toLowerCase().includes("unknown") ||
-              payload?.toLowerCase().includes("unsupported")
-            ) {
-              resolved = true;
-              clearTimeout(timeout);
-              cleanup();
-              resolve({
-                url: relayUrl,
-                status: "unsupported",
-                error: "Relay does not support COUNT (NIP-45)",
-              });
-            }
-          }
-        } catch {
-          // Ignore parse errors
-        }
-      };
-
-      ws.onerror = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          cleanup();
-          resolve({
-            url: relayUrl,
-            status: "error",
-            error: "Connection error",
-          });
-        }
-      };
-
-      ws.onclose = () => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          cleanup();
-          resolve({
-            url: relayUrl,
-            status: "error",
-            error: "Connection closed unexpectedly",
-          });
-        }
-      };
-    } catch (error) {
-      resolved = true;
-      clearTimeout(timeout);
-      cleanup();
-      resolve({
-        url: relayUrl,
-        status: "error",
-        error: error instanceof Error ? error.message : "Unknown error",
-      });
-    }
-  });
-}
-
-/**
- * Hook to perform COUNT requests to multiple relays
+ * Hook to perform COUNT requests using the relay pool
  */
 function useCount(filter: NostrFilter, relays: string[]) {
   const [results, setResults] = useState<Map<string, RelayCountResult>>(
     new Map(),
   );
   const [loading, setLoading] = useState(false);
+  const subscriptionRef = useRef<Subscription | null>(null);
 
-  const executeCount = useCallback(async () => {
+  const executeCount = useCallback(() => {
+    // Clean up any previous subscription
+    if (subscriptionRef.current) {
+      subscriptionRef.current.unsubscribe();
+      subscriptionRef.current = null;
+    }
+
     setLoading(true);
 
+    // Initialize all relays as loading
     const initialResults = new Map<string, RelayCountResult>();
     for (const url of relays) {
       initialResults.set(url, { url, status: "loading" });
     }
     setResults(initialResults);
 
-    const promises = relays.map(async (url) => {
-      const result = await sendCountRequest(url, filter);
-      setResults((prev) => {
-        const next = new Map(prev);
-        next.set(url, result);
-        return next;
-      });
-      return result;
+    // Use pool.count() which returns Observable<Record<string, CountResponse>>
+    // This handles connection management, retries, and timeouts automatically
+    // Cast filter to nostr-tools Filter type for compatibility
+    subscriptionRef.current = pool.count(relays, filter as Filter).subscribe({
+      next: (countResults) => {
+        // countResults is Record<string, { count: number }>
+        setResults((prev) => {
+          const next = new Map(prev);
+          for (const [url, response] of Object.entries(countResults)) {
+            next.set(url, {
+              url,
+              status: "success",
+              count: response.count,
+            });
+          }
+          return next;
+        });
+      },
+      error: (error) => {
+        // Handle error for relays that failed
+        setResults((prev) => {
+          const next = new Map(prev);
+          // Mark all still-loading relays as errored
+          for (const [url, result] of next) {
+            if (result.status === "loading") {
+              next.set(url, {
+                url,
+                status: "error",
+                error: error?.message || "Request failed",
+              });
+            }
+          }
+          return next;
+        });
+        setLoading(false);
+      },
+      complete: () => {
+        // Mark any relays that didn't respond as unsupported/error
+        setResults((prev) => {
+          const next = new Map(prev);
+          for (const [url, result] of next) {
+            if (result.status === "loading") {
+              next.set(url, {
+                url,
+                status: "unsupported",
+                error: "Relay did not respond - may not support NIP-45",
+              });
+            }
+          }
+          return next;
+        });
+        setLoading(false);
+      },
     });
-
-    await Promise.all(promises);
-    setLoading(false);
   }, [filter, relays]);
 
   useEffect(() => {
     executeCount();
+
+    return () => {
+      if (subscriptionRef.current) {
+        subscriptionRef.current.unsubscribe();
+      }
+    };
   }, [executeCount]);
 
   return { results, loading, refresh: executeCount };
+}
+
+interface QueryHeaderProps {
+  filter: NostrFilter;
+  relays: string[];
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+function QueryHeader({ filter, relays, loading, onRefresh }: QueryHeaderProps) {
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [relaysOpen, setRelaysOpen] = useState(false);
+
+  const authorPubkeys = filter.authors || [];
+  const pTagPubkeys = filter["#p"] || [];
+  const tTags = filter["#t"] || [];
+
+  return (
+    <div className="border-b border-border px-4 py-3 bg-muted/30 space-y-2">
+      {/* Summary line */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {/* Human-readable kinds */}
+        {filter.kinds && filter.kinds.length > 0 && (
+          <div className="flex items-center gap-1">
+            {filter.kinds.slice(0, 3).map((kind) => (
+              <KindBadge
+                key={kind}
+                kind={kind}
+                iconClassname="size-3"
+                className="text-xs"
+              />
+            ))}
+            {filter.kinds.length > 3 && (
+              <span className="text-xs text-muted-foreground">
+                +{filter.kinds.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Authors */}
+        {authorPubkeys.length > 0 && (
+          <div className="flex items-center gap-1 text-xs">
+            <span className="text-muted-foreground">by</span>
+            {authorPubkeys.slice(0, 2).map((pubkey) => (
+              <UserName key={pubkey} pubkey={pubkey} className="text-xs" />
+            ))}
+            {authorPubkeys.length > 2 && (
+              <span className="text-muted-foreground">
+                +{authorPubkeys.length - 2}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Mentions */}
+        {pTagPubkeys.length > 0 && (
+          <div className="flex items-center gap-1 text-xs">
+            <span className="text-muted-foreground">mentioning</span>
+            {pTagPubkeys.slice(0, 2).map((pubkey) => (
+              <UserName
+                key={pubkey}
+                pubkey={pubkey}
+                isMention
+                className="text-xs"
+              />
+            ))}
+            {pTagPubkeys.length > 2 && (
+              <span className="text-muted-foreground">
+                +{pTagPubkeys.length - 2}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Hashtags */}
+        {tTags.length > 0 && (
+          <div className="flex items-center gap-1">
+            {tTags.slice(0, 3).map((tag) => (
+              <span
+                key={tag}
+                className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded"
+              >
+                #{tag}
+              </span>
+            ))}
+            {tTags.length > 3 && (
+              <span className="text-xs text-muted-foreground">
+                +{tTags.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Time range */}
+        {(filter.since || filter.until) && (
+          <span className="text-xs text-muted-foreground">
+            {formatTimeRange(filter.since, filter.until)}
+          </span>
+        )}
+
+        {/* Search */}
+        {filter.search && (
+          <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+            "{filter.search}"
+          </code>
+        )}
+
+        {/* Refresh button */}
+        <div className="ml-auto">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRefresh}
+            disabled={loading}
+            className="h-7 px-2"
+          >
+            <RefreshCw
+              className={`size-3.5 ${loading ? "animate-spin" : ""}`}
+            />
+          </Button>
+        </div>
+      </div>
+
+      {/* Collapsible sections */}
+      <div className="flex gap-4 text-xs">
+        {/* Filter dropdown */}
+        <Collapsible open={filterOpen} onOpenChange={setFilterOpen}>
+          <CollapsibleTrigger className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors">
+            <FilterIcon className="size-3" />
+            <span>Filter</span>
+            <ChevronDown
+              className={`size-3 transition-transform ${filterOpen ? "rotate-180" : ""}`}
+            />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-2">
+            <FilterSummaryBadges filter={filter} />
+          </CollapsibleContent>
+        </Collapsible>
+
+        {/* Relays dropdown */}
+        <Collapsible open={relaysOpen} onOpenChange={setRelaysOpen}>
+          <CollapsibleTrigger className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors">
+            <Radio className="size-3" />
+            <span>
+              {relays.length} relay{relays.length !== 1 ? "s" : ""}
+            </span>
+            <ChevronDown
+              className={`size-3 transition-transform ${relaysOpen ? "rotate-180" : ""}`}
+            />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="pt-2">
+            <div className="flex flex-wrap gap-2">
+              {relays.map((url) => (
+                <RelayLink key={url} url={url} className="text-xs" />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  );
 }
 
 function RelayResultRow({ result }: { result: RelayCountResult }) {
@@ -354,31 +460,13 @@ export default function CountViewer({
 
   return (
     <div className="h-full flex flex-col">
-      {/* Compact Header */}
-      <div className="border-b border-border px-3 py-2 bg-muted/30 flex items-center gap-3 flex-wrap">
-        {isSingleRelay ? (
-          <RelayLink url={relays[0]} className="text-sm" />
-        ) : (
-          <span className="text-sm text-muted-foreground">
-            {relays.length} relays
-          </span>
-        )}
-        <span className="text-muted-foreground">·</span>
-        <FilterSummaryBadges filter={filter} />
-        <div className="ml-auto">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={refresh}
-            disabled={loading}
-            className="h-7 px-2"
-          >
-            <RefreshCw
-              className={`size-3.5 ${loading ? "animate-spin" : ""}`}
-            />
-          </Button>
-        </div>
-      </div>
+      {/* Header */}
+      <QueryHeader
+        filter={filter}
+        relays={relays}
+        loading={loading}
+        onRefresh={refresh}
+      />
 
       {/* Account Required Message */}
       {needsAccount && !accountPubkey && (

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -53,7 +53,7 @@ interface RelayCountResult {
   error?: string;
 }
 
-const COUNT_TIMEOUT = 10000; // 10 second timeout per relay
+const COUNT_TIMEOUT = 30000; // 30 second timeout per relay
 
 /**
  * Check if relay supports NIP-45 via NIP-11 relay info

--- a/src/components/CountViewer.tsx
+++ b/src/components/CountViewer.tsx
@@ -1,0 +1,573 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  Loader2,
+  AlertCircle,
+  CheckCircle2,
+  RefreshCw,
+  Filter as FilterIcon,
+  Hash,
+  User,
+  Clock,
+  Search,
+  FileText,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { useGrimoire } from "@/core/state";
+import { RelayLink } from "./nostr/RelayLink";
+import { UserName } from "./nostr/UserName";
+import { KindBadge } from "./KindBadge";
+import { Button } from "./ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import type { NostrFilter } from "@/types/nostr";
+import { resolveFilterAliases } from "@/lib/nostr-utils";
+import {
+  formatTimeRange,
+  formatHashtags,
+  formatGenericTag,
+} from "@/lib/filter-formatters";
+
+interface CountViewerProps {
+  filter: NostrFilter;
+  relays: string[];
+  needsAccount?: boolean;
+}
+
+type CountStatus = "pending" | "loading" | "success" | "error" | "unsupported";
+
+interface RelayCountResult {
+  url: string;
+  status: CountStatus;
+  count?: number;
+  approximate?: boolean;
+  error?: string;
+}
+
+/**
+ * Send a COUNT request to a relay and get the result
+ */
+async function sendCountRequest(
+  relayUrl: string,
+  filter: NostrFilter,
+): Promise<RelayCountResult> {
+  const queryId = `count-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return new Promise((resolve) => {
+    let ws: WebSocket | null = null;
+    let resolved = false;
+
+    const cleanup = () => {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    };
+
+    // Timeout after 10 seconds
+    const timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        cleanup();
+        resolve({
+          url: relayUrl,
+          status: "error",
+          error: "Timeout - relay did not respond",
+        });
+      }
+    }, 10000);
+
+    try {
+      // Convert wss:// to ws:// if needed for WebSocket constructor
+      ws = new WebSocket(relayUrl);
+
+      ws.onopen = () => {
+        // Send COUNT request
+        const countMsg = JSON.stringify(["COUNT", queryId, filter]);
+        ws?.send(countMsg);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const [type, id, payload] = data;
+
+          if (id !== queryId) return;
+
+          if (type === "COUNT") {
+            resolved = true;
+            clearTimeout(timeout);
+            cleanup();
+            resolve({
+              url: relayUrl,
+              status: "success",
+              count: payload.count,
+              approximate: payload.approximate,
+            });
+          } else if (type === "CLOSED") {
+            resolved = true;
+            clearTimeout(timeout);
+            cleanup();
+            // payload is the reason string for CLOSED
+            resolve({
+              url: relayUrl,
+              status: "error",
+              error: payload || "Request closed by relay",
+            });
+          } else if (type === "NOTICE") {
+            // Some relays send NOTICE for unsupported commands
+            if (
+              payload?.toLowerCase().includes("count") ||
+              payload?.toLowerCase().includes("unknown") ||
+              payload?.toLowerCase().includes("unsupported")
+            ) {
+              resolved = true;
+              clearTimeout(timeout);
+              cleanup();
+              resolve({
+                url: relayUrl,
+                status: "unsupported",
+                error: "Relay does not support COUNT (NIP-45)",
+              });
+            }
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      };
+
+      ws.onerror = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          cleanup();
+          resolve({
+            url: relayUrl,
+            status: "error",
+            error: "Connection error",
+          });
+        }
+      };
+
+      ws.onclose = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          cleanup();
+          resolve({
+            url: relayUrl,
+            status: "error",
+            error: "Connection closed unexpectedly",
+          });
+        }
+      };
+    } catch (error) {
+      resolved = true;
+      clearTimeout(timeout);
+      cleanup();
+      resolve({
+        url: relayUrl,
+        status: "error",
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  });
+}
+
+/**
+ * Hook to perform COUNT requests to multiple relays
+ */
+function useCount(filter: NostrFilter, relays: string[]) {
+  const [results, setResults] = useState<Map<string, RelayCountResult>>(
+    new Map(),
+  );
+  const [loading, setLoading] = useState(false);
+
+  const executeCount = useCallback(async () => {
+    setLoading(true);
+
+    // Initialize all relays as pending
+    const initialResults = new Map<string, RelayCountResult>();
+    for (const url of relays) {
+      initialResults.set(url, { url, status: "loading" });
+    }
+    setResults(initialResults);
+
+    // Send COUNT requests in parallel
+    const promises = relays.map(async (url) => {
+      const result = await sendCountRequest(url, filter);
+      setResults((prev) => {
+        const next = new Map(prev);
+        next.set(url, result);
+        return next;
+      });
+      return result;
+    });
+
+    await Promise.all(promises);
+    setLoading(false);
+  }, [filter, relays]);
+
+  // Execute on mount
+  useEffect(() => {
+    executeCount();
+  }, [executeCount]);
+
+  return { results, loading, refresh: executeCount };
+}
+
+function FilterSummary({ filter }: { filter: NostrFilter }) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const authorPubkeys = filter.authors || [];
+  const pTagPubkeys = filter["#p"] || [];
+  const tTags = filter["#t"];
+  const dTags = filter["#d"];
+
+  // Find generic tags
+  const genericTags = Object.entries(filter)
+    .filter(
+      ([key]) =>
+        key.startsWith("#") &&
+        key.length === 2 &&
+        !["#e", "#p", "#t", "#d", "#P"].includes(key),
+    )
+    .map(([key, values]) => ({ letter: key[1], values: values as string[] }));
+
+  const tagCount =
+    (filter["#e"]?.length || 0) +
+    (tTags?.length || 0) +
+    (dTags?.length || 0) +
+    genericTags.reduce((sum, tag) => sum + tag.values.length, 0);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger className="flex items-center gap-2 w-full text-left py-2 hover:bg-muted/50 rounded px-2 -mx-2">
+        {isOpen ? (
+          <ChevronDown className="size-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-4 text-muted-foreground" />
+        )}
+        <FilterIcon className="size-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Filter</span>
+
+        {/* Summary badges */}
+        <div className="flex items-center gap-3 ml-auto text-xs text-muted-foreground">
+          {filter.kinds && filter.kinds.length > 0 && (
+            <span className="flex items-center gap-1">
+              <FileText className="size-3" />
+              {filter.kinds.length}
+            </span>
+          )}
+          {authorPubkeys.length > 0 && (
+            <span className="flex items-center gap-1">
+              <User className="size-3" />
+              {authorPubkeys.length}
+            </span>
+          )}
+          {pTagPubkeys.length > 0 && (
+            <span className="flex items-center gap-1">
+              <User className="size-3" />@{pTagPubkeys.length}
+            </span>
+          )}
+          {(filter.since || filter.until) && <Clock className="size-3" />}
+          {filter.search && <Search className="size-3" />}
+          {tagCount > 0 && (
+            <span className="flex items-center gap-1">
+              <Hash className="size-3" />
+              {tagCount}
+            </span>
+          )}
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="pl-6 pr-2 py-2 space-y-2 text-sm">
+          {/* Kinds */}
+          {filter.kinds && filter.kinds.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground w-16">kinds:</span>
+              <div className="flex flex-wrap gap-1">
+                {filter.kinds.map((kind) => (
+                  <KindBadge key={kind} kind={kind} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Authors */}
+          {authorPubkeys.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground w-16">authors:</span>
+              <div className="flex flex-wrap gap-1">
+                {authorPubkeys.slice(0, 5).map((pubkey) => (
+                  <span
+                    key={pubkey}
+                    className="bg-muted px-2 py-0.5 rounded text-xs"
+                  >
+                    <UserName pubkey={pubkey} />
+                  </span>
+                ))}
+                {authorPubkeys.length > 5 && (
+                  <span className="text-muted-foreground text-xs">
+                    +{authorPubkeys.length - 5} more
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* #p tags (mentions) */}
+          {pTagPubkeys.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground w-16">#p:</span>
+              <div className="flex flex-wrap gap-1">
+                {pTagPubkeys.slice(0, 5).map((pubkey) => (
+                  <span
+                    key={pubkey}
+                    className="bg-muted px-2 py-0.5 rounded text-xs"
+                  >
+                    <UserName pubkey={pubkey} />
+                  </span>
+                ))}
+                {pTagPubkeys.length > 5 && (
+                  <span className="text-muted-foreground text-xs">
+                    +{pTagPubkeys.length - 5} more
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Time range */}
+          {(filter.since || filter.until) && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground w-16">time:</span>
+              <span className="text-xs">
+                {formatTimeRange(filter.since, filter.until)}
+              </span>
+            </div>
+          )}
+
+          {/* Search */}
+          {filter.search && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground w-16">search:</span>
+              <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded">
+                {filter.search}
+              </span>
+            </div>
+          )}
+
+          {/* Hashtags */}
+          {tTags && tTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground w-16">#t:</span>
+              <span className="text-xs">{formatHashtags(tTags)}</span>
+            </div>
+          )}
+
+          {/* Generic tags */}
+          {genericTags.map(({ letter, values }) => (
+            <div key={letter} className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground w-16">#{letter}:</span>
+              <span className="text-xs font-mono">
+                {formatGenericTag(letter, values)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function RelayResultRow({ result }: { result: RelayCountResult }) {
+  const statusIcon = useMemo(() => {
+    switch (result.status) {
+      case "loading":
+        return (
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        );
+      case "success":
+        return <CheckCircle2 className="size-4 text-green-500" />;
+      case "error":
+        return <AlertCircle className="size-4 text-destructive" />;
+      case "unsupported":
+        return <AlertCircle className="size-4 text-yellow-500" />;
+      default:
+        return null;
+    }
+  }, [result.status]);
+
+  return (
+    <div className="flex items-center justify-between py-2 px-3 hover:bg-muted/30 rounded">
+      <div className="flex items-center gap-2">
+        {statusIcon}
+        <RelayLink url={result.url} />
+      </div>
+
+      <div className="flex items-center gap-2">
+        {result.status === "success" && (
+          <>
+            <span className="font-mono text-lg font-semibold tabular-nums">
+              {result.count?.toLocaleString()}
+            </span>
+            {result.approximate && (
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="text-muted-foreground text-sm">~</span>
+                </TooltipTrigger>
+                <TooltipContent>Approximate count</TooltipContent>
+              </Tooltip>
+            )}
+          </>
+        )}
+        {result.status === "error" && (
+          <Tooltip>
+            <TooltipTrigger>
+              <span className="text-sm text-destructive truncate max-w-48">
+                {result.error}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{result.error}</TooltipContent>
+          </Tooltip>
+        )}
+        {result.status === "unsupported" && (
+          <span className="text-sm text-yellow-600 dark:text-yellow-400">
+            NIP-45 not supported
+          </span>
+        )}
+        {result.status === "loading" && (
+          <span className="text-sm text-muted-foreground">counting...</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SingleRelayResult({ result }: { result: RelayCountResult }) {
+  if (result.status === "loading") {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <Loader2 className="size-8 animate-spin text-muted-foreground" />
+        <p className="text-muted-foreground">Counting events...</p>
+      </div>
+    );
+  }
+
+  if (result.status === "error") {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <AlertCircle className="size-8 text-destructive" />
+        <p className="text-destructive">{result.error}</p>
+      </div>
+    );
+  }
+
+  if (result.status === "unsupported") {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 gap-4">
+        <AlertCircle className="size-8 text-yellow-500" />
+        <p className="text-yellow-600 dark:text-yellow-400">
+          This relay does not support COUNT (NIP-45)
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 gap-2">
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-5xl font-bold tabular-nums">
+          {result.count?.toLocaleString()}
+        </span>
+        {result.approximate && (
+          <Tooltip>
+            <TooltipTrigger>
+              <span className="text-2xl text-muted-foreground">~</span>
+            </TooltipTrigger>
+            <TooltipContent>Approximate count</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground">events</p>
+    </div>
+  );
+}
+
+export default function CountViewer({
+  filter: rawFilter,
+  relays,
+  needsAccount,
+}: CountViewerProps) {
+  const { state } = useGrimoire();
+
+  // Resolve $me and $contacts aliases
+  const filter = useMemo(() => {
+    if (!needsAccount) return rawFilter;
+
+    const pubkey = state.activeAccount?.pubkey;
+    // For COUNT, we don't have contacts loaded, so just resolve $me
+    // $contacts would need to be resolved at parse time
+    return resolveFilterAliases(rawFilter, pubkey, []);
+  }, [rawFilter, needsAccount, state.activeAccount?.pubkey]);
+
+  const { results, loading, refresh } = useCount(filter, relays);
+
+  const isSingleRelay = relays.length === 1;
+  const singleResult = isSingleRelay ? results.get(relays[0]) : null;
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="border-b border-border px-4 py-3 bg-muted/30">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            {isSingleRelay ? (
+              <RelayLink url={relays[0]} />
+            ) : (
+              <span className="text-sm text-muted-foreground">
+                {relays.length} relays
+              </span>
+            )}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={refresh}
+            disabled={loading}
+            className="h-8"
+          >
+            <RefreshCw
+              className={`size-4 mr-1 ${loading ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </Button>
+        </div>
+        <FilterSummary filter={filter} />
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-auto">
+        {isSingleRelay && singleResult ? (
+          <SingleRelayResult result={singleResult} />
+        ) : (
+          <div className="divide-y divide-border">
+            {relays.map((url) => {
+              const result = results.get(url) || {
+                url,
+                status: "pending" as const,
+              };
+              return <RelayResultRow key={url} result={result} />;
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -238,6 +238,28 @@ function generateRawCommand(appId: string, props: any): string {
       }
       return "req";
 
+    case "count":
+      // COUNT command - similar to REQ but for counting
+      if (props.filter) {
+        const parts: string[] = ["count"];
+        if (props.filter.kinds?.length) {
+          parts.push(`-k ${props.filter.kinds.join(",")}`);
+        }
+        if (props.filter["#t"]?.length) {
+          parts.push(`-t ${props.filter["#t"].slice(0, 2).join(",")}`);
+        }
+        if (props.filter.authors?.length) {
+          const authorDisplay = props.filter.authors.slice(0, 2).join(",");
+          parts.push(`-a ${authorDisplay}`);
+        }
+        if (props.filter["#p"]?.length) {
+          const pTagDisplay = props.filter["#p"].slice(0, 2).join(",");
+          parts.push(`-p ${pTagDisplay}`);
+        }
+        return parts.join(" ");
+      }
+      return "count";
+
     case "man":
       return props.cmd ? `man ${props.cmd}` : "man";
 

--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -239,24 +239,61 @@ function generateRawCommand(appId: string, props: any): string {
       return "req";
 
     case "count":
-      // COUNT command - similar to REQ but for counting
+      // COUNT command - human-readable summary
       if (props.filter) {
-        const parts: string[] = ["count"];
+        const parts: string[] = [];
+
+        // Kinds - use human-readable names
         if (props.filter.kinds?.length) {
-          parts.push(`-k ${props.filter.kinds.join(",")}`);
+          if (props.filter.kinds.length === 1) {
+            parts.push(getKindName(props.filter.kinds[0]));
+          } else if (props.filter.kinds.length <= 3) {
+            parts.push(props.filter.kinds.map(getKindName).join(", "));
+          } else {
+            parts.push(`${props.filter.kinds.length} kinds`);
+          }
         }
-        if (props.filter["#t"]?.length) {
-          parts.push(`-t ${props.filter["#t"].slice(0, 2).join(",")}`);
-        }
+
+        // Authors
         if (props.filter.authors?.length) {
-          const authorDisplay = props.filter.authors.slice(0, 2).join(",");
-          parts.push(`-a ${authorDisplay}`);
+          const count = props.filter.authors.length;
+          if (count === 1) {
+            const pk = props.filter.authors[0];
+            parts.push(`by ${pk.slice(0, 8)}...`);
+          } else {
+            parts.push(`by ${count} authors`);
+          }
         }
+
+        // Mentions (#p tags)
         if (props.filter["#p"]?.length) {
-          const pTagDisplay = props.filter["#p"].slice(0, 2).join(",");
-          parts.push(`-p ${pTagDisplay}`);
+          const count = props.filter["#p"].length;
+          if (count === 1) {
+            const pk = props.filter["#p"][0];
+            parts.push(`@${pk.slice(0, 8)}...`);
+          } else {
+            parts.push(`@${count} users`);
+          }
         }
-        return parts.join(" ");
+
+        // Hashtags
+        if (props.filter["#t"]?.length) {
+          const tags = props.filter["#t"];
+          if (tags.length <= 2) {
+            parts.push(tags.map((t: string) => `#${t}`).join(" "));
+          } else {
+            parts.push(`#${tags[0]} +${tags.length - 1}`);
+          }
+        }
+
+        // Search
+        if (props.filter.search) {
+          parts.push(`"${props.filter.search}"`);
+        }
+
+        if (parts.length > 0) {
+          return `count: ${parts.join(" ")}`;
+        }
       }
       return "count";
 

--- a/src/components/ReqViewer.tsx
+++ b/src/components/ReqViewer.tsx
@@ -79,6 +79,7 @@ import {
   shouldAnimate,
 } from "@/lib/req-state-machine";
 import { resolveFilterAliases, getTagValues } from "@/lib/nostr-utils";
+import { FilterSummaryBadges } from "./nostr/FilterSummaryBadges";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { MemoizedCompactEventRow } from "./nostr/CompactEventRow";
 import type { ViewMode } from "@/lib/req-parser";
@@ -141,8 +142,6 @@ function QueryDropdown({ filter, nip05Authors }: QueryDropdownProps) {
     (dTags?.length || 0) +
     genericTags.reduce((sum, tag) => sum + tag.values.length, 0);
 
-  const mentionCount = pTagPubkeys.length;
-
   // Determine if we should use accordion for complex queries
   const isComplexQuery =
     (filter.kinds?.length || 0) +
@@ -154,45 +153,7 @@ function QueryDropdown({ filter, nip05Authors }: QueryDropdownProps) {
   return (
     <div className="border-b border-border px-4 py-3 bg-muted/30 space-y-3">
       {/* Summary Header */}
-      <div className="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">
-        {filter.kinds && filter.kinds.length > 0 && (
-          <span className="flex items-center gap-1.5">
-            <FileText className="size-3.5" />
-            {filter.kinds.length} kind{filter.kinds.length !== 1 ? "s" : ""}
-          </span>
-        )}
-        {authorPubkeys.length > 0 && (
-          <span className="flex items-center gap-1.5">
-            <User className="size-3.5" />
-            {authorPubkeys.length} author
-            {authorPubkeys.length !== 1 ? "s" : ""}
-          </span>
-        )}
-        {mentionCount > 0 && (
-          <span className="flex items-center gap-1.5">
-            <User className="size-3.5" />
-            {mentionCount} mention{mentionCount !== 1 ? "s" : ""}
-          </span>
-        )}
-        {(filter.since || filter.until) && (
-          <span className="flex items-center gap-1.5">
-            <Clock className="size-3.5" />
-            time range
-          </span>
-        )}
-        {filter.search && (
-          <span className="flex items-center gap-1.5">
-            <Search className="size-3.5" />
-            search
-          </span>
-        )}
-        {tagCount > 0 && (
-          <span className="flex items-center gap-1.5">
-            <Hash className="size-3.5" />
-            {tagCount} tag{tagCount !== 1 ? "s" : ""}
-          </span>
-        )}
-      </div>
+      <FilterSummaryBadges filter={filter} />
 
       {isComplexQuery ? (
         /* Accordion for complex queries */

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -42,6 +42,7 @@ const SpellbooksViewer = lazy(() =>
 const BlossomViewer = lazy(() =>
   import("./BlossomViewer").then((m) => ({ default: m.BlossomViewer })),
 );
+const CountViewer = lazy(() => import("./CountViewer"));
 
 // Loading fallback component
 function ViewerLoading() {
@@ -153,6 +154,15 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
             view={window.props.view}
             nip05Authors={window.props.nip05Authors}
             nip05PTags={window.props.nip05PTags}
+            needsAccount={window.props.needsAccount}
+          />
+        );
+        break;
+      case "count":
+        content = (
+          <CountViewer
+            filter={window.props.filter}
+            relays={window.props.relays}
             needsAccount={window.props.needsAccount}
           />
         );

--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -83,9 +83,9 @@ export function WindowToolbar({
   const handleTurnIntoSpell = () => {
     if (!window) return;
 
-    // Only available for REQ windows
-    if (window.appId !== "req") {
-      toast.error("Only REQ windows can be turned into spells");
+    // Only available for REQ and COUNT windows
+    if (window.appId !== "req" && window.appId !== "count") {
+      toast.error("Only REQ and COUNT windows can be turned into spells");
       return;
     }
 
@@ -123,12 +123,14 @@ export function WindowToolbar({
     toast.success("NIP markdown copied to clipboard");
   };
 
-  // Check if this is a REQ window for spell creation
+  // Check if this is a REQ or COUNT window for spell creation
   const isReqWindow = window?.appId === "req";
+  const isCountWindow = window?.appId === "count";
+  const isSpellableWindow = isReqWindow || isCountWindow;
 
-  // Get REQ command for spell dialog
-  const reqCommand =
-    isReqWindow && window
+  // Get command for spell dialog
+  const spellCommand =
+    isSpellableWindow && window
       ? window.commandString ||
         reconstructReqCommand(
           window.props?.filter || {},
@@ -136,6 +138,7 @@ export function WindowToolbar({
           undefined,
           undefined,
           window.props?.closeOnEose,
+          isCountWindow ? "COUNT" : "REQ",
         )
       : "";
 
@@ -216,8 +219,8 @@ export function WindowToolbar({
                 </>
               )}
 
-              {/* REQ-specific actions */}
-              {isReqWindow && (
+              {/* REQ/COUNT-specific actions */}
+              {isSpellableWindow && (
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleTurnIntoSpell}>
@@ -230,12 +233,12 @@ export function WindowToolbar({
           </DropdownMenu>
 
           {/* Spell Dialog */}
-          {isReqWindow && (
+          {isSpellableWindow && (
             <SpellDialog
               open={showSpellDialog}
               onOpenChange={setShowSpellDialog}
               mode="create"
-              initialCommand={reqCommand}
+              initialCommand={spellCommand}
               onSuccess={() => {
                 toast.success("Spell published successfully!");
               }}

--- a/src/components/nostr/FilterSummaryBadges.tsx
+++ b/src/components/nostr/FilterSummaryBadges.tsx
@@ -1,0 +1,77 @@
+import { FileText, User, Clock, Search, Hash } from "lucide-react";
+import type { NostrFilter } from "@/types/nostr";
+
+interface FilterSummaryBadgesProps {
+  filter: NostrFilter;
+  className?: string;
+}
+
+/**
+ * Compact filter summary badges showing icons and counts
+ * Used by ReqViewer and CountViewer headers
+ */
+export function FilterSummaryBadges({
+  filter,
+  className = "",
+}: FilterSummaryBadgesProps) {
+  const authorPubkeys = filter.authors || [];
+  const pTagPubkeys = filter["#p"] || [];
+
+  // Calculate tag count (excluding #p which is shown separately)
+  const tagCount =
+    (filter["#e"]?.length || 0) +
+    (filter["#t"]?.length || 0) +
+    (filter["#d"]?.length || 0) +
+    Object.entries(filter)
+      .filter(
+        ([key]) =>
+          key.startsWith("#") &&
+          key.length === 2 &&
+          !["#e", "#p", "#t", "#d", "#P"].includes(key),
+      )
+      .reduce((sum, [, values]) => sum + (values as string[]).length, 0);
+
+  return (
+    <div
+      className={`flex items-center gap-4 text-xs text-muted-foreground flex-wrap ${className}`}
+    >
+      {filter.kinds && filter.kinds.length > 0 && (
+        <span className="flex items-center gap-1.5">
+          <FileText className="size-3.5" />
+          {filter.kinds.length} kind{filter.kinds.length !== 1 ? "s" : ""}
+        </span>
+      )}
+      {authorPubkeys.length > 0 && (
+        <span className="flex items-center gap-1.5">
+          <User className="size-3.5" />
+          {authorPubkeys.length} author
+          {authorPubkeys.length !== 1 ? "s" : ""}
+        </span>
+      )}
+      {pTagPubkeys.length > 0 && (
+        <span className="flex items-center gap-1.5">
+          <User className="size-3.5" />
+          {pTagPubkeys.length} mention{pTagPubkeys.length !== 1 ? "s" : ""}
+        </span>
+      )}
+      {(filter.since || filter.until) && (
+        <span className="flex items-center gap-1.5">
+          <Clock className="size-3.5" />
+          time range
+        </span>
+      )}
+      {filter.search && (
+        <span className="flex items-center gap-1.5">
+          <Search className="size-3.5" />
+          search
+        </span>
+      )}
+      {tagCount > 0 && (
+        <span className="flex items-center gap-1.5">
+          <Hash className="size-3.5" />
+          {tagCount} tag{tagCount !== 1 ? "s" : ""}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/constants/command-icons.ts
+++ b/src/constants/command-icons.ts
@@ -15,6 +15,7 @@ import {
   Bug,
   Wifi,
   MessageSquare,
+  Hash,
   type LucideIcon,
 } from "lucide-react";
 
@@ -54,6 +55,10 @@ export const COMMAND_ICONS: Record<string, CommandIcon> = {
   req: {
     icon: Podcast,
     description: "Active subscription to Nostr relays with filters",
+  },
+  count: {
+    icon: Hash,
+    description: "Count events on relays using NIP-45 COUNT verb",
   },
   open: {
     icon: ExternalLink,

--- a/src/lib/count-parser.ts
+++ b/src/lib/count-parser.ts
@@ -1,0 +1,542 @@
+import { nip19 } from "nostr-tools";
+import type { NostrFilter } from "@/types/nostr";
+import { isNip05 } from "./nip05";
+import {
+  isValidHexPubkey,
+  isValidHexEventId,
+  normalizeHex,
+} from "./nostr-validation";
+import { normalizeRelayURL } from "./relay-url";
+
+export interface ParsedCountCommand {
+  filter: NostrFilter;
+  relays: string[]; // Required - at least one relay
+  nip05Authors?: string[];
+  nip05PTags?: string[];
+  nip05PTagsUppercase?: string[];
+  needsAccount?: boolean;
+}
+
+/**
+ * Parse comma-separated values and apply a parser function to each
+ * Returns true if at least one value was successfully parsed
+ */
+function parseCommaSeparated<T>(
+  value: string,
+  parser: (v: string) => T | null,
+  target: Set<T>,
+): boolean {
+  const values = value.split(",").map((v) => v.trim());
+  let addedAny = false;
+
+  for (const val of values) {
+    if (!val) continue;
+    const parsed = parser(val);
+    if (parsed !== null) {
+      target.add(parsed);
+      addedAny = true;
+    }
+  }
+
+  return addedAny;
+}
+
+/**
+ * Parse COUNT command arguments into a Nostr filter
+ * Similar to REQ but:
+ * - Requires at least one relay (no automatic relay selection)
+ * - No --limit flag (COUNT returns total, not a subset)
+ * - No --close-on-eose flag (COUNT is inherently one-shot)
+ * - No --view flag (COUNT doesn't render events)
+ *
+ * Supports:
+ * - Filters: -k (kinds), -a (authors), -e (events), -p (#p), -P (#P), -t (#t), -d (#d), --tag/-T (any #tag)
+ * - Time: --since, --until
+ * - Search: --search
+ * - Relays: wss://relay.com or relay.com (required, at least one)
+ */
+export function parseCountCommand(args: string[]): ParsedCountCommand {
+  const filter: NostrFilter = {};
+  const relays: string[] = [];
+  const nip05Authors = new Set<string>();
+  const nip05PTags = new Set<string>();
+  const nip05PTagsUppercase = new Set<string>();
+
+  // Use sets for deduplication during accumulation
+  const kinds = new Set<number>();
+  const authors = new Set<string>();
+  const ids = new Set<string>();
+  const eventIds = new Set<string>();
+  const aTags = new Set<string>();
+  const pTags = new Set<string>();
+  const pTagsUppercase = new Set<string>();
+  const tTags = new Set<string>();
+  const dTags = new Set<string>();
+
+  // Map for arbitrary single-letter tags: letter -> Set<value>
+  const genericTags = new Map<string, Set<string>>();
+
+  let i = 0;
+
+  while (i < args.length) {
+    const arg = args[i];
+
+    // Relay URLs (starts with wss://, ws://, or looks like a domain)
+    if (arg.startsWith("wss://") || arg.startsWith("ws://")) {
+      relays.push(normalizeRelayURL(arg));
+      i++;
+      continue;
+    }
+
+    // Shorthand relay (domain-like string without protocol)
+    if (isRelayDomain(arg)) {
+      relays.push(normalizeRelayURL(arg));
+      i++;
+      continue;
+    }
+
+    // Flags
+    if (arg.startsWith("-")) {
+      const flag = arg;
+      const nextArg = args[i + 1];
+
+      switch (flag) {
+        case "-k":
+        case "--kind": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+          const addedAny = parseCommaSeparated(
+            nextArg,
+            (v) => {
+              const kind = parseInt(v, 10);
+              return isNaN(kind) ? null : kind;
+            },
+            kinds,
+          );
+          i += addedAny ? 2 : 1;
+          break;
+        }
+
+        case "-a":
+        case "--author": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+          let addedAny = false;
+          const values = nextArg.split(",").map((a) => a.trim());
+          for (const authorStr of values) {
+            if (!authorStr) continue;
+            const normalized = authorStr.toLowerCase();
+            if (normalized === "$me" || normalized === "$contacts") {
+              authors.add(normalized);
+              addedAny = true;
+            } else if (isNip05(authorStr)) {
+              nip05Authors.add(authorStr);
+              addedAny = true;
+            } else {
+              const result = parseNpubOrHex(authorStr);
+              if (result.pubkey) {
+                authors.add(result.pubkey);
+                addedAny = true;
+                if (result.relays) {
+                  relays.push(...result.relays.map(normalizeRelayURL));
+                }
+              }
+            }
+          }
+          i += addedAny ? 2 : 1;
+          break;
+        }
+
+        case "-e": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+
+          let addedAny = false;
+          const values = nextArg.split(",").map((v) => v.trim());
+
+          for (const val of values) {
+            if (!val) continue;
+
+            const parsed = parseEventIdentifier(val);
+            if (parsed) {
+              if (parsed.type === "direct-event") {
+                ids.add(parsed.value);
+              } else if (parsed.type === "direct-address") {
+                aTags.add(parsed.value);
+              } else if (parsed.type === "tag-event") {
+                eventIds.add(parsed.value);
+              }
+
+              if (parsed.relays) {
+                relays.push(...parsed.relays);
+              }
+
+              addedAny = true;
+            }
+          }
+
+          i += addedAny ? 2 : 1;
+          break;
+        }
+
+        case "-p": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+          let addedAny = false;
+          const values = nextArg.split(",").map((p) => p.trim());
+          for (const pubkeyStr of values) {
+            if (!pubkeyStr) continue;
+            const normalized = pubkeyStr.toLowerCase();
+            if (normalized === "$me" || normalized === "$contacts") {
+              pTags.add(normalized);
+              addedAny = true;
+            } else if (isNip05(pubkeyStr)) {
+              nip05PTags.add(pubkeyStr);
+              addedAny = true;
+            } else {
+              const result = parseNpubOrHex(pubkeyStr);
+              if (result.pubkey) {
+                pTags.add(result.pubkey);
+                addedAny = true;
+                if (result.relays) {
+                  relays.push(...result.relays.map(normalizeRelayURL));
+                }
+              }
+            }
+          }
+          i += addedAny ? 2 : 1;
+          break;
+        }
+
+        case "-P": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+          let addedAny = false;
+          const values = nextArg.split(",").map((p) => p.trim());
+          for (const pubkeyStr of values) {
+            if (!pubkeyStr) continue;
+            const normalized = pubkeyStr.toLowerCase();
+            if (normalized === "$me" || normalized === "$contacts") {
+              pTagsUppercase.add(normalized);
+              addedAny = true;
+            } else if (isNip05(pubkeyStr)) {
+              nip05PTagsUppercase.add(pubkeyStr);
+              addedAny = true;
+            } else {
+              const result = parseNpubOrHex(pubkeyStr);
+              if (result.pubkey) {
+                pTagsUppercase.add(result.pubkey);
+                addedAny = true;
+                if (result.relays) {
+                  relays.push(...result.relays.map(normalizeRelayURL));
+                }
+              }
+            }
+          }
+          i += addedAny ? 2 : 1;
+          break;
+        }
+
+        case "-t": {
+          if (nextArg) {
+            const addedAny = parseCommaSeparated(nextArg, (v) => v, tTags);
+            i += addedAny ? 2 : 1;
+          } else {
+            i++;
+          }
+          break;
+        }
+
+        case "-d": {
+          if (nextArg) {
+            const addedAny = parseCommaSeparated(nextArg, (v) => v, dTags);
+            i += addedAny ? 2 : 1;
+          } else {
+            i++;
+          }
+          break;
+        }
+
+        case "--since": {
+          const timestamp = parseTimestamp(nextArg);
+          if (timestamp) {
+            filter.since = timestamp;
+            i += 2;
+          } else {
+            i++;
+          }
+          break;
+        }
+
+        case "--until": {
+          const timestamp = parseTimestamp(nextArg);
+          if (timestamp) {
+            filter.until = timestamp;
+            i += 2;
+          } else {
+            i++;
+          }
+          break;
+        }
+
+        case "--search": {
+          if (nextArg) {
+            filter.search = nextArg;
+            i += 2;
+          } else {
+            i++;
+          }
+          break;
+        }
+
+        case "-T":
+        case "--tag": {
+          if (!nextArg) {
+            i++;
+            break;
+          }
+
+          const letter = nextArg;
+          const valueArg = args[i + 2];
+
+          if (letter.length !== 1 || !valueArg) {
+            i++;
+            break;
+          }
+
+          let tagSet = genericTags.get(letter);
+          if (!tagSet) {
+            tagSet = new Set<string>();
+            genericTags.set(letter, tagSet);
+          }
+
+          const addedAny = parseCommaSeparated(valueArg, (v) => v, tagSet);
+
+          i += addedAny ? 3 : 1;
+          break;
+        }
+
+        default:
+          i++;
+          break;
+      }
+    } else {
+      i++;
+    }
+  }
+
+  // Validate: at least one relay is required
+  if (relays.length === 0) {
+    throw new Error("At least one relay is required for COUNT");
+  }
+
+  // Convert accumulated sets to filter arrays
+  if (kinds.size > 0) filter.kinds = Array.from(kinds);
+  if (authors.size > 0) filter.authors = Array.from(authors);
+  if (ids.size > 0) filter.ids = Array.from(ids);
+  if (eventIds.size > 0) filter["#e"] = Array.from(eventIds);
+  if (aTags.size > 0) filter["#a"] = Array.from(aTags);
+  if (pTags.size > 0) filter["#p"] = Array.from(pTags);
+  if (pTagsUppercase.size > 0) filter["#P"] = Array.from(pTagsUppercase);
+  if (tTags.size > 0) filter["#t"] = Array.from(tTags);
+  if (dTags.size > 0) filter["#d"] = Array.from(dTags);
+
+  // Convert generic tags to filter
+  for (const [letter, tagSet] of genericTags.entries()) {
+    if (tagSet.size > 0) {
+      (filter as any)[`#${letter}`] = Array.from(tagSet);
+    }
+  }
+
+  // Check if filter contains $me or $contacts aliases
+  const needsAccount =
+    filter.authors?.some((a) => a === "$me" || a === "$contacts") ||
+    filter["#p"]?.some((p) => p === "$me" || p === "$contacts") ||
+    filter["#P"]?.some((p) => p === "$me" || p === "$contacts") ||
+    false;
+
+  // Deduplicate relays
+  const uniqueRelays = [...new Set(relays)];
+
+  return {
+    filter,
+    relays: uniqueRelays,
+    nip05Authors: nip05Authors.size > 0 ? Array.from(nip05Authors) : undefined,
+    nip05PTags: nip05PTags.size > 0 ? Array.from(nip05PTags) : undefined,
+    nip05PTagsUppercase:
+      nip05PTagsUppercase.size > 0
+        ? Array.from(nip05PTagsUppercase)
+        : undefined,
+    needsAccount,
+  };
+}
+
+/**
+ * Check if a string looks like a relay domain
+ */
+function isRelayDomain(value: string): boolean {
+  if (!value || value.startsWith("-")) return false;
+  return /^[a-zA-Z0-9][\w.-]+\.[a-zA-Z]{2,}(:\d+)?(\/.*)?$/.test(value);
+}
+
+/**
+ * Parse timestamp - supports unix timestamp, relative time, or "now"
+ */
+function parseTimestamp(value: string): number | null {
+  if (!value) return null;
+
+  if (value.toLowerCase() === "now") {
+    return Math.floor(Date.now() / 1000);
+  }
+
+  if (/^\d{10}$/.test(value)) {
+    return parseInt(value, 10);
+  }
+
+  const relativeMatch = value.match(/^(\d+)(s|m|h|d|w|mo|y)$/);
+  if (relativeMatch) {
+    const amount = parseInt(relativeMatch[1], 10);
+    const unit = relativeMatch[2];
+    const now = Math.floor(Date.now() / 1000);
+
+    const multipliers: Record<string, number> = {
+      s: 1,
+      m: 60,
+      h: 3600,
+      d: 86400,
+      w: 604800,
+      mo: 2592000,
+      y: 31536000,
+    };
+
+    return now - amount * multipliers[unit];
+  }
+
+  return null;
+}
+
+/**
+ * Parse npub, nprofile, or hex pubkey
+ */
+function parseNpubOrHex(value: string): {
+  pubkey: string | null;
+  relays?: string[];
+} {
+  if (!value) return { pubkey: null };
+
+  if (value.startsWith("npub") || value.startsWith("nprofile")) {
+    try {
+      const decoded = nip19.decode(value);
+      if (decoded.type === "npub") {
+        return { pubkey: decoded.data };
+      }
+      if (decoded.type === "nprofile") {
+        return {
+          pubkey: decoded.data.pubkey,
+          relays: decoded.data.relays,
+        };
+      }
+    } catch {
+      // Not valid npub/nprofile
+    }
+  }
+
+  if (isValidHexPubkey(value)) {
+    return { pubkey: normalizeHex(value) };
+  }
+
+  return { pubkey: null };
+}
+
+interface ParsedEventIdentifier {
+  type: "direct-event" | "direct-address" | "tag-event";
+  value: string;
+  relays?: string[];
+}
+
+/**
+ * Parse event identifier - supports note, nevent, naddr, and hex event ID
+ */
+function parseEventIdentifier(value: string): ParsedEventIdentifier | null {
+  if (!value) return null;
+
+  if (value.startsWith("nevent")) {
+    try {
+      const decoded = nip19.decode(value);
+      if (decoded.type === "nevent") {
+        return {
+          type: "direct-event",
+          value: decoded.data.id,
+          relays: decoded.data.relays
+            ?.map((url) => {
+              try {
+                return normalizeRelayURL(url);
+              } catch {
+                return null;
+              }
+            })
+            .filter((url): url is string => url !== null),
+        };
+      }
+    } catch {
+      // Not valid nevent
+    }
+  }
+
+  if (value.startsWith("naddr")) {
+    try {
+      const decoded = nip19.decode(value);
+      if (decoded.type === "naddr") {
+        const coordinate = `${decoded.data.kind}:${decoded.data.pubkey}:${decoded.data.identifier}`;
+        return {
+          type: "direct-address",
+          value: coordinate,
+          relays: decoded.data.relays
+            ?.map((url) => {
+              try {
+                return normalizeRelayURL(url);
+              } catch {
+                return null;
+              }
+            })
+            .filter((url): url is string => url !== null),
+        };
+      }
+    } catch {
+      // Not valid naddr
+    }
+  }
+
+  if (value.startsWith("note")) {
+    try {
+      const decoded = nip19.decode(value);
+      if (decoded.type === "note") {
+        return {
+          type: "tag-event",
+          value: decoded.data,
+        };
+      }
+    } catch {
+      // Not valid note
+    }
+  }
+
+  if (isValidHexEventId(value)) {
+    return {
+      type: "tag-event",
+      value: normalizeHex(value),
+    };
+  }
+
+  return null;
+}

--- a/src/lib/count-parser.ts
+++ b/src/lib/count-parser.ts
@@ -335,10 +335,7 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
     }
   }
 
-  // Validate: at least one relay is required
-  if (relays.length === 0) {
-    throw new Error("At least one relay is required for COUNT");
-  }
+  // Relays are optional - will use outbox model if not specified
 
   // Convert accumulated sets to filter arrays
   if (kinds.size > 0) filter.kinds = Array.from(kinds);

--- a/src/lib/count-parser.ts
+++ b/src/lib/count-parser.ts
@@ -44,7 +44,7 @@ function parseCommaSeparated<T>(
 /**
  * Parse COUNT command arguments into a Nostr filter
  * Similar to REQ but:
- * - Requires at least one relay (no automatic relay selection)
+ * - Requires at least one relay
  * - No --limit flag (COUNT returns total, not a subset)
  * - No --close-on-eose flag (COUNT is inherently one-shot)
  * - No --view flag (COUNT doesn't render events)
@@ -335,7 +335,10 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
     }
   }
 
-  // Relays are optional - will use outbox model if not specified
+  // Validate that at least one relay is specified
+  if (relays.length === 0) {
+    throw new Error("At least one relay is required for COUNT");
+  }
 
   // Convert accumulated sets to filter arrays
   if (kinds.size > 0) filter.kinds = Array.from(kinds);

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -8,6 +8,7 @@ export type AppId =
   | "kinds"
   | "man"
   | "req"
+  | "count"
   //| "event"
   | "open"
   | "profile"

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -325,14 +325,14 @@ export const manPages: Record<string, ManPageEntry> = {
   count: {
     name: "count",
     section: "1",
-    synopsis: "count [options] <relay...>",
+    synopsis: "count [relay...] [options]",
     description:
-      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. At least one relay is required. If querying multiple relays, shows per-relay breakdown. Automatically checks NIP-11 relay info to detect NIP-45 support before querying. Can be saved as a spell for quick access.",
+      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. If no relays specified, automatically selects relays using the outbox model (NIP-65) filtered by NIP-45 support. Checks NIP-11 relay info to detect NIP-45 support before querying. Can be saved as a spell for quick access.",
     options: [
       {
-        flag: "<relay...>",
+        flag: "[relay...]",
         description:
-          "Relay URLs to query (required, at least one). Can appear anywhere in the command. Supports wss://relay.com or shorthand: relay.com",
+          "Relay URLs to query (optional). If omitted, uses outbox model with NIP-45 filtering. Can appear anywhere in the command. Supports wss://relay.com or shorthand: relay.com",
       },
       {
         flag: "-k, --kind <number>",
@@ -390,11 +390,12 @@ export const manPages: Record<string, ManPageEntry> = {
       },
     ],
     examples: [
-      "count relay.damus.io -k 3 -p npub1...                  Count followers on one relay",
-      "count nos.lol relay.damus.io -k 1 -a fiatjaf.com       Compare post counts across relays",
-      "count relay.nostr.band -k 1 --search bitcoin           Count search results",
-      "count relay.damus.io -k 9735 -p $me --since 30d        Count zaps received in last month",
-      "count nos.lol -t nostr,bitcoin                         Count events with hashtags",
+      "count -k 1 -a fiatjaf.com                              Count posts (auto relay selection)",
+      "count -k 3 -p $me                                      Count followers (auto relay selection)",
+      "count relay.damus.io -k 3 -p npub1...                  Count followers on specific relay",
+      "count nos.lol relay.damus.io -k 1 -a fiatjaf.com       Compare counts across relays",
+      "count -k 9735 -p $me --since 30d                       Count zaps received in last month",
+      "count -t nostr,bitcoin                                 Count events with hashtags",
     ],
     seeAlso: ["req", "nip"],
     appId: "count",

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -325,14 +325,14 @@ export const manPages: Record<string, ManPageEntry> = {
   count: {
     name: "count",
     section: "1",
-    synopsis: "count [relay...] [options]",
+    synopsis: "count <relay...> [options]",
     description:
-      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. If no relays specified, automatically selects relays using the outbox model (NIP-65) filtered by NIP-45 support. Checks NIP-11 relay info to detect NIP-45 support before querying. Can be saved as a spell for quick access.",
+      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. Requires at least one relay. Checks NIP-11 relay info to detect NIP-45 support before querying. Can be saved as a spell for quick access.",
     options: [
       {
-        flag: "[relay...]",
+        flag: "<relay...>",
         description:
-          "Relay URLs to query (optional). If omitted, uses outbox model with NIP-45 filtering. Can appear anywhere in the command. Supports wss://relay.com or shorthand: relay.com",
+          "Relay URLs to query (required). At least one relay must be specified. Can appear anywhere in the command. Supports wss://relay.com or shorthand: relay.com",
       },
       {
         flag: "-k, --kind <number>",
@@ -390,12 +390,11 @@ export const manPages: Record<string, ManPageEntry> = {
       },
     ],
     examples: [
-      "count -k 1 -a fiatjaf.com                              Count posts (auto relay selection)",
-      "count -k 3 -p $me                                      Count followers (auto relay selection)",
-      "count relay.damus.io -k 3 -p npub1...                  Count followers on specific relay",
-      "count nos.lol relay.damus.io -k 1 -a fiatjaf.com       Compare counts across relays",
-      "count -k 9735 -p $me --since 30d                       Count zaps received in last month",
-      "count -t nostr,bitcoin                                 Count events with hashtags",
+      "count relay.damus.io -k 1 -a fiatjaf.com               Count posts from author",
+      "count nos.lol -k 3 -p npub1...                         Count followers on specific relay",
+      "count nos.lol relay.damus.io -k 1 -a npub1...          Compare counts across relays",
+      "count relay.damus.io -k 9735 -p $me --since 30d        Count zaps received in last month",
+      "count nos.lol -t nostr,bitcoin                         Count events with hashtags",
     ],
     seeAlso: ["req", "nip"],
     appId: "count",

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -327,7 +327,7 @@ export const manPages: Record<string, ManPageEntry> = {
     section: "1",
     synopsis: "count [options] <relay...>",
     description:
-      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. At least one relay is required. If querying multiple relays, shows per-relay breakdown.",
+      "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. At least one relay is required. If querying multiple relays, shows per-relay breakdown. Automatically checks NIP-11 relay info to detect NIP-45 support before querying. Can be saved as a spell for quick access.",
     options: [
       {
         flag: "<relay...>",

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -325,14 +325,14 @@ export const manPages: Record<string, ManPageEntry> = {
   count: {
     name: "count",
     section: "1",
-    synopsis: "count <relay...> [options]",
+    synopsis: "count [options] <relay...>",
     description:
       "Count events on Nostr relays using the NIP-45 COUNT verb. Returns event counts matching specified filter criteria. At least one relay is required. If querying multiple relays, shows per-relay breakdown.",
     options: [
       {
         flag: "<relay...>",
         description:
-          "Relay URLs to query (required, at least one). Supports wss://relay.com or shorthand: relay.com",
+          "Relay URLs to query (required, at least one). Can appear anywhere in the command. Supports wss://relay.com or shorthand: relay.com",
       },
       {
         flag: "-k, --kind <number>",


### PR DESCRIPTION
Implements the COUNT verb from NIP-45, allowing users to count events on relays without fetching them. Features:

- New `count` command requiring at least one relay
- Filter-only flags (excludes --limit, --close-on-eose, --view)
- Single relay shows centered count result
- Multiple relays show per-relay breakdown
- Handles approximate counts, errors, and unsupported relays
- Supports $me/$contacts aliases and NIP-05 resolution

Examples:
  count relay.damus.io -k 3 -p npub1... count nos.lol relay.damus.io -k 1 -a fiatjaf.com