### PR TITLE
feat: communikey fallback detection to NIP-29 adapter

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -446,40 +446,6 @@ export function ChatViewer({
   // Ref to MentionEditor for programmatic submission
   const editorRef = useRef<MentionEditorHandle>(null);
 
-  // Extract communikey blossom servers if available
-  const communikeyServers = useMemo(() => {
-    if (
-      conversationResult.status === "success" &&
-      conversationResult.conversation.protocol === "communikeys"
-    ) {
-      return (
-        conversationResult.conversation.metadata?.communikeyConfig
-          ?.blossomServers || []
-      );
-    }
-    return [];
-  }, [conversationResult]);
-
-  // Blossom upload hook for file attachments
-  const { open: openUpload, dialog: uploadDialog } = useBlossomUpload({
-    accept: "image/*,video/*,audio/*",
-    communikeyServers,
-    onSuccess: (results) => {
-      if (results.length > 0 && editorRef.current) {
-        // Insert the first successful upload as a blob attachment with metadata
-        const { blob, server } = results[0];
-        editorRef.current.insertBlob({
-          url: blob.url,
-          sha256: blob.sha256,
-          mimeType: blob.type,
-          size: blob.size,
-          server,
-        });
-        editorRef.current.focus();
-      }
-    },
-  });
-
   // Get the appropriate adapter for this protocol
   const adapter = useMemo(() => getAdapter(protocol), [protocol]);
 
@@ -514,6 +480,34 @@ export function ChatViewer({
     conversationResult?.status === "success"
       ? conversationResult.conversation
       : null;
+
+  // Extract communikey blossom servers if available
+  const communikeyServers = useMemo(() => {
+    if (conversation && conversation.protocol === "communikeys") {
+      return conversation.metadata?.communikeyConfig?.blossomServers || [];
+    }
+    return [];
+  }, [conversation]);
+
+  // Blossom upload hook for file attachments
+  const { open: openUpload, dialog: uploadDialog } = useBlossomUpload({
+    accept: "image/*,video/*,audio/*",
+    communikeyServers,
+    onSuccess: (results) => {
+      if (results.length > 0 && editorRef.current) {
+        // Insert the first successful upload as a blob attachment with metadata
+        const { blob, server } = results[0];
+        editorRef.current.insertBlob({
+          url: blob.url,
+          sha256: blob.sha256,
+          mimeType: blob.type,
+          size: blob.size,
+          server,
+        });
+        editorRef.current.focus();
+      }
+    },
+  });
 
   // Slash command search for action autocomplete
   // Context-aware: only shows relevant actions based on membership status

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -446,9 +446,24 @@ export function ChatViewer({
   // Ref to MentionEditor for programmatic submission
   const editorRef = useRef<MentionEditorHandle>(null);
 
+  // Extract communikey blossom servers if available
+  const communikeyServers = useMemo(() => {
+    if (
+      conversationResult.status === "success" &&
+      conversationResult.conversation.protocol === "communikeys"
+    ) {
+      return (
+        conversationResult.conversation.metadata?.communikeyConfig
+          ?.blossomServers || []
+      );
+    }
+    return [];
+  }, [conversationResult]);
+
   // Blossom upload hook for file attachments
   const { open: openUpload, dialog: uploadDialog } = useBlossomUpload({
     accept: "image/*,video/*,audio/*",
+    communikeyServers,
     onSuccess: (results) => {
       if (results.length > 0 && editorRef.current) {
         // Insert the first successful upload as a blob attachment with metadata

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -730,7 +730,7 @@ export function ChatViewer({
       addWindow("nip", { number: 53 });
     } else if (conversation?.protocol === "communikeys") {
       // Open NIP-CC specification (communikeys)
-      addWindow("event", {
+      addWindow("open", {
         id: "naddr1qvzqqqrcvypzp22rfmsktmgpk2rtan7zwu00zuzax5maq5dnsu5g3xxvqr2u3pd7qydhwumn8ghj7argv4nx7un9wd6zumn0wd68yvfwvdhk6tcpz4mhxue69uhhyetvv9ujuerpd46hxtnfduhsqrrrdakk6atwdykkketewvsrwsq9",
       });
     }

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -139,7 +139,7 @@ function isLiveActivityMetadata(value: unknown): value is LiveActivityMetadata {
  * Returns a string that can be passed to the `chat` command to open this conversation
  *
  * For NIP-29 groups: relay'group-id (without wss:// prefix)
- * For communikeys (NIP-CC): relay'pubkey or just pubkey
+ * For communikeys (NIP-CC): relay'pubkey (relay hint required)
  * For NIP-53 live activities: naddr1... encoding
  */
 function getChatIdentifier(conversation: Conversation): string | null {
@@ -156,16 +156,12 @@ function getChatIdentifier(conversation: Conversation): string | null {
   if (conversation.protocol === "communikeys") {
     const pubkey = conversation.metadata?.groupId; // For communikeys, groupId is the pubkey
     const relayUrl = conversation.metadata?.relayUrl;
-    if (!pubkey) return null;
 
-    // If there's a relay hint, include it
-    if (relayUrl) {
-      const cleanRelay = relayUrl.replace(/^wss?:\/\//, "");
-      return `${cleanRelay}'${pubkey}`;
-    }
+    // Communikeys require relay hints (from naddr or relay'pubkey format)
+    if (!pubkey || !relayUrl) return null;
 
-    // Otherwise just return the pubkey
-    return pubkey;
+    const cleanRelay = relayUrl.replace(/^wss?:\/\//, "");
+    return `${cleanRelay}'${pubkey}`;
   }
 
   if (conversation.protocol === "nip-53") {

--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -708,12 +708,13 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
     const identifier = props.identifier as ProtocolIdentifier;
 
     // Get adapter and resolve conversation
-    // Currently only NIP-29 is supported
+    // Currently only NIP-29 and communikeys are supported
     const getAdapter = () => {
       switch (protocol) {
         // case "nip-c7":  // Coming soon
         //   return new NipC7Adapter();
         case "nip-29":
+        case "communikeys": // NIP-CC (uses same adapter as NIP-29)
           return new Nip29Adapter();
         default:
           return null;

--- a/src/components/nostr/kinds/CommunikeyRenderer.tsx
+++ b/src/components/nostr/kinds/CommunikeyRenderer.tsx
@@ -1,0 +1,356 @@
+import { BaseEventProps, BaseEventContainer } from "./BaseEventRenderer";
+import type { NostrEvent } from "@/types/nostr";
+import { getTagValue } from "applesauce-core/helpers";
+import { getTagValues } from "@/lib/nostr-utils";
+import { useGrimoire } from "@/core/state";
+import { MessageSquare, HardDrive, Coins, Shield } from "lucide-react";
+import { useProfile } from "@/hooks/useProfile";
+import { UserName } from "@/components/nostr/UserName";
+
+/**
+ * Kind 10222 Renderer - Communikey Definition (Feed View)
+ * Shows communikey info with chat link
+ */
+export function CommunikeyRenderer({ event }: BaseEventProps) {
+  const { addWindow } = useGrimoire();
+  const profile = useProfile(event.pubkey);
+
+  // Extract communikey configuration
+  const description = getTagValue(event, "description");
+  const relays = getTagValues(event, "r");
+  const blossomServers = getTagValues(event, "blossom");
+  const mints = getTagValues(event, "mint");
+
+  // Get content sections
+  const contentTags = event.tags.filter((t) => t[0] === "content");
+  const contentSections = contentTags.map((t) => t[1]).filter(Boolean);
+
+  // Community name from profile or pubkey
+  const name =
+    profile?.display_name ||
+    profile?.name ||
+    `Communikey ${event.pubkey.slice(0, 8)}`;
+
+  const handleOpenChat = () => {
+    try {
+      addWindow("chat", {
+        protocol: "communikeys",
+        identifier: {
+          type: "group",
+          value: event.pubkey,
+          relays,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to open communikey chat:", error);
+    }
+  };
+
+  const canOpenChat = relays.length > 0;
+
+  return (
+    <BaseEventContainer event={event}>
+      <div className="flex flex-col gap-1.5">
+        {/* Title */}
+        <div className="flex items-center gap-2">
+          <Shield className="size-4 text-primary flex-shrink-0" />
+          <div className="font-semibold text-sm truncate">{name}</div>
+          <span className="text-xs text-muted-foreground">
+            (<UserName pubkey={event.pubkey} />)
+          </span>
+        </div>
+
+        {/* Description */}
+        {(description || profile?.about) && (
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {description || profile?.about}
+          </p>
+        )}
+
+        {/* Stats */}
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {relays.length > 0 && (
+            <span className="flex items-center gap-1">
+              <Shield className="size-3" />
+              {relays.length} relay{relays.length !== 1 ? "s" : ""}
+            </span>
+          )}
+          {blossomServers.length > 0 && (
+            <span className="flex items-center gap-1">
+              <HardDrive className="size-3" />
+              {blossomServers.length} blossom
+            </span>
+          )}
+          {mints.length > 0 && (
+            <span className="flex items-center gap-1">
+              <Coins className="size-3" />
+              {mints.length} mint{mints.length !== 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+
+        {/* Content Sections */}
+        {contentSections.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap text-xs">
+            {contentSections.slice(0, 3).map((section, i) => (
+              <span
+                key={i}
+                className="bg-muted px-1.5 py-0.5 rounded text-muted-foreground"
+              >
+                {section}
+              </span>
+            ))}
+            {contentSections.length > 3 && (
+              <span className="text-muted-foreground">
+                +{contentSections.length - 3} more
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Open Chat Button */}
+        {canOpenChat && (
+          <button
+            onClick={handleOpenChat}
+            className="text-xs text-primary hover:underline flex items-center gap-1 w-fit mt-0.5"
+          >
+            <MessageSquare className="size-3" />
+            Open Chat
+          </button>
+        )}
+      </div>
+    </BaseEventContainer>
+  );
+}
+
+/**
+ * Kind 10222 Detail Renderer - Communikey Definition (Detail View)
+ * Shows full communikey configuration
+ */
+export function CommunikeyDetailRenderer({ event }: { event: NostrEvent }) {
+  const { addWindow } = useGrimoire();
+  const profile = useProfile(event.pubkey);
+
+  // Extract all configuration
+  const description = getTagValue(event, "description");
+  const location = getTagValue(event, "location");
+  const geoHash = getTagValue(event, "g");
+  const relays = getTagValues(event, "r");
+  const blossomServers = getTagValues(event, "blossom");
+  const mints = getTagValues(event, "mint");
+
+  // Parse content sections with their settings
+  interface ContentSection {
+    name: string;
+    kinds: number[];
+    roles: string[];
+    fee?: { amount: number; unit: string };
+    exclusive: boolean;
+  }
+
+  const contentSections: ContentSection[] = [];
+  let currentSection: ContentSection | null = null;
+
+  for (const tag of event.tags) {
+    if (tag[0] === "content" && tag[1]) {
+      // Save previous section
+      if (currentSection) {
+        contentSections.push(currentSection);
+      }
+      // Start new section
+      currentSection = {
+        name: tag[1],
+        kinds: [],
+        roles: [],
+        exclusive: false,
+      };
+    } else if (currentSection) {
+      if (tag[0] === "k" && tag[1]) {
+        const kind = parseInt(tag[1], 10);
+        if (!isNaN(kind)) {
+          currentSection.kinds.push(kind);
+        }
+      } else if (tag[0] === "role") {
+        currentSection.roles.push(...tag.slice(1));
+      } else if (tag[0] === "fee" && tag[1] && tag[2]) {
+        currentSection.fee = {
+          amount: parseInt(tag[1], 10),
+          unit: tag[2],
+        };
+      } else if (tag[0] === "exclusive") {
+        currentSection.exclusive = tag[1] === "true";
+      }
+    }
+  }
+
+  // Don't forget the last section
+  if (currentSection) {
+    contentSections.push(currentSection);
+  }
+
+  // Community name from profile or pubkey
+  const name =
+    profile?.display_name ||
+    profile?.name ||
+    `Communikey ${event.pubkey.slice(0, 8)}`;
+
+  const handleOpenChat = () => {
+    try {
+      addWindow("chat", {
+        protocol: "communikeys",
+        identifier: {
+          type: "group",
+          value: event.pubkey,
+          relays,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to open communikey chat:", error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Shield className="size-5 text-primary" />
+          <h2 className="text-xl font-bold">{name}</h2>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          <UserName pubkey={event.pubkey} />
+        </div>
+      </div>
+
+      {/* Description */}
+      {(description || profile?.about) && (
+        <div className="text-sm">{description || profile?.about}</div>
+      )}
+
+      {/* Location */}
+      {location && (
+        <div className="text-sm">
+          <span className="font-medium">Location:</span> {location}
+          {geoHash && (
+            <span className="text-muted-foreground ml-2">({geoHash})</span>
+          )}
+        </div>
+      )}
+
+      {/* Relays */}
+      {relays.length > 0 && (
+        <div>
+          <h3 className="font-medium text-sm mb-2 flex items-center gap-2">
+            <Shield className="size-4" />
+            Relays ({relays.length})
+          </h3>
+          <div className="space-y-1">
+            {relays.map((relay, i) => (
+              <div
+                key={i}
+                className="font-mono text-xs bg-muted rounded px-2 py-1 break-all"
+              >
+                {i === 0 && (
+                  <span className="text-primary font-semibold mr-2">
+                    [Main]
+                  </span>
+                )}
+                {relay}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Blossom Servers */}
+      {blossomServers.length > 0 && (
+        <div>
+          <h3 className="font-medium text-sm mb-2 flex items-center gap-2">
+            <HardDrive className="size-4" />
+            Blossom Servers ({blossomServers.length})
+          </h3>
+          <div className="space-y-1">
+            {blossomServers.map((server, i) => (
+              <div
+                key={i}
+                className="font-mono text-xs bg-muted rounded px-2 py-1 break-all"
+              >
+                {server}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Mints */}
+      {mints.length > 0 && (
+        <div>
+          <h3 className="font-medium text-sm mb-2 flex items-center gap-2">
+            <Coins className="size-4" />
+            Ecash Mints ({mints.length})
+          </h3>
+          <div className="space-y-1">
+            {mints.map((mint, i) => (
+              <div
+                key={i}
+                className="font-mono text-xs bg-muted rounded px-2 py-1 break-all"
+              >
+                {mint}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content Sections */}
+      {contentSections.length > 0 && (
+        <div>
+          <h3 className="font-medium text-sm mb-2">
+            Content Sections ({contentSections.length})
+          </h3>
+          <div className="space-y-3">
+            {contentSections.map((section, i) => (
+              <div key={i} className="border rounded p-3 space-y-2">
+                <div className="font-medium text-sm">{section.name}</div>
+                {section.kinds.length > 0 && (
+                  <div className="text-xs">
+                    <span className="text-muted-foreground">Kinds:</span>{" "}
+                    {section.kinds.join(", ")}
+                  </div>
+                )}
+                {section.roles.length > 0 && (
+                  <div className="text-xs">
+                    <span className="text-muted-foreground">Roles:</span>{" "}
+                    {section.roles.join(", ")}
+                  </div>
+                )}
+                {section.fee && (
+                  <div className="text-xs">
+                    <span className="text-muted-foreground">Fee:</span>{" "}
+                    {section.fee.amount} {section.fee.unit}
+                  </div>
+                )}
+                {section.exclusive && (
+                  <div className="text-xs text-amber-600">
+                    ⚠ Exclusive (cannot target other communities)
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Open Chat Button */}
+      {relays.length > 0 && (
+        <button
+          onClick={handleOpenChat}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 px-4 py-2 rounded flex items-center justify-center gap-2 text-sm font-medium"
+        >
+          <MessageSquare className="size-4" />
+          Open Chat
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -30,6 +30,10 @@ import {
   BlossomServerListRenderer,
   BlossomServerListDetailRenderer,
 } from "./BlossomServerListRenderer";
+import {
+  CommunikeyRenderer,
+  CommunikeyDetailRenderer,
+} from "./CommunikeyRenderer";
 import { Kind10317Renderer } from "./GraspListRenderer";
 import { Kind10317DetailRenderer } from "./GraspListDetailRenderer";
 import { Kind30023Renderer } from "./ArticleRenderer";
@@ -189,6 +193,7 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
   10063: BlossomServerListRenderer, // Blossom User Server List (BUD-03)
   10101: WikiAuthorsRenderer, // Good Wiki Authors (NIP-51)
   10102: WikiRelaysRenderer, // Good Wiki Relays (NIP-51)
+  10222: CommunikeyRenderer, // Communikey Definition (NIP-CC)
   10317: Kind10317Renderer, // User Grasp List (NIP-34)
   13534: RelayMembersRenderer, // Relay Members (NIP-43)
   30000: FollowSetRenderer, // Follow Sets (NIP-51)
@@ -282,6 +287,7 @@ const detailRenderers: Record<
   10063: BlossomServerListDetailRenderer, // Blossom User Server List Detail (BUD-03)
   10101: WikiAuthorsDetailRenderer, // Good Wiki Authors Detail (NIP-51)
   10102: WikiRelaysDetailRenderer, // Good Wiki Relays Detail (NIP-51)
+  10222: CommunikeyDetailRenderer, // Communikey Definition Detail (NIP-CC)
   10317: Kind10317DetailRenderer, // User Grasp List Detail (NIP-34)
   13534: RelayMembersDetailRenderer, // Relay Members Detail (NIP-43)
   30000: FollowSetDetailRenderer, // Follow Sets Detail (NIP-51)

--- a/src/hooks/useBlossomUpload.tsx
+++ b/src/hooks/useBlossomUpload.tsx
@@ -11,6 +11,8 @@ export interface UseBlossomUploadOptions {
   onError?: (error: Error) => void;
   /** File types to accept (e.g., "image/*,video/*,audio/*") */
   accept?: string;
+  /** Additional blossom servers from communikey (NIP-CC) */
+  communikeyServers?: string[];
 }
 
 export interface UseBlossomUploadReturn {
@@ -84,9 +86,17 @@ export function useBlossomUpload(
         onCancel={handleCancel}
         onError={handleError}
         accept={options.accept}
+        communikeyServers={options.communikeyServers}
       />
     ),
-    [isOpen, handleSuccess, handleCancel, handleError, options.accept],
+    [
+      isOpen,
+      handleSuccess,
+      handleCancel,
+      handleError,
+      options.accept,
+      options.communikeyServers,
+    ],
   );
 
   return { open, close, isOpen, dialog };

--- a/src/lib/chat/adapters/nip-29-adapter.ts
+++ b/src/lib/chat/adapters/nip-29-adapter.ts
@@ -45,9 +45,7 @@ export class Nip29Adapter extends ChatProtocolAdapter {
    *   - relay.example.com'bitcoin-dev (NIP-29, wss:// prefix is optional)
    *   - naddr1... (kind 39000 group metadata address, NIP-29)
    *   - naddr1... (kind 10222 communikey definition, NIP-CC)
-   *   - relay.example.com'npub1xxx (NIP-CC communikey)
-   *   - npub1xxx (NIP-CC communikey, relays from kind 10222)
-   *   - hex-pubkey (NIP-CC communikey, relays from kind 10222)
+   *   - relay.example.com'npub1xxx (NIP-CC communikey with relay hint)
    */
   parseIdentifier(input: string): ProtocolIdentifier | null {
     // Try naddr format first
@@ -123,17 +121,6 @@ export class Nip29Adapter extends ChatProtocolAdapter {
         type: "group",
         value: groupId,
         relays: [relayUrl],
-      };
-    }
-
-    // NIP-CC bare communikey format: npub1xxx or hex pubkey
-    // Check if input is a valid pubkey (relays will be fetched from kind 10222)
-    const pubkey = this.extractPubkey(input);
-    if (pubkey) {
-      return {
-        type: "group",
-        value: pubkey,
-        relays: [], // Will be resolved from kind 10222
       };
     }
 

--- a/src/lib/chat/adapters/nip-29-adapter.ts
+++ b/src/lib/chat/adapters/nip-29-adapter.ts
@@ -1305,7 +1305,7 @@ export class Nip29Adapter extends ChatProtocolAdapter {
     return {
       id: `nip-cc:${pubkey}`,
       type: "group",
-      protocol: "nip-29", // Still uses NIP-29 message format
+      protocol: "communikeys", // NIP-CC protocol (uses kind 9 format)
       title,
       participants,
       metadata: {

--- a/src/lib/chat/adapters/nip-29-adapter.ts
+++ b/src/lib/chat/adapters/nip-29-adapter.ts
@@ -39,13 +39,12 @@ export class Nip29Adapter extends ChatProtocolAdapter {
   readonly type = "group" as const;
 
   /**
-   * Parse identifier - accepts group ID format, naddr, or communikey format
+   * Parse identifier - accepts group ID format and naddr
    * Examples:
    *   - wss://relay.example.com'bitcoin-dev (NIP-29)
    *   - relay.example.com'bitcoin-dev (NIP-29, wss:// prefix is optional)
    *   - naddr1... (kind 39000 group metadata address, NIP-29)
    *   - naddr1... (kind 10222 communikey definition, NIP-CC)
-   *   - relay.example.com'npub1xxx (NIP-CC communikey with relay hint)
    */
   parseIdentifier(input: string): ProtocolIdentifier | null {
     // Try naddr format first
@@ -106,7 +105,7 @@ export class Nip29Adapter extends ChatProtocolAdapter {
       }
     }
 
-    // NIP-29/NIP-CC format: [wss://]relay'group-id-or-pubkey
+    // NIP-29 format: [wss://]relay'group-id
     const match = input.match(/^((?:wss?:\/\/)?[^']+)'([^']+)$/);
     if (match) {
       let [, relayUrl] = match;

--- a/src/lib/command-reconstructor.ts
+++ b/src/lib/command-reconstructor.ts
@@ -116,9 +116,9 @@ export function reconstructCommand(window: WindowInstance): string {
           }
         }
 
-        // NIP-CC communikeys: chat npub1... or chat relay'npub1...
+        // NIP-CC communikeys: chat relay'npub1... (relay hint required)
         if (protocol === "communikeys" && identifier.type === "group") {
-          const relayUrl = identifier.relays?.[0] || "";
+          const relayUrl = identifier.relays?.[0];
           const groupId = identifier.value; // This is a pubkey
 
           if (relayUrl && groupId) {
@@ -127,10 +127,8 @@ export function reconstructCommand(window: WindowInstance): string {
             return `chat ${cleanRelay}'${groupId}`;
           }
 
-          // If no relay hint, just return the pubkey
-          if (groupId) {
-            return `chat ${groupId}`;
-          }
+          // Fallback: communikeys should always have relay hints
+          return "chat";
         }
 
         // NIP-53 live activities: chat naddr1...

--- a/src/lib/command-reconstructor.ts
+++ b/src/lib/command-reconstructor.ts
@@ -116,18 +116,25 @@ export function reconstructCommand(window: WindowInstance): string {
           }
         }
 
-        // NIP-CC communikeys: chat relay'npub1... (relay hint required)
+        // NIP-CC communikeys: chat naddr1... (kind 10222)
         if (protocol === "communikeys" && identifier.type === "group") {
-          const relayUrl = identifier.relays?.[0];
-          const groupId = identifier.value; // This is a pubkey
+          const pubkey = identifier.value; // This is a pubkey
+          const relays = identifier.relays;
 
-          if (relayUrl && groupId) {
-            // Strip wss:// prefix for cleaner command
-            const cleanRelay = relayUrl.replace(/^wss?:\/\//, "");
-            return `chat ${cleanRelay}'${groupId}`;
+          if (pubkey) {
+            try {
+              const naddr = nip19.naddrEncode({
+                kind: 10222,
+                pubkey,
+                identifier: "", // Communikeys use empty identifier
+                relays,
+              });
+              return `chat ${naddr}`;
+            } catch {
+              // Fallback if encoding fails
+            }
           }
 
-          // Fallback: communikeys should always have relay hints
           return "chat";
         }
 

--- a/src/lib/command-reconstructor.ts
+++ b/src/lib/command-reconstructor.ts
@@ -116,6 +116,23 @@ export function reconstructCommand(window: WindowInstance): string {
           }
         }
 
+        // NIP-CC communikeys: chat npub1... or chat relay'npub1...
+        if (protocol === "communikeys" && identifier.type === "group") {
+          const relayUrl = identifier.relays?.[0] || "";
+          const groupId = identifier.value; // This is a pubkey
+
+          if (relayUrl && groupId) {
+            // Strip wss:// prefix for cleaner command
+            const cleanRelay = relayUrl.replace(/^wss?:\/\//, "");
+            return `chat ${cleanRelay}'${groupId}`;
+          }
+
+          // If no relay hint, just return the pubkey
+          if (groupId) {
+            return `chat ${groupId}`;
+          }
+        }
+
         // NIP-53 live activities: chat naddr1...
         if (protocol === "nip-53" && identifier.type === "live-activity") {
           const { pubkey, identifier: dTag } = identifier.value || {};

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -14,7 +14,13 @@ export const CHAT_KINDS = [
 /**
  * Chat protocol identifier
  */
-export type ChatProtocol = "nip-c7" | "nip-17" | "nip-28" | "nip-29" | "nip-53";
+export type ChatProtocol =
+  | "nip-c7"
+  | "nip-17"
+  | "nip-28"
+  | "nip-29"
+  | "nip-53"
+  | "communikeys"; // NIP-CC
 
 /**
  * Conversation type

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -64,6 +64,23 @@ export interface ConversationMetadata {
   description?: string; // Group description
   icon?: string; // Group icon/picture URL
 
+  // NIP-CC communikey
+  communikeyConfig?: {
+    mainRelay: string;
+    backupRelays: string[];
+    blossomServers: string[];
+    mints: string[];
+    roles: Record<string, string>;
+    contentSections: Array<{
+      name: string;
+      kinds: number[];
+      roles: string[];
+      fee?: { amount: number; unit: string };
+      exclusive: boolean;
+    }>;
+    description?: string;
+  };
+
   // NIP-53 live chat
   activityAddress?: {
     kind: number;


### PR DESCRIPTION
Implements automatic fallback detection and handling for NIP-CC communikeys in the NIP-29 chat adapter. Communikeys use pubkeys as community identifiers with metadata from kind 10222 events.

Key features:
- Detect communikeys by checking if group ID is a valid pubkey (npub/hex)
- Fetch kind 10222 for relay/blossom server config + kind 0 for profile
- Support multiple relay formats: npub1xxx, hex, relay'npub1xxx
- Use main + backup relays from communikey config for all operations
- Add blossom server hints to imeta tags for attachments
- Maintain full NIP-29 compatibility (same kind 9 + h tag format)

Implementation:
- Added extractPubkey() helper for pubkey detection
- Added resolveCommunikeyConversation() for metadata resolution
- Added parseCommunikeyEvent() for kind 10222 parsing
- Updated loadMessages(), loadMoreMessages(), sendMessage() to support communikey relays
- Updated loadReplyMessage() to use multiple relays
- Extended ConversationMetadata type with communikeyConfig field

The adapter now seamlessly supports both traditional NIP-29 groups (relay'group-id) and NIP-CC communikeys (pubkey-based) with automatic detection and appropriate handling for each protocol.