### PR TITLE
Instant scroll to bottom in chat messages

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -942,7 +942,7 @@ export function ChatViewer({
             ref={virtuosoRef}
             data={messagesWithMarkers}
             initialTopMostItemIndex={messagesWithMarkers.length - 1}
-            followOutput="smooth"
+            followOutput="auto"
             alignToBottom
             components={{
               Header: () =>

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -583,6 +583,34 @@ export function ChatViewer({
   // Ref to Virtuoso for programmatic scrolling
   const virtuosoRef = useRef<VirtuosoHandle>(null);
 
+  // Track if we've done initial scroll to bottom for this conversation
+  const hasScrolledToBottomRef = useRef(false);
+
+  // Reset scroll tracking when conversation changes
+  useEffect(() => {
+    hasScrolledToBottomRef.current = false;
+  }, [conversation?.id]);
+
+  // Scroll to bottom when messages first load (handles async loading)
+  useEffect(() => {
+    if (
+      messagesWithMarkers &&
+      messagesWithMarkers.length > 0 &&
+      !hasScrolledToBottomRef.current &&
+      virtuosoRef.current
+    ) {
+      // Use requestAnimationFrame to ensure DOM is ready
+      requestAnimationFrame(() => {
+        virtuosoRef.current?.scrollToIndex({
+          index: messagesWithMarkers.length - 1,
+          align: "end",
+          behavior: "auto",
+        });
+        hasScrolledToBottomRef.current = true;
+      });
+    }
+  }, [messagesWithMarkers]);
+
   // State for send in progress (prevents double-sends)
   const [isSending, setIsSending] = useState(false);
 


### PR DESCRIPTION
Change Virtuoso followOutput from "smooth" to "auto" so new messages appear instantly at the bottom rather than slowly animating into view.