### PR TITLE
feat: add @domain alias for NIP-05 domain directory resolution

### DIFF
--- a/src/components/ReqViewer.tsx
+++ b/src/components/ReqViewer.tsx
@@ -97,6 +97,8 @@ interface ReqViewerProps {
   view?: ViewMode;
   nip05Authors?: string[];
   nip05PTags?: string[];
+  domainAuthors?: string[];
+  domainPTags?: string[];
   needsAccount?: boolean;
   title?: string;
 }
@@ -105,9 +107,16 @@ interface QueryDropdownProps {
   filter: NostrFilter;
   nip05Authors?: string[];
   nip05PTags?: string[];
+  domainAuthors?: string[];
+  domainPTags?: string[];
 }
 
-function QueryDropdown({ filter, nip05Authors }: QueryDropdownProps) {
+function QueryDropdown({
+  filter,
+  nip05Authors,
+  domainAuthors,
+  domainPTags,
+}: QueryDropdownProps) {
   const { copy: handleCopy, copied } = useCopy();
 
   // Expandable lists state
@@ -271,6 +280,13 @@ function QueryDropdown({ filter, nip05Authors }: QueryDropdownProps) {
                       ))}
                     </div>
                   )}
+                  {domainAuthors && domainAuthors.length > 0 && (
+                    <div className="text-xs space-y-0.5 text-muted-foreground">
+                      {domainAuthors.map((domain) => (
+                        <div key={domain}>→ @{domain}</div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </AccordionContent>
             </AccordionItem>
@@ -310,6 +326,13 @@ function QueryDropdown({ filter, nip05Authors }: QueryDropdownProps) {
                         ? "Show less"
                         : `Show all ${pTagPubkeys.length}`}
                     </button>
+                  )}
+                  {domainPTags && domainPTags.length > 0 && (
+                    <div className="text-xs space-y-0.5 text-muted-foreground">
+                      {domainPTags.map((domain) => (
+                        <div key={domain}>→ @{domain}</div>
+                      ))}
+                    </div>
                   )}
                 </div>
               </AccordionContent>
@@ -610,6 +633,8 @@ export default function ReqViewer({
   view = "list",
   nip05Authors,
   nip05PTags,
+  domainAuthors,
+  domainPTags,
   needsAccount = false,
   title = "nostr-events",
 }: ReqViewerProps) {
@@ -1203,6 +1228,8 @@ export default function ReqViewer({
           filter={resolvedFilter}
           nip05Authors={nip05Authors}
           nip05PTags={nip05PTags}
+          domainAuthors={domainAuthors}
+          domainPTags={domainPTags}
         />
       )}
 

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -154,6 +154,8 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
             view={window.props.view}
             nip05Authors={window.props.nip05Authors}
             nip05PTags={window.props.nip05PTags}
+            domainAuthors={window.props.domainAuthors}
+            domainPTags={window.props.domainPTags}
             needsAccount={window.props.needsAccount}
           />
         );

--- a/src/lib/count-parser.ts
+++ b/src/lib/count-parser.ts
@@ -1,6 +1,6 @@
 import { nip19 } from "nostr-tools";
 import type { NostrFilter } from "@/types/nostr";
-import { isNip05 } from "./nip05";
+import { isNip05, isDomain } from "./nip05";
 import {
   isValidHexPubkey,
   isValidHexEventId,
@@ -14,6 +14,9 @@ export interface ParsedCountCommand {
   nip05Authors?: string[];
   nip05PTags?: string[];
   nip05PTagsUppercase?: string[];
+  domainAuthors?: string[];
+  domainPTags?: string[];
+  domainPTagsUppercase?: string[];
   needsAccount?: boolean;
 }
 
@@ -61,6 +64,9 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
   const nip05Authors = new Set<string>();
   const nip05PTags = new Set<string>();
   const nip05PTagsUppercase = new Set<string>();
+  const domainAuthors = new Set<string>();
+  const domainPTags = new Set<string>();
+  const domainPTagsUppercase = new Set<string>();
 
   // Use sets for deduplication during accumulation
   const kinds = new Set<number>();
@@ -133,6 +139,12 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
             if (normalized === "$me" || normalized === "$contacts") {
               authors.add(normalized);
               addedAny = true;
+            } else if (authorStr.startsWith("@")) {
+              const domain = authorStr.slice(1);
+              if (isDomain(domain)) {
+                domainAuthors.add(domain);
+                addedAny = true;
+              }
             } else if (isNip05(authorStr)) {
               nip05Authors.add(authorStr);
               addedAny = true;
@@ -198,6 +210,12 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
             if (normalized === "$me" || normalized === "$contacts") {
               pTags.add(normalized);
               addedAny = true;
+            } else if (pubkeyStr.startsWith("@")) {
+              const domain = pubkeyStr.slice(1);
+              if (isDomain(domain)) {
+                domainPTags.add(domain);
+                addedAny = true;
+              }
             } else if (isNip05(pubkeyStr)) {
               nip05PTags.add(pubkeyStr);
               addedAny = true;
@@ -229,6 +247,12 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
             if (normalized === "$me" || normalized === "$contacts") {
               pTagsUppercase.add(normalized);
               addedAny = true;
+            } else if (pubkeyStr.startsWith("@")) {
+              const domain = pubkeyStr.slice(1);
+              if (isDomain(domain)) {
+                domainPTagsUppercase.add(domain);
+                addedAny = true;
+              }
             } else if (isNip05(pubkeyStr)) {
               nip05PTagsUppercase.add(pubkeyStr);
               addedAny = true;
@@ -376,6 +400,13 @@ export function parseCountCommand(args: string[]): ParsedCountCommand {
     nip05PTagsUppercase:
       nip05PTagsUppercase.size > 0
         ? Array.from(nip05PTagsUppercase)
+        : undefined,
+    domainAuthors:
+      domainAuthors.size > 0 ? Array.from(domainAuthors) : undefined,
+    domainPTags: domainPTags.size > 0 ? Array.from(domainPTags) : undefined,
+    domainPTagsUppercase:
+      domainPTagsUppercase.size > 0
+        ? Array.from(domainPTagsUppercase)
         : undefined,
     needsAccount,
   };

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -5,7 +5,7 @@ import type { AppId } from "./app";
 import { parseOpenCommand } from "@/lib/open-parser";
 import { parseProfileCommand } from "@/lib/profile-parser";
 import { parseRelayCommand } from "@/lib/relay-parser";
-import { resolveNip05Batch } from "@/lib/nip05";
+import { resolveNip05Batch, resolveDomainDirectoryBatch } from "@/lib/nip05";
 import { parseChatCommand } from "@/lib/chat-parser";
 import { parseBlossomCommand } from "@/lib/blossom-parser";
 
@@ -318,6 +318,50 @@ export const manPages: Record<string, ManPageEntry> = {
         }
       }
 
+      // Resolve domain directories if present
+      const allDomains = [
+        ...(parsed.domainAuthors || []),
+        ...(parsed.domainPTags || []),
+        ...(parsed.domainPTagsUppercase || []),
+      ];
+
+      if (allDomains.length > 0) {
+        const resolved = await resolveDomainDirectoryBatch(allDomains);
+
+        // Add resolved authors to filter
+        if (parsed.domainAuthors) {
+          for (const domain of parsed.domainAuthors) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter.authors) parsed.filter.authors = [];
+              parsed.filter.authors.push(...pubkeys);
+            }
+          }
+        }
+
+        // Add resolved #p tags to filter
+        if (parsed.domainPTags) {
+          for (const domain of parsed.domainPTags) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter["#p"]) parsed.filter["#p"] = [];
+              parsed.filter["#p"].push(...pubkeys);
+            }
+          }
+        }
+
+        // Add resolved #P tags to filter
+        if (parsed.domainPTagsUppercase) {
+          for (const domain of parsed.domainPTagsUppercase) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter["#P"]) parsed.filter["#P"] = [];
+              parsed.filter["#P"].push(...pubkeys);
+            }
+          }
+        }
+      }
+
       return parsed;
     },
     defaultProps: { filter: { kinds: [1], limit: 50 } },
