### PR TITLE
feat: Add npm install step to verify skill

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -2,9 +2,10 @@ Run full verification suite for the current changes.
 
 Execute these checks in sequence, stopping on first failure:
 
-1. **Lint Check**: `npm run lint`
-2. **Test Suite**: `npm run test:run`
-3. **Build Check**: `npm run build`
+1. **Install Dependencies**: `npm install`
+2. **Lint Check**: `npm run lint`
+3. **Test Suite**: `npm run test:run`
+4. **Build Check**: `npm run build`
 
 For each step:
 - If it passes, proceed to the next


### PR DESCRIPTION
Add npm install as the first step in the verification suite to ensure
all dependencies are installed before running lint, tests, and build.
This prevents failures due to missing or outdated dependencies.