### PR TITLE
feat: add separate gradients for Grimoire members based on login state

### DIFF
--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -41,7 +41,7 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         isGrimoire
           ? isActiveAccount
             ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-blue-400 via-purple-500 to-purple-600 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-blue-400 via-purple-400 to-purple-500 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -15,7 +15,9 @@ interface UserNameProps {
  * Shows placeholder derived from pubkey while loading or if no profile exists
  * Clicking opens the user's profile
  * Uses highlight color for the logged-in user (themeable amber)
- * Shows Grimoire members with yellow-orange gradient styling
+ * Shows Grimoire members with gradient styling:
+ * - Orange-yellow gradient for logged-in Grimoire member
+ * - Purple-blue gradient for other Grimoire members
  */
 export function UserName({ pubkey, isMention, className }: UserNameProps) {
   const { addWindow, state } = useGrimoire();
@@ -37,7 +39,9 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
       className={cn(
         "font-semibold cursor-crosshair hover:underline hover:decoration-dotted",
         isGrimoire
-          ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
+          ? isActiveAccount
+            ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-purple-500 via-purple-600 to-cyan-500 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -40,22 +40,32 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
       dir="auto"
       className={cn(
         "font-semibold cursor-crosshair hover:underline hover:decoration-dotted inline-flex items-center gap-1",
-        isGrimoire
-          ? isActiveAccount
-            ? "bg-gradient-to-tr from-orange-400 to-amber-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-tr from-violet-500 to-fuchsia-600 bg-clip-text text-transparent"
-          : isActiveAccount
-            ? "text-highlight"
-            : "text-accent",
         className,
       )}
       onClick={handleClick}
     >
-      <span>
+      <span
+        className={cn(
+          isGrimoire
+            ? isActiveAccount
+              ? "bg-gradient-to-tr from-orange-400 to-amber-600 bg-clip-text text-transparent"
+              : "bg-gradient-to-tr from-violet-500 to-fuchsia-600 bg-clip-text text-transparent"
+            : isActiveAccount
+              ? "text-highlight"
+              : "text-accent",
+        )}
+      >
         {isMention ? "@" : null}
         {displayName}
       </span>
-      {isGrimoire && <BadgeCheck className="inline-block w-[1em] h-[1em]" />}
+      {isGrimoire && (
+        <BadgeCheck
+          className={cn(
+            "inline-block w-[1em] h-[1em]",
+            isActiveAccount ? "text-orange-500" : "text-violet-500",
+          )}
+        />
+      )}
     </span>
   );
 }

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -14,10 +14,10 @@ interface UserNameProps {
  * Component that displays a user's name from their Nostr profile
  * Shows placeholder derived from pubkey while loading or if no profile exists
  * Clicking opens the user's profile
- * Uses highlight color for the logged-in user (themeable amber)
+ * Uses highlight color for the logged-in user (themeable orange)
  * Shows Grimoire members with gradient styling:
- * - Orange-yellow gradient for logged-in Grimoire member
- * - Purple-blue gradient for other Grimoire members
+ * - Orange gradient for logged-in Grimoire member (matches highlight)
+ * - Purple-pink gradient for other Grimoire members (matches accent)
  */
 export function UserName({ pubkey, isMention, className }: UserNameProps) {
   const { addWindow, state } = useGrimoire();
@@ -40,8 +40,8 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         "font-semibold cursor-crosshair hover:underline hover:decoration-dotted",
         isGrimoire
           ? isActiveAccount
-            ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-blue-400 via-purple-400 to-purple-500 bg-clip-text text-transparent"
+            ? "bg-gradient-to-br from-orange-400 via-orange-500 to-amber-600 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-violet-500 via-purple-500 to-fuchsia-600 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -41,7 +41,7 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         isGrimoire
           ? isActiveAccount
             ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-purple-500 via-purple-600 to-cyan-500 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-purple-500 via-purple-600 to-blue-400 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -3,6 +3,7 @@ import { getDisplayName } from "@/lib/nostr-utils";
 import { cn } from "@/lib/utils";
 import { useGrimoire } from "@/core/state";
 import { isGrimoireMember } from "@/lib/grimoire-members";
+import { BadgeCheck } from "lucide-react";
 
 interface UserNameProps {
   pubkey: string;
@@ -15,9 +16,10 @@ interface UserNameProps {
  * Shows placeholder derived from pubkey while loading or if no profile exists
  * Clicking opens the user's profile
  * Uses highlight color for the logged-in user (themeable orange)
- * Shows Grimoire members with 4-color gradient styling:
- * - Yellow→Orange→Amber for logged-in member (bright shimmer at top)
- * - Violet→Purple→Fuchsia for other members (bright highlight at top)
+ * Shows Grimoire members with elegant 2-color gradient styling and badge check:
+ * - Orange→Amber gradient for logged-in member
+ * - Violet→Fuchsia gradient for other members
+ * - BadgeCheck icon that scales with username size
  */
 export function UserName({ pubkey, isMention, className }: UserNameProps) {
   const { addWindow, state } = useGrimoire();
@@ -37,11 +39,11 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
     <span
       dir="auto"
       className={cn(
-        "font-semibold cursor-crosshair hover:underline hover:decoration-dotted",
+        "font-semibold cursor-crosshair hover:underline hover:decoration-dotted inline-flex items-center gap-1",
         isGrimoire
           ? isActiveAccount
-            ? "bg-gradient-to-br from-yellow-300 via-orange-400 via-orange-500 to-amber-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-violet-400 via-violet-500 via-purple-500 to-fuchsia-600 bg-clip-text text-transparent"
+            ? "bg-gradient-to-tr from-orange-400 to-amber-600 bg-clip-text text-transparent"
+            : "bg-gradient-to-tr from-violet-500 to-fuchsia-600 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",
@@ -49,8 +51,11 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
       )}
       onClick={handleClick}
     >
-      {isMention ? "@" : null}
-      {displayName}
+      <span>
+        {isMention ? "@" : null}
+        {displayName}
+      </span>
+      {isGrimoire && <BadgeCheck className="inline-block w-[1em] h-[1em]" />}
     </span>
   );
 }

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -15,9 +15,9 @@ interface UserNameProps {
  * Shows placeholder derived from pubkey while loading or if no profile exists
  * Clicking opens the user's profile
  * Uses highlight color for the logged-in user (themeable orange)
- * Shows Grimoire members with gradient styling:
- * - Orange gradient for logged-in Grimoire member (matches highlight)
- * - Purple-pink gradient for other Grimoire members (matches accent)
+ * Shows Grimoire members with 4-color gradient styling:
+ * - Yellow→Orange→Amber for logged-in member (bright shimmer at top)
+ * - Violet→Purple→Fuchsia for other members (bright highlight at top)
  */
 export function UserName({ pubkey, isMention, className }: UserNameProps) {
   const { addWindow, state } = useGrimoire();
@@ -40,8 +40,8 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         "font-semibold cursor-crosshair hover:underline hover:decoration-dotted",
         isGrimoire
           ? isActiveAccount
-            ? "bg-gradient-to-br from-orange-400 via-orange-500 to-amber-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-violet-500 via-purple-500 to-fuchsia-600 bg-clip-text text-transparent"
+            ? "bg-gradient-to-br from-yellow-300 via-orange-400 via-orange-500 to-amber-600 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-violet-400 via-violet-500 via-purple-500 to-fuchsia-600 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -62,9 +62,7 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         <BadgeCheck
           className={cn(
             "inline-block w-[1em] h-[1em]",
-            isActiveAccount
-              ? "bg-gradient-to-tr from-amber-600 to-amber-400 bg-clip-text text-transparent"
-              : "bg-gradient-to-tr from-fuchsia-600 to-fuchsia-400 bg-clip-text text-transparent",
+            isActiveAccount ? "text-amber-500" : "text-fuchsia-500",
           )}
         />
       )}

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -62,7 +62,9 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         <BadgeCheck
           className={cn(
             "inline-block w-[1em] h-[1em]",
-            isActiveAccount ? "text-orange-500" : "text-violet-500",
+            isActiveAccount
+              ? "bg-gradient-to-tr from-amber-600 to-amber-400 bg-clip-text text-transparent"
+              : "bg-gradient-to-tr from-fuchsia-600 to-fuchsia-400 bg-clip-text text-transparent",
           )}
         />
       )}

--- a/src/components/nostr/UserName.tsx
+++ b/src/components/nostr/UserName.tsx
@@ -41,7 +41,7 @@ export function UserName({ pubkey, isMention, className }: UserNameProps) {
         isGrimoire
           ? isActiveAccount
             ? "bg-gradient-to-br from-yellow-500 via-orange-500 to-orange-600 bg-clip-text text-transparent"
-            : "bg-gradient-to-br from-purple-500 via-purple-600 to-blue-400 bg-clip-text text-transparent"
+            : "bg-gradient-to-br from-blue-400 via-purple-500 to-purple-600 bg-clip-text text-transparent"
           : isActiveAccount
             ? "text-highlight"
             : "text-accent",


### PR DESCRIPTION
Updates the UserName component to display different gradient colors for
Grimoire members depending on whether they are the logged-in user:
- Orange-yellow gradient for logged-in Grimoire members (current user)
- Purple-blue gradient for other Grimoire members (not logged in)

This visual distinction makes it easier to identify your own username
versus other Grimoire members in feeds and conversations.