### PR TITLE
feat: detect and display zap payments in NWC wallet viewer

### DIFF
--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -50,8 +50,6 @@ import {
 import ConnectWalletDialog from "./ConnectWalletDialog";
 import { RelayLink } from "@/components/nostr/RelayLink";
 import { parseZapRequest } from "@/lib/wallet-utils";
-import { useProfile } from "@/hooks/useProfile";
-import { getDisplayName } from "@/lib/nostr-utils";
 import { Zap } from "lucide-react";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { KindRenderer } from "./nostr/kinds";
@@ -310,9 +308,6 @@ function ZapTransactionDetail({ transaction }: { transaction: Transaction }) {
 function TransactionLabel({ transaction }: { transaction: Transaction }) {
   const zapInfo = parseZapRequest(transaction);
 
-  // Call hooks unconditionally (before conditional rendering)
-  const profile = useProfile(zapInfo?.sender);
-
   // Not a zap - use original description or default label
   if (!zapInfo) {
     return (
@@ -323,24 +318,20 @@ function TransactionLabel({ transaction }: { transaction: Transaction }) {
     );
   }
 
-  // It's a zap! Show username + message preview
-  const displayName = getDisplayName(zapInfo.sender, profile);
+  // It's a zap! Show username + message on one line
 
   return (
     <div className="flex items-center gap-2 min-w-0">
       <Zap className="size-3.5 flex-shrink-0 fill-zap text-zap" />
-      <div className="text-sm truncate min-w-0">
-        <span className="font-medium">{displayName}</span>
+      <div className="text-sm truncate min-w-0 flex items-center gap-1">
+        <UserName pubkey={zapInfo.sender} className="flex-shrink-0" />
         {zapInfo.message && (
-          <>
-            <span className="text-muted-foreground">: </span>
-            <span className="inline">
-              <RichText
-                content={zapInfo.message}
-                event={zapInfo.zapRequestEvent}
-              />
-            </span>
-          </>
+          <span className="truncate">
+            <RichText
+              content={zapInfo.message}
+              event={zapInfo.zapRequestEvent}
+            />
+          </span>
         )}
       </div>
     </div>
@@ -1201,12 +1192,12 @@ export default function WalletViewer() {
 
       {/* Transaction Detail Dialog */}
       <Dialog open={detailDialogOpen} onOpenChange={setDetailDialogOpen}>
-        <DialogContent className="max-h-[90vh] flex flex-col">
+        <DialogContent className="max-h-[70vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Transaction Details</DialogTitle>
           </DialogHeader>
 
-          <div className="overflow-y-auto max-h-[calc(90vh-8rem)] pr-2">
+          <div className="overflow-y-auto max-h-[calc(70vh-8rem)] pr-2">
             {selectedTransaction && (
               <div className="space-y-4">
                 <div className="flex items-center gap-3">

--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -323,10 +323,10 @@ function TransactionLabel({ transaction }: { transaction: Transaction }) {
   return (
     <div className="flex items-center gap-2 min-w-0">
       <Zap className="size-3.5 flex-shrink-0 fill-zap text-zap" />
-      <div className="text-sm truncate min-w-0 flex items-center gap-1">
+      <div className="text-sm min-w-0 flex items-center gap-2">
         <UserName pubkey={zapInfo.sender} className="flex-shrink-0" />
         {zapInfo.message && (
-          <span className="truncate">
+          <span className="truncate min-w-0">
             <RichText
               content={zapInfo.message}
               event={zapInfo.zapRequestEvent}

--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -91,7 +91,7 @@ interface InvoiceDetails {
   expiry?: number;
 }
 
-const BATCH_SIZE = 10; // Smaller pages for better performance with zap rendering
+const BATCH_SIZE = 20;
 const PAYMENT_CHECK_INTERVAL = 5000; // Check every 5 seconds
 
 /**

--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -91,7 +91,7 @@ interface InvoiceDetails {
   expiry?: number;
 }
 
-const BATCH_SIZE = 20;
+const BATCH_SIZE = 10; // Smaller pages for better performance with zap rendering
 const PAYMENT_CHECK_INTERVAL = 5000; // Check every 5 seconds
 
 /**

--- a/src/lib/wallet-utils.ts
+++ b/src/lib/wallet-utils.ts
@@ -13,6 +13,7 @@ export interface ZapRequestInfo {
   zappedEventId?: string; // ID of the zapped event (from e tag)
   zappedEventAddress?: string; // Address of the zapped event (from a tag)
   amount?: number; // amount in sats (if available)
+  zapRequestEvent: NostrEvent; // The full kind 9734 zap request event
 }
 
 // Symbol for caching parsed zap requests on transaction objects
@@ -79,6 +80,7 @@ export function parseZapRequest(transaction: {
         message: event.content || "",
         zappedEventId,
         zappedEventAddress,
+        zapRequestEvent: event,
       };
     } catch {
       // Not JSON or parsing failed - not a zap request

--- a/src/lib/wallet-utils.ts
+++ b/src/lib/wallet-utils.ts
@@ -6,6 +6,7 @@
 
 import { NostrEvent } from "@/types/nostr";
 import { getOrComputeCachedValue } from "applesauce-core/helpers";
+import { decode as decodeBolt11 } from "light-bolt11-decoder";
 
 export interface ZapRequestInfo {
   sender: string; // pubkey of the zapper
@@ -20,71 +21,101 @@ export interface ZapRequestInfo {
 const ZapRequestSymbol = Symbol("zapRequest");
 
 /**
+ * Try to parse a zap request JSON string into a ZapRequestInfo object
+ * @param jsonString - The JSON string to parse
+ * @returns ZapRequestInfo if valid zap request, null otherwise
+ */
+function tryParseZapRequestJson(jsonString: string): ZapRequestInfo | null {
+  try {
+    // Try to parse as JSON
+    const parsed = JSON.parse(jsonString);
+
+    // Check if it's a valid zap request (kind 9734)
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      parsed.kind !== 9734 ||
+      !parsed.pubkey ||
+      typeof parsed.pubkey !== "string"
+    ) {
+      return null;
+    }
+
+    const event = parsed as NostrEvent;
+
+    // Extract zapped event from tags
+    let zappedEventId: string | undefined;
+    let zappedEventAddress: string | undefined;
+
+    if (Array.isArray(event.tags)) {
+      // Look for e tag (event ID)
+      const eTag = event.tags.find(
+        (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "e",
+      );
+      if (eTag && typeof eTag[1] === "string") {
+        zappedEventId = eTag[1];
+      }
+
+      // Look for a tag (address/coordinate)
+      const aTag = event.tags.find(
+        (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "a",
+      );
+      if (aTag && typeof aTag[1] === "string") {
+        zappedEventAddress = aTag[1];
+      }
+    }
+
+    return {
+      sender: event.pubkey,
+      message: event.content || "",
+      zappedEventId,
+      zappedEventAddress,
+      zapRequestEvent: event,
+    };
+  } catch {
+    // Not JSON or parsing failed - not a zap request
+    return null;
+  }
+}
+
+/**
  * Try to parse a zap request from a transaction
+ * Checks both the transaction description and the invoice description
  * Transaction descriptions for zaps contain a JSON-stringified kind 9734 event
  * Results are cached on the transaction object using applesauce pattern
  *
- * @param transaction - The transaction object with description field
+ * @param transaction - The transaction object with description and/or invoice field
  * @returns ZapRequestInfo if this is a zap payment, null otherwise
  */
 export function parseZapRequest(transaction: {
   description?: string;
+  invoice?: string;
 }): ZapRequestInfo | null {
-  if (!transaction.description) return null;
-
   // Use applesauce caching pattern - cache result on transaction object
   return getOrComputeCachedValue(transaction, ZapRequestSymbol, () => {
-    const description = transaction.description!;
-
-    try {
-      // Try to parse as JSON
-      const parsed = JSON.parse(description);
-
-      // Check if it's a valid zap request (kind 9734)
-      if (
-        !parsed ||
-        typeof parsed !== "object" ||
-        parsed.kind !== 9734 ||
-        !parsed.pubkey ||
-        typeof parsed.pubkey !== "string"
-      ) {
-        return null;
-      }
-
-      const event = parsed as NostrEvent;
-
-      // Extract zapped event from tags
-      let zappedEventId: string | undefined;
-      let zappedEventAddress: string | undefined;
-
-      if (Array.isArray(event.tags)) {
-        // Look for e tag (event ID)
-        const eTag = event.tags.find(
-          (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "e",
-        );
-        if (eTag && typeof eTag[1] === "string") {
-          zappedEventId = eTag[1];
-        }
-
-        // Look for a tag (address/coordinate)
-        const aTag = event.tags.find(
-          (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "a",
-        );
-        if (aTag && typeof aTag[1] === "string") {
-          zappedEventAddress = aTag[1];
-        }
-      }
-
-      return {
-        sender: event.pubkey,
-        message: event.content || "",
-        zappedEventId,
-        zappedEventAddress,
-        zapRequestEvent: event,
-      };
-    } catch {
-      // Not JSON or parsing failed - not a zap request
-      return null;
+    // Try parsing the transaction description first
+    if (transaction.description) {
+      const result = tryParseZapRequestJson(transaction.description);
+      if (result) return result;
     }
+
+    // If that didn't work, try decoding the invoice and checking its description
+    if (transaction.invoice) {
+      try {
+        const decoded = decodeBolt11(transaction.invoice);
+        const descSection = decoded.sections.find(
+          (s) => s.name === "description",
+        );
+
+        if (descSection && descSection.value) {
+          const result = tryParseZapRequestJson(descSection.value as string);
+          if (result) return result;
+        }
+      } catch {
+        // Invoice decoding failed, ignore
+      }
+    }
+
+    return null;
   });
 }

--- a/src/lib/wallet-utils.ts
+++ b/src/lib/wallet-utils.ts
@@ -1,0 +1,125 @@
+/**
+ * Wallet Utilities
+ *
+ * Helper functions for working with wallet transactions and zap payments
+ */
+
+import { NostrEvent } from "@/types/nostr";
+
+export interface ZapRequestInfo {
+  sender: string; // pubkey of the zapper
+  message: string; // zap message content
+  zappedEventId?: string; // ID of the zapped event (from e tag)
+  zappedEventAddress?: string; // Address of the zapped event (from a tag)
+  amount?: number; // amount in sats (if available)
+}
+
+// Cache for parsed zap requests (keyed by description string)
+// Use Map with size limit to prevent unbounded growth
+const zapRequestCache = new Map<string, ZapRequestInfo | null>();
+const MAX_CACHE_SIZE = 500;
+
+/**
+ * Try to parse a zap request from a transaction description
+ * Transaction descriptions for zaps contain a JSON-stringified kind 9734 event
+ * Results are cached to avoid re-parsing the same descriptions
+ *
+ * @param description - The transaction description field
+ * @returns ZapRequestInfo if this is a zap payment, null otherwise
+ */
+export function parseZapRequest(description?: string): ZapRequestInfo | null {
+  if (!description) return null;
+
+  // Check cache first
+  if (zapRequestCache.has(description)) {
+    return zapRequestCache.get(description)!;
+  }
+
+  let result: ZapRequestInfo | null = null;
+
+  try {
+    // Try to parse as JSON
+    const parsed = JSON.parse(description);
+
+    // Check if it's a valid zap request (kind 9734)
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      parsed.kind !== 9734 ||
+      !parsed.pubkey ||
+      typeof parsed.pubkey !== "string"
+    ) {
+      result = null;
+    } else {
+      const event = parsed as NostrEvent;
+
+      // Extract zapped event from tags
+      let zappedEventId: string | undefined;
+      let zappedEventAddress: string | undefined;
+
+      if (Array.isArray(event.tags)) {
+        // Look for e tag (event ID)
+        const eTag = event.tags.find(
+          (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "e",
+        );
+        if (eTag && typeof eTag[1] === "string") {
+          zappedEventId = eTag[1];
+        }
+
+        // Look for a tag (address/coordinate)
+        const aTag = event.tags.find(
+          (tag) => Array.isArray(tag) && tag.length >= 2 && tag[0] === "a",
+        );
+        if (aTag && typeof aTag[1] === "string") {
+          zappedEventAddress = aTag[1];
+        }
+      }
+
+      result = {
+        sender: event.pubkey,
+        message: event.content || "",
+        zappedEventId,
+        zappedEventAddress,
+      };
+    }
+  } catch {
+    // Not JSON or parsing failed - not a zap request
+    result = null;
+  }
+
+  // Cache the result (with size limit to prevent unbounded growth)
+  if (zapRequestCache.size >= MAX_CACHE_SIZE) {
+    // Remove oldest entry (first key in the map)
+    const firstKey = zapRequestCache.keys().next().value;
+    if (firstKey) {
+      zapRequestCache.delete(firstKey);
+    }
+  }
+  zapRequestCache.set(description, result);
+
+  return result;
+}
+
+/**
+ * Get a short preview of a zap message for display in lists
+ * Truncates to maxLength characters and removes line breaks
+ *
+ * @param message - The full zap message
+ * @param maxLength - Maximum length before truncation (default 50)
+ * @returns Truncated message with ellipsis if needed
+ */
+export function getZapMessagePreview(
+  message: string,
+  maxLength: number = 50,
+): string {
+  if (!message) return "";
+
+  // Remove line breaks and extra whitespace
+  const cleaned = message.replace(/\s+/g, " ").trim();
+
+  if (cleaned.length <= maxLength) {
+    return cleaned;
+  }
+
+  return cleaned.substring(0, maxLength - 1) + "…";
+}


### PR DESCRIPTION
Add intelligent zap payment detection and enhanced display in the NWC wallet transaction list and detail views.

Changes:
- Add wallet-utils.ts with zap request parsing (kind 9734 detection)
- Parse zap requests from transaction descriptions with LRU caching (500 entry limit)
- Display username + message preview in transaction list with ⚡ indicator
- Show full zap details in transaction detail dialog:
  - Zapper name (clickable UserName component)
  - Full zap message with RichText formatting
  - Zapped post rendered inline using KindRenderer
  - Loading states for event fetching
- Follow React Hooks rules (unconditional hook calls)
- Type-safe implementation with proper pointer handling

Technical notes:
- parseZapRequest() extracts sender, message, and event pointers from JSON-embedded zap requests
- Caching prevents redundant JSON parsing on re-renders
- Supports both event IDs (e tag) and address coordinates (a tag)
- parseAddressCoordinate() handles kind:pubkey:identifier format