### PR TITLE
feat: Add Grimoire welcome chat to suggested commands

### DIFF
--- a/src/components/GrimoireWelcome.tsx
+++ b/src/components/GrimoireWelcome.tsx
@@ -8,6 +8,10 @@ interface GrimoireWelcomeProps {
 }
 
 const EXAMPLE_COMMANDS = [
+  {
+    command: "chat groups.0xchat.com'NkeVhXuWHGKKJCpn",
+    description: "Join the Grimoire welcome chat",
+  },
   { command: "nip 29", description: "View relay-based groups spec" },
   {
     command: "profile fiatjaf.com",


### PR DESCRIPTION
Add "chat groups.0xchat.com'NkeVhXuWHGKKJCpn" as the first suggested command on the welcome screen to help new users discover and join the Grimoire community chat.