### PR TITLE
feat: Add root context display to NIP-22 comment renderer

### DIFF
--- a/src/components/ThreadViewer.tsx
+++ b/src/components/ThreadViewer.tsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from "react";
+import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { KindRenderer } from "./nostr/kinds";
+import { EventErrorBoundary } from "./EventErrorBoundary";
+import { EventDetailSkeleton } from "@/components/ui/skeleton";
+import type { NostrEvent } from "@/types/nostr";
+import { use$ } from "applesauce-react/hooks";
+import eventStore from "@/services/event-store";
+import {
+  getCommentRootPointer,
+  getCommentReplyPointer,
+  isCommentEventPointer,
+  isCommentAddressPointer,
+} from "applesauce-common/helpers/comment";
+import { ChevronDown, ChevronRight, MessageCircle } from "lucide-react";
+import { UserName } from "./nostr/UserName";
+import { RichText } from "./nostr/RichText";
+import { BaseEventContainer } from "./nostr/kinds/BaseEventRenderer";
+import { formatDistanceToNow } from "date-fns";
+
+export interface ThreadViewerProps {
+  pointer: EventPointer | AddressPointer;
+  focusEventId?: string; // Optional: Event ID to focus/scroll to
+}
+
+interface CommentNode {
+  event: NostrEvent;
+  children: CommentNode[];
+  depth: number;
+}
+
+/**
+ * Check if a comment's root matches the given pointer
+ */
+function isRootMatch(
+  comment: NostrEvent,
+  pointer: EventPointer | AddressPointer,
+): boolean {
+  const rootPointer = getCommentRootPointer(comment);
+  if (!rootPointer) return false;
+
+  // Check event pointer match
+  if ("id" in pointer && isCommentEventPointer(rootPointer)) {
+    return rootPointer.id === pointer.id;
+  }
+
+  // Check address pointer match
+  if (
+    "kind" in pointer &&
+    "pubkey" in pointer &&
+    "identifier" in pointer &&
+    isCommentAddressPointer(rootPointer)
+  ) {
+    return (
+      rootPointer.kind === pointer.kind &&
+      rootPointer.pubkey === pointer.pubkey &&
+      rootPointer.identifier === pointer.identifier
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Build a comment tree from a flat list of NIP-22 comments
+ */
+function buildCommentTree(
+  comments: NostrEvent[],
+  rootPointer: EventPointer | AddressPointer,
+): CommentNode[] {
+  // Filter comments that belong to this root
+  const relevantComments = comments.filter((c) => isRootMatch(c, rootPointer));
+
+  // Build a map of event ID to comment
+  const commentMap = new Map<string, NostrEvent>();
+  relevantComments.forEach((c) => commentMap.set(c.id, c));
+
+  // Build nodes
+  const nodes = new Map<string, CommentNode>();
+  relevantComments.forEach((event) => {
+    nodes.set(event.id, { event, children: [], depth: 0 });
+  });
+
+  // Organize into tree structure
+  const rootNodes: CommentNode[] = [];
+
+  relevantComments.forEach((comment) => {
+    const node = nodes.get(comment.id);
+    if (!node) return;
+
+    const parentPointer = getCommentReplyPointer(comment);
+    const rootCheckPointer = getCommentRootPointer(comment);
+
+    // Check if this is a top-level comment (parent === root)
+    const isTopLevel =
+      parentPointer &&
+      rootCheckPointer &&
+      JSON.stringify(parentPointer) === JSON.stringify(rootCheckPointer);
+
+    if (isTopLevel) {
+      // Top-level comment
+      rootNodes.push(node);
+    } else if (parentPointer && isCommentEventPointer(parentPointer)) {
+      // Reply to another comment
+      const parentNode = nodes.get(parentPointer.id);
+      if (parentNode) {
+        node.depth = parentNode.depth + 1;
+        parentNode.children.push(node);
+      } else {
+        // Parent comment not found (maybe not loaded yet), treat as top-level
+        rootNodes.push(node);
+      }
+    } else {
+      // Fallback: treat as top-level
+      rootNodes.push(node);
+    }
+  });
+
+  // Sort by created_at (oldest first)
+  const sortByCreatedAt = (a: CommentNode, b: CommentNode) =>
+    a.event.created_at - b.event.created_at;
+
+  rootNodes.sort(sortByCreatedAt);
+  nodes.forEach((node) => node.children.sort(sortByCreatedAt));
+
+  return rootNodes;
+}
+
+/**
+ * Single comment renderer with expandable replies
+ */
+function CommentReply({
+  node,
+  focusEventId,
+}: {
+  node: CommentNode;
+  focusEventId?: string;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const isFocused = focusEventId === node.event.id;
+
+  const hasReplies = node.children.length > 0;
+  const timeAgo = formatDistanceToNow(node.event.created_at * 1000, {
+    addSuffix: true,
+  });
+
+  return (
+    <div
+      className={`border-l-2 pl-3 ${
+        isFocused ? "border-accent" : "border-border"
+      }`}
+    >
+      {/* Comment Header */}
+      <div className="flex items-center gap-2 mb-1">
+        {hasReplies && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="p-0.5 hover:bg-muted rounded transition-colors"
+            aria-label={expanded ? "Collapse" : "Expand"}
+          >
+            {expanded ? (
+              <ChevronDown className="size-3" />
+            ) : (
+              <ChevronRight className="size-3" />
+            )}
+          </button>
+        )}
+        {!hasReplies && <div className="w-4" />}
+
+        <UserName
+          pubkey={node.event.pubkey}
+          className="font-semibold text-sm"
+        />
+        <span className="text-xs text-muted-foreground">{timeAgo}</span>
+        {hasReplies && (
+          <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <MessageCircle className="size-3" />
+            {node.children.length}
+          </span>
+        )}
+      </div>
+
+      {/* Comment Content */}
+      <div className="mb-2">
+        <RichText event={node.event} className="text-sm" />
+      </div>
+
+      {/* Nested Replies */}
+      {hasReplies && expanded && (
+        <div className="space-y-3 mt-2">
+          {node.children.map((child) => (
+            <CommentReply
+              key={child.event.id}
+              node={child}
+              focusEventId={focusEventId}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * ThreadViewer - Display a NIP-22 comment thread
+ * Shows root event + tree of comments
+ */
+export function ThreadViewer({ pointer, focusEventId }: ThreadViewerProps) {
+  const rootEvent = useNostrEvent(pointer);
+
+  // Build filter for comments on this event
+  const commentsFilter = useMemo(() => {
+    if (!rootEvent) return null;
+
+    // Build filter based on pointer type
+    if ("id" in pointer) {
+      // Event pointer: look for comments with E tag matching this ID
+      return [
+        {
+          kinds: [1111],
+          "#E": [pointer.id],
+        },
+      ];
+    } else {
+      // Address pointer: look for comments with A tag matching this address
+      const aTag = `${pointer.kind}:${pointer.pubkey}:${pointer.identifier}`;
+      return [
+        {
+          kinds: [1111],
+          "#A": [aTag],
+        },
+      ];
+    }
+  }, [rootEvent, pointer]);
+
+  // Fetch comments timeline and subscribe to events
+  const comments = use$(() => {
+    if (!commentsFilter) return undefined;
+    return eventStore.timeline(commentsFilter);
+  }, [commentsFilter]);
+
+  // Build comment tree
+  const commentTree = useMemo(() => {
+    if (!rootEvent || !comments) return [];
+    return buildCommentTree(comments, pointer);
+  }, [comments, rootEvent, pointer]);
+
+  // Loading state
+  if (!rootEvent) {
+    return (
+      <div className="flex flex-col h-full p-8">
+        <EventDetailSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Root Event */}
+      <div className="border-b border-border">
+        <EventErrorBoundary event={rootEvent}>
+          <BaseEventContainer event={rootEvent}>
+            <KindRenderer event={rootEvent} depth={0} />
+          </BaseEventContainer>
+        </EventErrorBoundary>
+      </div>
+
+      {/* Comment Thread */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {commentTree.length === 0 ? (
+          <div className="text-center text-muted-foreground py-8">
+            <MessageCircle className="size-8 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">No comments yet</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="text-xs text-muted-foreground mb-3">
+              {commentTree.length} top-level{" "}
+              {commentTree.length === 1 ? "comment" : "comments"}
+            </div>
+            {commentTree.map((node) => (
+              <CommentReply
+                key={node.event.id}
+                node={node}
+                focusEventId={focusEventId}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -12,6 +12,9 @@ const ReqViewer = lazy(() => import("./ReqViewer"));
 const EventDetailViewer = lazy(() =>
   import("./EventDetailViewer").then((m) => ({ default: m.EventDetailViewer })),
 );
+const ThreadViewer = lazy(() =>
+  import("./ThreadViewer").then((m) => ({ default: m.ThreadViewer })),
+);
 const ProfileViewer = lazy(() =>
   import("./ProfileViewer").then((m) => ({ default: m.ProfileViewer })),
 );
@@ -169,6 +172,14 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
         break;
       case "open":
         content = <EventDetailViewer pointer={window.props.pointer} />;
+        break;
+      case "thread":
+        content = (
+          <ThreadViewer
+            pointer={window.props.pointer}
+            focusEventId={window.props.focusEventId}
+          />
+        );
         break;
       case "profile":
         content = <ProfileViewer pubkey={window.props.pubkey} />;

--- a/src/components/nostr/kinds/BaseEventRenderer.tsx
+++ b/src/components/nostr/kinds/BaseEventRenderer.tsx
@@ -10,7 +10,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Menu, Copy, Check, FileJson, ExternalLink } from "lucide-react";
+import {
+  Menu,
+  Copy,
+  Check,
+  FileJson,
+  ExternalLink,
+  MessageCircle,
+} from "lucide-react";
 import { useGrimoire } from "@/core/state";
 import { useCopy } from "@/hooks/useCopy";
 import { JsonViewer } from "@/components/JsonViewer";
@@ -126,6 +133,27 @@ export function EventMenu({ event }: { event: NostrEvent }) {
     addWindow("open", { pointer });
   };
 
+  const openThread = () => {
+    let pointer;
+    // For replaceable/parameterized replaceable events, use AddressPointer
+    if (isAddressableKind(event.kind)) {
+      // Find d-tag for identifier
+      const dTag = getTagValue(event, "d") || "";
+      pointer = {
+        kind: event.kind,
+        pubkey: event.pubkey,
+        identifier: dTag,
+      };
+    } else {
+      // For regular events, use EventPointer
+      pointer = {
+        id: event.id,
+      };
+    }
+
+    addWindow("thread", { pointer });
+  };
+
   const copyEventId = () => {
     // Get relay hints from where the event has been seen
     const seenRelaysSet = getSeenRelays(event);
@@ -180,6 +208,10 @@ export function EventMenu({ event }: { event: NostrEvent }) {
         <DropdownMenuItem onClick={openEventDetail}>
           <ExternalLink className="size-4 mr-2" />
           Open
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={openThread}>
+          <MessageCircle className="size-4 mr-2" />
+          Thread
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={copyEventId}>

--- a/src/lib/write-relay-selection.test.ts
+++ b/src/lib/write-relay-selection.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  sanitizeRelays,
+  normalizeAndDedupe,
+  getWriteRelaysForPubkey,
+  getRelaysWhereEventSeen,
+  combineRelayStrategies,
+  getOptimalWriteRelays,
+  FALLBACK_RELAYS,
+  type WriteRelaySelectionResult,
+} from "./write-relay-selection";
+import type { NostrEvent } from "@/types/nostr";
+import eventStore from "@/services/event-store";
+
+// Mock modules
+vi.mock("@/services/event-store", () => ({
+  default: {
+    getReplaceable: vi.fn(),
+  },
+}));
+
+vi.mock("applesauce-core/helpers/relays", () => ({
+  getSeenRelays: vi.fn(),
+}));
+
+vi.mock("applesauce-core/helpers", () => ({
+  getOutboxes: vi.fn(),
+  normalizeURL: vi.fn((url: string) => {
+    // Simple normalization for testing
+    const normalized = url.toLowerCase().replace(/\/+$/, "");
+    if (!normalized.startsWith("ws://") && !normalized.startsWith("wss://")) {
+      throw new Error("Invalid URL");
+    }
+    return normalized;
+  }),
+}));
+
+// Import mocked functions for type safety
+import { getSeenRelays } from "applesauce-core/helpers/relays";
+import { getOutboxes } from "applesauce-core/helpers";
+
+describe("sanitizeRelays", () => {
+  it("should remove localhost relays", () => {
+    const input = [
+      "wss://relay.damus.io",
+      "ws://localhost:7777",
+      "wss://127.0.0.1:8080",
+      "ws://[::1]:9000",
+    ];
+    const result = sanitizeRelays(input);
+    expect(result).toEqual(["wss://relay.damus.io"]);
+  });
+
+  it("should remove TOR relays", () => {
+    const input = [
+      "wss://relay.damus.io",
+      "wss://something.onion",
+      "ws://test.ONION",
+    ];
+    const result = sanitizeRelays(input);
+    expect(result).toEqual(["wss://relay.damus.io"]);
+  });
+
+  it("should keep normal relays", () => {
+    const input = [
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+      "wss://relay.nostr.band",
+    ];
+    const result = sanitizeRelays(input);
+    expect(result).toEqual(input);
+  });
+
+  it("should handle empty array", () => {
+    expect(sanitizeRelays([])).toEqual([]);
+  });
+});
+
+describe("normalizeAndDedupe", () => {
+  it("should normalize URLs", () => {
+    const input = ["wss://relay.damus.io/", "wss://relay.damus.io"];
+    const result = normalizeAndDedupe(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe("wss://relay.damus.io");
+  });
+
+  it("should remove duplicates after normalization", () => {
+    const input = [
+      "wss://relay.damus.io",
+      "wss://relay.damus.io/",
+      "wss://nos.lol",
+      "wss://nos.lol/",
+    ];
+    const result = normalizeAndDedupe(input);
+    expect(result).toHaveLength(2);
+    expect(result).toContain("wss://relay.damus.io");
+    expect(result).toContain("wss://nos.lol");
+  });
+
+  it("should skip invalid URLs", () => {
+    const input = ["wss://relay.damus.io", "not-a-url", "wss://nos.lol"];
+    const result = normalizeAndDedupe(input);
+    // Result may include valid URLs only - exact count depends on normalizeURL implementation
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain("wss://relay.damus.io");
+    expect(result).toContain("wss://nos.lol");
+    // Should not contain invalid URL
+    expect(
+      result.every(
+        (url) => url.startsWith("wss://") || url.startsWith("ws://"),
+      ),
+    ).toBe(true);
+  });
+
+  it("should handle empty array", () => {
+    expect(normalizeAndDedupe([])).toEqual([]);
+  });
+});
+
+describe("getWriteRelaysForPubkey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return relays from NIP-65 relay list", () => {
+    const pubkey = "abc123";
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [
+        ["r", "wss://relay1.com", "write"],
+        ["r", "wss://relay2.com", "write"],
+      ],
+    } as unknown as NostrEvent;
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(
+      new Set(["wss://relay1.com", "wss://relay2.com"]),
+    );
+
+    const result = getWriteRelaysForPubkey(pubkey);
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).toContain("wss://relay2.com");
+    expect(result.strategy).toBe("pubkey-outbox");
+    expect(result.sources).toEqual([pubkey]);
+  });
+
+  it("should use fallback when no relay list found", () => {
+    const pubkey = "abc123";
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(undefined);
+
+    const result = getWriteRelaysForPubkey(pubkey);
+
+    expect(result.relays).toEqual(FALLBACK_RELAYS.slice(0, 5));
+    expect(result.strategy).toBe("fallback");
+    expect(result.sources).toEqual([]);
+  });
+
+  it("should respect maxRelays option", () => {
+    const pubkey = "abc123";
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(
+      new Set([
+        "wss://relay1.com",
+        "wss://relay2.com",
+        "wss://relay3.com",
+        "wss://relay4.com",
+        "wss://relay5.com",
+      ]),
+    );
+
+    const result = getWriteRelaysForPubkey(pubkey, { maxRelays: 2 });
+
+    expect(result.relays).toHaveLength(2);
+  });
+
+  it("should sanitize relays when requested", () => {
+    const pubkey = "abc123";
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(
+      new Set(["wss://relay1.com", "ws://localhost:7777", "wss://test.onion"]),
+    );
+
+    const result = getWriteRelaysForPubkey(pubkey, { sanitize: true });
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).not.toContain("ws://localhost:7777");
+    expect(result.relays).not.toContain("wss://test.onion");
+  });
+
+  it("should add fallback when insufficient relays", () => {
+    const pubkey = "abc123";
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(new Set(["wss://relay1.com"]));
+
+    const result = getWriteRelaysForPubkey(pubkey, { includeFallback: true });
+
+    expect(result.relays.length).toBeGreaterThan(1);
+    expect(result.relays).toContain("wss://relay1.com");
+    // Should include some fallback relays
+    const hasFallback = result.relays.some((r) =>
+      FALLBACK_RELAYS.includes(r as any),
+    );
+    expect(hasFallback).toBe(true);
+  });
+
+  it("should not add fallback when includeFallback is false", () => {
+    const pubkey = "abc123";
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(new Set(["wss://relay1.com"]));
+
+    const result = getWriteRelaysForPubkey(pubkey, { includeFallback: false });
+
+    expect(result.relays).toEqual(["wss://relay1.com"]);
+  });
+});
+
+describe("getRelaysWhereEventSeen", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return relays where event was seen", () => {
+    const event = {
+      id: "event123",
+      pubkey: "abc123",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    vi.mocked(getSeenRelays).mockReturnValue(
+      new Set(["wss://relay1.com", "wss://relay2.com"]),
+    );
+
+    const result = getRelaysWhereEventSeen(event);
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).toContain("wss://relay2.com");
+    expect(result.strategy).toBe("event-seen");
+    expect(result.sources).toEqual([event.pubkey]);
+  });
+
+  it("should use fallback when no seen relays", () => {
+    const event = {
+      id: "event123",
+      pubkey: "abc123",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    vi.mocked(getSeenRelays).mockReturnValue(undefined);
+
+    const result = getRelaysWhereEventSeen(event);
+
+    expect(result.relays).toEqual(FALLBACK_RELAYS.slice(0, 5));
+  });
+
+  it("should respect maxRelays option", () => {
+    const event = {
+      id: "event123",
+      pubkey: "abc123",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    vi.mocked(getSeenRelays).mockReturnValue(
+      new Set([
+        "wss://relay1.com",
+        "wss://relay2.com",
+        "wss://relay3.com",
+        "wss://relay4.com",
+      ]),
+    );
+
+    const result = getRelaysWhereEventSeen(event, { maxRelays: 2 });
+
+    expect(result.relays).toHaveLength(2);
+  });
+});
+
+describe("combineRelayStrategies", () => {
+  it("should merge relays from multiple sources", () => {
+    const source1: WriteRelaySelectionResult = {
+      relays: ["wss://relay1.com", "wss://relay2.com"],
+      strategy: "event-seen",
+      sources: ["pubkey1"],
+    };
+
+    const source2: WriteRelaySelectionResult = {
+      relays: ["wss://relay3.com", "wss://relay4.com"],
+      strategy: "pubkey-outbox",
+      sources: ["pubkey2"],
+    };
+
+    const result = combineRelayStrategies([source1, source2]);
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).toContain("wss://relay2.com");
+    expect(result.relays).toContain("wss://relay3.com");
+    expect(result.relays).toContain("wss://relay4.com");
+    expect(result.strategy).toBe("combined");
+    expect(result.sources).toContain("pubkey1");
+    expect(result.sources).toContain("pubkey2");
+  });
+
+  it("should deduplicate relays", () => {
+    const source1: WriteRelaySelectionResult = {
+      relays: ["wss://relay1.com", "wss://relay2.com"],
+      strategy: "event-seen",
+      sources: ["pubkey1"],
+    };
+
+    const source2: WriteRelaySelectionResult = {
+      relays: ["wss://relay2.com", "wss://relay3.com"],
+      strategy: "pubkey-outbox",
+      sources: ["pubkey2"],
+    };
+
+    const result = combineRelayStrategies([source1, source2]);
+
+    expect(result.relays).toHaveLength(3);
+    expect(result.relays.filter((r) => r === "wss://relay2.com")).toHaveLength(
+      1,
+    );
+  });
+
+  it("should preserve order (event-seen first)", () => {
+    const source1: WriteRelaySelectionResult = {
+      relays: ["wss://relay1.com"],
+      strategy: "event-seen",
+      sources: ["pubkey1"],
+    };
+
+    const source2: WriteRelaySelectionResult = {
+      relays: ["wss://relay2.com"],
+      strategy: "pubkey-outbox",
+      sources: ["pubkey2"],
+    };
+
+    const result = combineRelayStrategies([source1, source2]);
+
+    expect(result.relays[0]).toBe("wss://relay1.com");
+    expect(result.relays[1]).toBe("wss://relay2.com");
+  });
+
+  it("should respect maxRelays option", () => {
+    const source1: WriteRelaySelectionResult = {
+      relays: ["wss://relay1.com", "wss://relay2.com"],
+      strategy: "event-seen",
+      sources: ["pubkey1"],
+    };
+
+    const source2: WriteRelaySelectionResult = {
+      relays: ["wss://relay3.com", "wss://relay4.com"],
+      strategy: "pubkey-outbox",
+      sources: ["pubkey2"],
+    };
+
+    const result = combineRelayStrategies([source1, source2], {
+      maxRelays: 2,
+    });
+
+    expect(result.relays).toHaveLength(2);
+  });
+});
+
+describe("getOptimalWriteRelays", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should prioritize event-seen over pubkey relays", () => {
+    const pubkey = "abc123";
+    const relatedEvent = {
+      id: "event123",
+      pubkey: "other123",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    vi.mocked(getSeenRelays).mockReturnValue(
+      new Set(["wss://event-relay.com"]),
+    );
+
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(new Set(["wss://pubkey-relay.com"]));
+
+    const result = getOptimalWriteRelays(pubkey, [relatedEvent], {
+      maxRelays: 10,
+      includeFallback: false,
+    });
+
+    // Event-seen relay should come first
+    expect(result.relays[0]).toBe("wss://event-relay.com");
+    expect(result.relays).toContain("wss://pubkey-relay.com");
+    expect(result.strategy).toBe("combined");
+  });
+
+  it("should work with no related events", () => {
+    const pubkey = "abc123";
+
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(
+      new Set(["wss://relay1.com", "wss://relay2.com"]),
+    );
+
+    const result = getOptimalWriteRelays(pubkey, [], {
+      includeFallback: false,
+    });
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).toContain("wss://relay2.com");
+  });
+
+  it("should combine multiple related events", () => {
+    const pubkey = "abc123";
+    const event1 = {
+      id: "event1",
+      pubkey: "other1",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    const event2 = {
+      id: "event2",
+      pubkey: "other2",
+      kind: 1,
+      content: "test",
+      tags: [],
+      created_at: 123456,
+      sig: "sig",
+    } as NostrEvent;
+
+    vi.mocked(getSeenRelays)
+      .mockReturnValueOnce(new Set(["wss://relay1.com"]))
+      .mockReturnValueOnce(new Set(["wss://relay2.com"]));
+
+    const mockRelayList = {
+      kind: 10002,
+      pubkey,
+      tags: [],
+    } as unknown as NostrEvent;
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(mockRelayList);
+    vi.mocked(getOutboxes).mockReturnValue(new Set(["wss://relay3.com"]));
+
+    const result = getOptimalWriteRelays(pubkey, [event1, event2], {
+      maxRelays: 10,
+      includeFallback: false,
+    });
+
+    expect(result.relays).toContain("wss://relay1.com");
+    expect(result.relays).toContain("wss://relay2.com");
+    expect(result.relays).toContain("wss://relay3.com");
+  });
+
+  it("should add fallback when enabled", () => {
+    const pubkey = "abc123";
+
+    vi.mocked(eventStore.getReplaceable).mockReturnValue(undefined);
+
+    const result = getOptimalWriteRelays(pubkey, [], {
+      maxRelays: 3,
+      includeFallback: true,
+    });
+
+    expect(result.relays.length).toBeGreaterThan(0);
+    const hasFallback = result.relays.some((r) =>
+      FALLBACK_RELAYS.includes(r as any),
+    );
+    expect(hasFallback).toBe(true);
+  });
+});

--- a/src/lib/write-relay-selection.ts
+++ b/src/lib/write-relay-selection.ts
@@ -1,0 +1,340 @@
+/**
+ * Write Relay Selection Utilities
+ *
+ * Core infrastructure for selecting optimal relays to publish events.
+ * Provides multiple selection strategies that can be combined:
+ * - Pubkey-based: Use author's NIP-65 outbox relays (where they publish)
+ * - Seen-based: Use relays where related events were seen
+ * - Fallback: Use well-known aggregator relays
+ *
+ * All utilities are pure functions for easy testing and composition.
+ */
+
+import type { NostrEvent } from "@/types/nostr";
+import { getSeenRelays } from "applesauce-core/helpers/relays";
+import { getOutboxes } from "applesauce-core/helpers";
+import { normalizeRelayURL } from "./relay-url";
+import eventStore from "@/services/event-store";
+
+/**
+ * Well-known aggregator relays for fallback
+ * These relays are highly available and accept most events
+ */
+export const FALLBACK_RELAYS = [
+  "wss://relay.damus.io",
+  "wss://relay.nostr.band",
+  "wss://nos.lol",
+  "wss://relay.primal.net",
+] as const;
+
+/**
+ * Result of relay selection with reasoning
+ */
+export interface WriteRelaySelectionResult {
+  /** Selected relay URLs (normalized) */
+  relays: string[];
+  /** Reasoning for why these relays were selected */
+  strategy: WriteRelayStrategy;
+  /** Source pubkeys that contributed relays */
+  sources: string[];
+}
+
+/**
+ * Strategy used for relay selection
+ */
+export type WriteRelayStrategy =
+  | "pubkey-outbox" // From NIP-65 relay lists
+  | "event-seen" // From where events were observed
+  | "combined" // Multiple strategies merged
+  | "fallback"; // Default aggregators
+
+/**
+ * Options for relay selection
+ */
+export interface WriteRelaySelectionOptions {
+  /** Maximum number of relays to return */
+  maxRelays?: number;
+  /** Filter out localhost/tor relays */
+  sanitize?: boolean;
+  /** Include fallback relays if insufficient relays found */
+  includeFallback?: boolean;
+}
+
+/**
+ * Sanitizes relay URLs by removing localhost and TOR relays
+ *
+ * @param relays - Array of relay URLs
+ * @returns Filtered array without localhost or TOR relays
+ *
+ * @example
+ * sanitizeRelays(["wss://relay.damus.io", "ws://localhost:7777"])
+ * // => ["wss://relay.damus.io"]
+ */
+export function sanitizeRelays(relays: string[]): string[] {
+  return relays.filter((url) => {
+    // Remove localhost relays
+    if (/^wss?:\/\/(localhost|127\.0\.0\.1|\[::1\])/i.test(url)) {
+      return false;
+    }
+    // Remove TOR relays (*.onion)
+    if (/\.onion/i.test(url)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Normalizes and deduplicates relay URLs
+ *
+ * @param relays - Array of potentially unnormalized relay URLs
+ * @returns Array of normalized, deduplicated URLs
+ *
+ * @example
+ * normalizeAndDedupe(["wss://relay.damus.io/", "wss://relay.damus.io"])
+ * // => ["wss://relay.damus.io"]
+ */
+export function normalizeAndDedupe(relays: string[]): string[] {
+  const normalized = new Set<string>();
+
+  for (const relay of relays) {
+    try {
+      const normalizedUrl = normalizeRelayURL(relay);
+      normalized.add(normalizedUrl);
+    } catch (err) {
+      // Skip invalid URLs
+      console.debug(
+        `[WriteRelaySelection] Skipping invalid URL: ${relay}`,
+        err,
+      );
+    }
+  }
+
+  return Array.from(normalized);
+}
+
+/**
+ * Gets write relays for a pubkey from their NIP-65 relay list (kind 10002)
+ *
+ * @param pubkey - Hex pubkey to get write relays for
+ * @param options - Selection options
+ * @returns Write relay selection result
+ *
+ * @example
+ * const result = getWriteRelaysForPubkey("abc123...");
+ * console.log(result.relays); // ["wss://relay1.com", "wss://relay2.com"]
+ * console.log(result.strategy); // "pubkey-outbox"
+ */
+export function getWriteRelaysForPubkey(
+  pubkey: string,
+  options: WriteRelaySelectionOptions = {},
+): WriteRelaySelectionResult {
+  const { maxRelays = 5, sanitize = true, includeFallback = true } = options;
+
+  // Get relay list from event store (synchronous)
+  const relayListEvent = eventStore.getReplaceable(10002, pubkey, "");
+
+  if (!relayListEvent) {
+    // No relay list found - use fallback
+    if (includeFallback) {
+      return {
+        relays: FALLBACK_RELAYS.slice(0, maxRelays),
+        strategy: "fallback",
+        sources: [],
+      };
+    }
+    return {
+      relays: [],
+      strategy: "pubkey-outbox",
+      sources: [],
+    };
+  }
+
+  // Extract outbox (write) relays
+  let relays = Array.from(getOutboxes(relayListEvent));
+
+  // Normalize and deduplicate
+  relays = normalizeAndDedupe(relays);
+
+  // Sanitize if requested
+  if (sanitize) {
+    relays = sanitizeRelays(relays);
+  }
+
+  // Limit to max
+  relays = relays.slice(0, maxRelays);
+
+  // Add fallback if insufficient relays
+  if (includeFallback && relays.length < 2) {
+    const needed = Math.min(maxRelays - relays.length, FALLBACK_RELAYS.length);
+    const fallbacks = FALLBACK_RELAYS.slice(0, needed).filter(
+      (r) => !relays.includes(r),
+    );
+    relays = [...relays, ...fallbacks];
+  }
+
+  return {
+    relays,
+    strategy: "pubkey-outbox",
+    sources: [pubkey],
+  };
+}
+
+/**
+ * Gets relays where an event was seen
+ *
+ * @param event - Nostr event to get seen relays for
+ * @param options - Selection options
+ * @returns Write relay selection result
+ *
+ * @example
+ * const result = getRelaysWhereEventSeen(someEvent);
+ * console.log(result.relays); // ["wss://relay1.com", "wss://relay2.com"]
+ * console.log(result.strategy); // "event-seen"
+ */
+export function getRelaysWhereEventSeen(
+  event: NostrEvent,
+  options: WriteRelaySelectionOptions = {},
+): WriteRelaySelectionResult {
+  const { maxRelays = 5, sanitize = true, includeFallback = true } = options;
+
+  // Get relays where event was seen
+  const seenRelaysSet = getSeenRelays(event);
+  let relays = seenRelaysSet ? Array.from(seenRelaysSet) : [];
+
+  // Normalize and deduplicate
+  relays = normalizeAndDedupe(relays);
+
+  // Sanitize if requested
+  if (sanitize) {
+    relays = sanitizeRelays(relays);
+  }
+
+  // Limit to max
+  relays = relays.slice(0, maxRelays);
+
+  // Add fallback if insufficient relays
+  if (includeFallback && relays.length < 2) {
+    const needed = Math.min(maxRelays - relays.length, FALLBACK_RELAYS.length);
+    const fallbacks = FALLBACK_RELAYS.slice(0, needed).filter(
+      (r) => !relays.includes(r),
+    );
+    relays = [...relays, ...fallbacks];
+  }
+
+  return {
+    relays,
+    strategy: "event-seen",
+    sources: [event.pubkey],
+  };
+}
+
+/**
+ * Combines multiple relay selection strategies
+ *
+ * Merges relays from multiple sources, prioritizing:
+ * 1. Event seen relays (most relevant)
+ * 2. Pubkey outbox relays (where author publishes)
+ * 3. Fallback relays (if needed)
+ *
+ * @param sources - Array of selection results to combine
+ * @param options - Selection options
+ * @returns Combined write relay selection result
+ *
+ * @example
+ * const eventRelays = getRelaysWhereEventSeen(event);
+ * const authorRelays = getWriteRelaysForPubkey(event.pubkey);
+ * const combined = combineRelayStrategies([eventRelays, authorRelays]);
+ * console.log(combined.relays); // Merged and deduplicated
+ */
+export function combineRelayStrategies(
+  sources: WriteRelaySelectionResult[],
+  options: WriteRelaySelectionOptions = {},
+): WriteRelaySelectionResult {
+  const { maxRelays = 5, sanitize = true, includeFallback = true } = options;
+
+  // Merge all relays, preserving order (event-seen first)
+  const allRelays: string[] = [];
+  const allSources = new Set<string>();
+
+  for (const source of sources) {
+    for (const relay of source.relays) {
+      if (!allRelays.includes(relay)) {
+        allRelays.push(relay);
+      }
+    }
+    source.sources.forEach((s) => allSources.add(s));
+  }
+
+  let relays = allRelays;
+
+  // Sanitize if requested
+  if (sanitize) {
+    relays = sanitizeRelays(relays);
+  }
+
+  // Limit to max
+  relays = relays.slice(0, maxRelays);
+
+  // Add fallback if insufficient relays
+  if (includeFallback && relays.length < 2) {
+    const needed = Math.min(maxRelays - relays.length, FALLBACK_RELAYS.length);
+    const fallbacks = FALLBACK_RELAYS.slice(0, needed).filter(
+      (r) => !relays.includes(r),
+    );
+    relays = [...relays, ...fallbacks];
+  }
+
+  return {
+    relays,
+    strategy: "combined",
+    sources: Array.from(allSources),
+  };
+}
+
+/**
+ * Gets optimal write relays for publishing an event
+ *
+ * Uses combined strategy:
+ * 1. Relays where related events were seen
+ * 2. Author's outbox relays
+ * 3. Fallback to aggregators if needed
+ *
+ * @param pubkey - Author's pubkey
+ * @param relatedEvents - Related events to consider (optional)
+ * @param options - Selection options
+ * @returns Optimal write relay selection
+ *
+ * @example
+ * // For a reply to an existing event
+ * const relays = getOptimalWriteRelays(
+ *   myPubkey,
+ *   [parentEvent],
+ *   { maxRelays: 3 }
+ * );
+ *
+ * // For a new post
+ * const relays = getOptimalWriteRelays(myPubkey);
+ */
+export function getOptimalWriteRelays(
+  pubkey: string,
+  relatedEvents: NostrEvent[] = [],
+  options: WriteRelaySelectionOptions = {},
+): WriteRelaySelectionResult {
+  const sources: WriteRelaySelectionResult[] = [];
+
+  // 1. Get relays from related events (highest priority)
+  for (const event of relatedEvents) {
+    sources.push(
+      getRelaysWhereEventSeen(event, { ...options, includeFallback: false }),
+    );
+  }
+
+  // 2. Get author's outbox relays
+  sources.push(
+    getWriteRelaysForPubkey(pubkey, { ...options, includeFallback: false }),
+  );
+
+  // Combine all strategies
+  return combineRelayStrategies(sources, options);
+}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -11,6 +11,7 @@ export type AppId =
   | "count"
   //| "event"
   | "open"
+  | "thread"
   | "profile"
   | "encode"
   | "decode"

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -463,8 +463,34 @@ export const manPages: Record<string, ManPageEntry> = {
       "open naddr1qvzqqqrkvupzpn6956apxcad0mfp8grcuugdysg44eepex68h50t73zcathmfs49qy88wumn8ghj7mn0wvhxcmmv9uq3wamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmny9uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uq3qamnwvaz7tmwdaehgu3wd4hk6tcpz9mhxue69uhkummnw3ezuamfdejj7qghwaehxw309a3xjarrda5kuetj9eek7cmfv9kz7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3samnwvaz7tmxd9k8getj9ehx7um5wgh8w6twv5hszymhwden5te0danxvcmgv95kutnsw43z7qgawaehxw309ahx7um5wghxy6t5vdhkjmn9wgh8xmmrd9skctcpr9mhxue69uhhyetvv9ujuumwdae8gtnnda3kjctv9uqsuamnwvaz7tmev9382tndv5hsz9nhwden5te0wfjkccte9e3k76twdaeju6t09uq3vamnwvaz7tmjv4kxz7fwxvuns6np9eu8j730qqjr2vehvyenvdtr94nrzetr956rgctr94skvvfs95eryep3x3snwve389nxy97cjwx  Open addressable event",
       "open 30023:7fa56f5d6962ab1e3cd424e758c3002b8665f7b0d8dcee9fe9e288d7751ac194:grimoire  Open by address pointer (kind:pubkey:d-tag)",
     ],
-    seeAlso: ["req", "kind"],
+    seeAlso: ["req", "kind", "thread"],
     appId: "open",
+    category: "Nostr",
+    argParser: (args: string[]) => {
+      const parsed = parseOpenCommand(args);
+      return parsed;
+    },
+  },
+  thread: {
+    name: "thread",
+    section: "1",
+    synopsis: "thread <identifier>",
+    description:
+      "Display a NIP-22 comment thread for a Nostr event. Shows the root event at the top followed by an expandable tree of all NIP-22 comments (kind 1111). Threads use two-level expandable replies for easy navigation. If opened with a specific reply, that comment will be focused in the tree.",
+    options: [
+      {
+        flag: "<identifier>",
+        description:
+          "Event identifier in any supported format (note, nevent, naddr, hex ID, or kind:pubkey:d-tag)",
+      },
+    ],
+    examples: [
+      "thread nevent1...  View thread for an event with relay hints",
+      "thread naddr1...  View thread for an addressable event",
+      "thread abc123...  View thread for event by hex ID",
+    ],
+    seeAlso: ["open", "req"],
+    appId: "thread",
     category: "Nostr",
     argParser: (args: string[]) => {
       const parsed = parseOpenCommand(args);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,5 +27,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Enhances Kind1111Renderer to properly display both root context (what the comment thread is about) and parent reply (immediate parent comment) according to NIP-22 specification.

- Import and use getCommentRootPointer from applesauce-common
- Display root context with Hash icon and "Comment on" tooltip
- Display parent reply with Reply icon (only when different from root)
- Add arePointersEqual helper to detect top-level comments
- Update component documentation to reflect dual-context display

This implements the uppercase/lowercase tag distinction in NIP-22:
- Root scope (uppercase K, E, A, I, P tags) = conversation topic
- Parent item (lowercase k, e, a, i, p tags) = immediate reply target

Top-level comments (where root === parent) now show only one context card to avoid redundancy, while nested comments show both for full thread clarity.