@@ -438,6 +482,47 @@ export const manPages: Record<string, ManPageEntry> = {
             if (pubkey) {
               if (!parsed.filter["#P"]) parsed.filter["#P"] = [];
               parsed.filter["#P"].push(pubkey);
+            }
+          }
+        }
+      }
+
+      // Resolve domain directories if present
+      const allDomains = [
+        ...(parsed.domainAuthors || []),
+        ...(parsed.domainPTags || []),
+        ...(parsed.domainPTagsUppercase || []),
+      ];
+
+      if (allDomains.length > 0) {
+        const resolved = await resolveDomainDirectoryBatch(allDomains);
+
+        if (parsed.domainAuthors) {
+          for (const domain of parsed.domainAuthors) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter.authors) parsed.filter.authors = [];
+              parsed.filter.authors.push(...pubkeys);
+            }
+          }
+        }
+
+        if (parsed.domainPTags) {
+          for (const domain of parsed.domainPTags) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter["#p"]) parsed.filter["#p"] = [];
+              parsed.filter["#p"].push(...pubkeys);
+            }
+          }
+        }
+
+        if (parsed.domainPTagsUppercase) {
+          for (const domain of parsed.domainPTagsUppercase) {
+            const pubkeys = resolved.get(domain);
+            if (pubkeys) {
+              if (!parsed.filter["#P"]) parsed.filter["#P"] = [];
+              parsed.filter["#P"].push(...pubkeys);
             }
           }
         }

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"errors":true,"version":"5.9.3"}
+{"root":["./vite.config.ts"],"version":"5.6.3"}


### PR DESCRIPTION
Add support for @domain syntax in req and count commands to query all
users from a domain's NIP-05 directory (e.g., @habla.news).

Features:
- Fetches /.well-known/nostr.json from domain
- Extracts all pubkeys from the names object
- Works with -a (authors), -p (#p tags), and -P (#P tags) flags
- Supports mixed usage with npub, hex, NIP-05, $me, $contacts
- 5-minute caching for domain lookups
- UI display in ReqViewer query dropdown

Implementation:
- Added resolveDomainDirectory and resolveDomainDirectoryBatch to nip05.ts
- Updated req-parser and count-parser to detect @domain syntax
- Updated argParsers in man.ts to resolve domains asynchronously
- Updated ReqViewer to display queried domains in dropdown
- Added comprehensive tests for domain resolution

Examples:
- req -k 1 -a @habla.news
- req -k 7 -p @nostr.band
- count relay.damus.io -k 1 -a @getcurrent.io