### PR TITLE
feat: add NIP-57 zap command foundation

### DIFF
--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -867,10 +867,6 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
       title = chatTitle;
       icon = getCommandIcon("chat");
       tooltip = rawCommand;
-    } else if (zapTitle) {
-      title = zapTitle;
-      icon = getCommandIcon("zap");
-      tooltip = rawCommand;
     } else {
       title = staticTitle || appId.toUpperCase();
       tooltip = rawCommand;

--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -303,6 +303,34 @@ function generateRawCommand(appId: string, props: any): string {
     case "spells":
       return "spells";
 
+    case "zap":
+      if (props.recipientPubkey) {
+        try {
+          const npub = nip19.npubEncode(props.recipientPubkey);
+          let result = `zap ${npub}`;
+          if (props.eventPointer) {
+            if ("id" in props.eventPointer) {
+              const nevent = nip19.neventEncode({ id: props.eventPointer.id });
+              result += ` ${nevent}`;
+            } else if (
+              "kind" in props.eventPointer &&
+              "pubkey" in props.eventPointer
+            ) {
+              const naddr = nip19.naddrEncode({
+                kind: props.eventPointer.kind,
+                pubkey: props.eventPointer.pubkey,
+                identifier: props.eventPointer.identifier || "",
+              });
+              result += ` ${naddr}`;
+            }
+          }
+          return result;
+        } catch {
+          return `zap ${props.recipientPubkey.slice(0, 16)}...`;
+        }
+      }
+      return "zap";
+
     default:
       return appId;
   }

--- a/src/components/DynamicWindowTitle.tsx
+++ b/src/components/DynamicWindowTitle.tsx
@@ -474,6 +474,23 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
   const countHashtags =
     appId === "count" && props.filter?.["#t"] ? props.filter["#t"] : [];
 
+  // Zap titles
+  const zapRecipientPubkey = appId === "zap" ? props.recipientPubkey : null;
+  const zapRecipientProfile = useProfile(zapRecipientPubkey || "");
+  const zapTitle = useMemo(() => {
+    if (appId !== "zap" || !zapRecipientPubkey) return null;
+
+    if (zapRecipientProfile) {
+      const name =
+        zapRecipientProfile.display_name ||
+        zapRecipientProfile.name ||
+        `${zapRecipientPubkey.slice(0, 8)}...`;
+      return `Zap ${name}`;
+    }
+
+    return `Zap ${zapRecipientPubkey.slice(0, 8)}...`;
+  }, [appId, zapRecipientPubkey, zapRecipientProfile]);
+
   // REQ titles
   const reqTitle = useMemo(() => {
     if (appId !== "req") return null;
@@ -783,7 +800,11 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
     }
 
     // Priority order for title selection (dynamic titles based on data)
-    if (profileTitle) {
+    if (zapTitle) {
+      title = zapTitle;
+      icon = getCommandIcon("zap");
+      tooltip = rawCommand;
+    } else if (profileTitle) {
       title = profileTitle;
       icon = getCommandIcon("profile");
       tooltip = rawCommand;
@@ -846,6 +867,10 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
       title = chatTitle;
       icon = getCommandIcon("chat");
       tooltip = rawCommand;
+    } else if (zapTitle) {
+      title = zapTitle;
+      icon = getCommandIcon("zap");
+      tooltip = rawCommand;
     } else {
       title = staticTitle || appId.toUpperCase();
       tooltip = rawCommand;
@@ -857,6 +882,7 @@ function useDynamicTitle(window: WindowInstance): WindowTitleData {
     props,
     event,
     customTitle,
+    zapTitle,
     profileTitle,
     eventTitle,
     kindTitle,

--- a/src/components/ProfileViewer.tsx
+++ b/src/components/ProfileViewer.tsx
@@ -441,20 +441,18 @@ export function ProfileViewer({ pubkey }: ProfileViewerProps) {
                 <div className="text-xs text-muted-foreground uppercase tracking-wide">
                   Lightning Address
                 </div>
-                <div className="flex items-center gap-2">
-                  <code className="text-sm font-mono flex-1">
+                <button
+                  onClick={() =>
+                    addWindow("zap", { recipientPubkey: resolvedPubkey })
+                  }
+                  className="flex items-center gap-2 w-full text-left hover:bg-muted/50 rounded px-2 py-1 -mx-2 transition-colors group"
+                  title="Send zap"
+                >
+                  <Zap className="size-4 text-yellow-500 group-hover:text-yellow-600 transition-colors flex-shrink-0" />
+                  <code className="text-sm font-mono flex-1 min-w-0 truncate">
                     {profile.lud16}
                   </code>
-                  <button
-                    onClick={() =>
-                      addWindow("zap", { recipientPubkey: resolvedPubkey })
-                    }
-                    className="text-yellow-500 hover:text-yellow-600 transition-colors"
-                    title="Send zap"
-                  >
-                    <Zap className="size-4" />
-                  </button>
-                </div>
+                </button>
               </div>
             )}
 

--- a/src/components/ProfileViewer.tsx
+++ b/src/components/ProfileViewer.tsx
@@ -10,6 +10,7 @@ import {
   Send,
   Wifi,
   HardDrive,
+  Zap,
 } from "lucide-react";
 import { kinds, nip19 } from "nostr-tools";
 import { useEventStore, use$ } from "applesauce-react/hooks";
@@ -440,7 +441,20 @@ export function ProfileViewer({ pubkey }: ProfileViewerProps) {
                 <div className="text-xs text-muted-foreground uppercase tracking-wide">
                   Lightning Address
                 </div>
-                <code className="text-sm font-mono">{profile.lud16}</code>
+                <div className="flex items-center gap-2">
+                  <code className="text-sm font-mono flex-1">
+                    {profile.lud16}
+                  </code>
+                  <button
+                    onClick={() =>
+                      addWindow("zap", { recipientPubkey: resolvedPubkey })
+                    }
+                    className="text-yellow-500 hover:text-yellow-600 transition-colors"
+                    title="Send zap"
+                  >
+                    <Zap className="size-4" />
+                  </button>
+                </div>
               </div>
             )}
 

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -43,6 +43,9 @@ const BlossomViewer = lazy(() =>
   import("./BlossomViewer").then((m) => ({ default: m.BlossomViewer })),
 );
 const WalletViewer = lazy(() => import("./WalletViewer"));
+const ZapWindow = lazy(() =>
+  import("./ZapWindow").then((m) => ({ default: m.ZapWindow })),
+);
 const CountViewer = lazy(() => import("./CountViewer"));
 
 // Loading fallback component
@@ -225,6 +228,14 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
         break;
       case "wallet":
         content = <WalletViewer />;
+        break;
+      case "zap":
+        content = (
+          <ZapWindow
+            recipientPubkey={window.props.recipientPubkey}
+            eventPointer={window.props.eventPointer}
+          />
+        );
         break;
       default:
         content = (

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -234,6 +234,7 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
           <ZapWindow
             recipientPubkey={window.props.recipientPubkey}
             eventPointer={window.props.eventPointer}
+            onClose={onClose}
           />
         );
         break;

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -33,9 +33,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import QRCode from "qrcode";
-import { useProfile } from "applesauce-react/hooks";
+import { useProfile } from "@/hooks/useProfile";
 import { use$ } from "applesauce-react/hooks";
 import eventStore from "@/services/event-store";
 import { useWallet } from "@/hooks/useWallet";
@@ -397,7 +396,7 @@ export function ZapWindow({
 
               {/* Custom amount */}
               <div className="space-y-2">
-                <Label htmlFor="custom-amount">Custom Amount</Label>
+                <Label>Custom Amount</Label>
                 <Input
                   id="custom-amount"
                   type="number"
@@ -413,7 +412,7 @@ export function ZapWindow({
 
               {/* Comment */}
               <div className="space-y-2">
-                <Label htmlFor="comment">Comment (optional)</Label>
+                <Label>Comment (optional)</Label>
                 <Input
                   id="comment"
                   placeholder="Say something nice..."

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -78,7 +78,7 @@ export function ZapWindow({
   // Resolve recipient: use provided pubkey or derive from event author
   const recipientPubkey = initialRecipientPubkey || event?.pubkey || "";
 
-  const recipientProfile = useProfile(recipientPubkey, eventStore);
+  const recipientProfile = useProfile(recipientPubkey);
 
   const { wallet, payInvoice, refreshBalance, getInfo } = useWallet();
 
@@ -127,11 +127,8 @@ export function ZapWindow({
 
   // Get recipient name for display
   const recipientName = useMemo(() => {
-    const content = recipientProfile
-      ? getProfileContent(recipientProfile)
-      : null;
-    return content
-      ? getDisplayName(recipientPubkey, content)
+    return recipientProfile
+      ? getDisplayName(recipientPubkey, recipientProfile)
       : recipientPubkey.slice(0, 8);
   }, [recipientPubkey, recipientProfile]);
 
@@ -139,10 +136,11 @@ export function ZapWindow({
   const eventAuthorName = useMemo(() => {
     if (!event) return null;
     const authorProfile = eventStore.getReplaceable(0, event.pubkey);
-    const content = authorProfile ? getProfileContent(authorProfile) : null;
-    return content
-      ? getDisplayName(event.pubkey, content)
-      : event.pubkey.slice(0, 8);
+    if (authorProfile) {
+      const content = getProfileContent(authorProfile);
+      return getDisplayName(event.pubkey, content);
+    }
+    return event.pubkey.slice(0, 8);
   }, [event]);
 
   // Track amount usage
@@ -202,11 +200,8 @@ export function ZapWindow({
       trackAmountUsage(amount);
 
       // Step 1: Get Lightning address from recipient profile
-      const content = recipientProfile
-        ? getProfileContent(recipientProfile)
-        : null;
-      const lud16 = content?.lud16;
-      const lud06 = content?.lud06;
+      const lud16 = recipientProfile?.lud16;
+      const lud06 = recipientProfile?.lud06;
 
       if (!lud16 && !lud06) {
         throw new Error(
@@ -292,7 +287,7 @@ export function ZapWindow({
 
         setIsPaid(true);
         toast.success(
-          `⚡ Zapped ${amount} sats to ${content?.name || recipientName}!`,
+          `⚡ Zapped ${amount} sats to ${recipientProfile?.name || recipientName}!`,
         );
 
         // Show success message from LNURL service if available

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -40,7 +40,6 @@ import { useWallet } from "@/hooks/useWallet";
 import { getDisplayName } from "@/lib/nostr-utils";
 import { KindRenderer } from "./nostr/kinds";
 import type { EventPointer, AddressPointer } from "@/lib/open-parser";
-import { useGrimoire } from "@/core/state";
 import accountManager from "@/services/accounts";
 import {
   MentionEditor,
@@ -48,6 +47,7 @@ import {
 } from "./editor/MentionEditor";
 import { useEmojiSearch } from "@/hooks/useEmojiSearch";
 import { useProfileSearch } from "@/hooks/useProfileSearch";
+import LoginDialog from "./nostr/LoginDialog";
 
 export interface ZapWindowProps {
   /** Recipient pubkey (who receives the zap) */
@@ -99,7 +99,6 @@ export function ZapWindow({
 
   const recipientProfile = useProfile(recipientPubkey);
 
-  const { addWindow } = useGrimoire();
   const activeAccount = accountManager.active;
   const canSign = !!activeAccount?.signer;
 
@@ -122,6 +121,7 @@ export function ZapWindow({
   const [qrCodeUrl, setQrCodeUrl] = useState<string>("");
   const [invoice, setInvoice] = useState<string>("");
   const [showQrDialog, setShowQrDialog] = useState(false);
+  const [showLogin, setShowLogin] = useState(false);
 
   // Editor ref and search functions
   const editorRef = useRef<MentionEditorHandle>(null);
@@ -378,9 +378,9 @@ export function ZapWindow({
     window.open(`lightning:${invoice}`, "_blank");
   };
 
-  // Open account selector for login
+  // Open login dialog
   const handleLogin = () => {
-    addWindow("conn", {});
+    setShowLogin(true);
   };
 
   return (
@@ -481,6 +481,9 @@ export function ZapWindow({
           )}
         </div>
       </div>
+
+      {/* Login Dialog */}
+      <LoginDialog open={showLogin} onOpenChange={setShowLogin} />
 
       {/* QR Code Dialog */}
       <Dialog open={showQrDialog} onOpenChange={setShowQrDialog}>

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -54,6 +54,8 @@ export interface ZapWindowProps {
   recipientPubkey: string;
   /** Optional event being zapped (adds context) */
   eventPointer?: EventPointer | AddressPointer;
+  /** Callback to close the window */
+  onClose?: () => void;
 }
 
 // Default preset amounts in sats
@@ -79,6 +81,7 @@ function formatAmount(amount: number): string {
 export function ZapWindow({
   recipientPubkey: initialRecipientPubkey,
   eventPointer,
+  onClose,
 }: ZapWindowProps) {
   // Load event if we have a pointer and no recipient pubkey (derive from event author)
   const event = use$(() => {
@@ -344,6 +347,12 @@ export function ZapWindow({
         // Show success message from LNURL service if available
         if (invoiceResponse.successAction?.message) {
           toast.info(invoiceResponse.successAction.message);
+        }
+
+        // Close the window after successful zap
+        if (onClose) {
+          // Small delay to let the user see the success toast
+          setTimeout(() => onClose(), 1500);
         }
       } else {
         // Show QR code and invoice

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -11,7 +11,7 @@
  * - Shows feed render of zapped event
  */
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { toast } from "sonner";
 import {
   Zap,
@@ -43,8 +43,6 @@ import { getProfileContent } from "applesauce-core/helpers";
 import { getDisplayName } from "@/lib/nostr-utils";
 import { KindRenderer } from "./nostr/kinds";
 import type { EventPointer, AddressPointer } from "@/lib/open-parser";
-import { isAddressableKind } from "applesauce-core/helpers";
-import type { NostrEvent } from "@/types/nostr";
 
 export interface ZapWindowProps {
   /** Recipient pubkey (who receives the zap) */
@@ -83,7 +81,17 @@ export function ZapWindow({
 
   const recipientProfile = useProfile(recipientPubkey, eventStore);
 
-  const { wallet, walletInfo, payInvoice, refreshBalance } = useWallet();
+  const { wallet, payInvoice, refreshBalance, getInfo } = useWallet();
+
+  // Fetch wallet info
+  const [walletInfo, setWalletInfo] = useState<any>(null);
+  useEffect(() => {
+    if (wallet) {
+      getInfo()
+        .then((info) => setWalletInfo(info))
+        .catch((error) => console.error("Failed to get wallet info:", error));
+    }
+  }, [wallet, getInfo]);
 
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
   const [customAmount, setCustomAmount] = useState("");

--- a/src/components/nostr/kinds/BaseEventRenderer.tsx
+++ b/src/components/nostr/kinds/BaseEventRenderer.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Menu, Copy, Check, FileJson, ExternalLink } from "lucide-react";
+import { Menu, Copy, Check, FileJson, ExternalLink, Zap } from "lucide-react";
 import { useGrimoire } from "@/core/state";
 import { useCopy } from "@/hooks/useCopy";
 import { JsonViewer } from "@/components/JsonViewer";
@@ -157,6 +157,29 @@ export function EventMenu({ event }: { event: NostrEvent }) {
     setJsonDialogOpen(true);
   };
 
+  const zapEvent = () => {
+    // Create event pointer for the zap
+    let eventPointer;
+    if (isAddressableKind(event.kind)) {
+      const dTag = getTagValue(event, "d") || "";
+      eventPointer = {
+        kind: event.kind,
+        pubkey: event.pubkey,
+        identifier: dTag,
+      };
+    } else {
+      eventPointer = {
+        id: event.id,
+      };
+    }
+
+    // Open zap window with event context
+    addWindow("zap", {
+      recipientPubkey: event.pubkey,
+      eventPointer,
+    });
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -180,6 +203,10 @@ export function EventMenu({ event }: { event: NostrEvent }) {
         <DropdownMenuItem onClick={openEventDetail}>
           <ExternalLink className="size-4 mr-2" />
           Open
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={zapEvent}>
+          <Zap className="size-4 mr-2 text-yellow-500" />
+          Zap
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={copyEventId}>

--- a/src/constants/command-icons.ts
+++ b/src/constants/command-icons.ts
@@ -16,6 +16,7 @@ import {
   Wifi,
   MessageSquare,
   Hash,
+  Zap,
   type LucideIcon,
 } from "lucide-react";
 
@@ -79,6 +80,10 @@ export const COMMAND_ICONS: Record<string, CommandIcon> = {
   chat: {
     icon: MessageSquare,
     description: "Join and participate in NIP-29 relay-based group chats",
+  },
+  zap: {
+    icon: Zap,
+    description: "Send a Lightning zap to a Nostr user or event",
   },
 
   // Utility commands

--- a/src/lib/create-zap-request.ts
+++ b/src/lib/create-zap-request.ts
@@ -3,7 +3,7 @@
  */
 
 import { EventFactory } from "applesauce-core/event-factory";
-import { EventTemplate, NostrEvent } from "@/types/nostr";
+import type { NostrEvent } from "@/types/nostr";
 import type { EventPointer, AddressPointer } from "./open-parser";
 import accountManager from "@/services/accounts";
 import { relayListCache } from "@/services/relay-list-cache";
@@ -88,7 +88,7 @@ export async function createZapRequest(
   }
 
   // Create event template
-  const template: EventTemplate = {
+  const template = {
     kind: 9734,
     content: params.comment || "",
     tags,

--- a/src/lib/create-zap-request.ts
+++ b/src/lib/create-zap-request.ts
@@ -1,0 +1,111 @@
+/**
+ * Create NIP-57 zap request (kind 9734)
+ */
+
+import { EventFactory } from "applesauce-core/event-factory";
+import { EventTemplate, NostrEvent } from "@/types/nostr";
+import type { EventPointer, AddressPointer } from "./open-parser";
+import accountManager from "@/services/accounts";
+import { relayListCache } from "@/services/relay-list-cache";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+export interface ZapRequestParams {
+  /** Recipient pubkey (who receives the zap) */
+  recipientPubkey: string;
+  /** Amount in millisatoshis */
+  amountMillisats: number;
+  /** Optional comment/message */
+  comment?: string;
+  /** Optional event being zapped */
+  eventPointer?: EventPointer | AddressPointer;
+  /** Relays where zap receipt should be published */
+  relays?: string[];
+  /** LNURL for the recipient */
+  lnurl?: string;
+}
+
+/**
+ * Create and sign a zap request event (kind 9734)
+ * This event is NOT published to relays - it's sent to the LNURL callback
+ */
+export async function createZapRequest(
+  params: ZapRequestParams,
+): Promise<NostrEvent> {
+  const account = accountManager.active;
+
+  if (!account) {
+    throw new Error("No active account. Please log in to send zaps.");
+  }
+
+  const signer = account.signer;
+  if (!signer) {
+    throw new Error("No signer available for active account");
+  }
+
+  // Get relays for zap receipt publication
+  let relays = params.relays;
+  if (!relays || relays.length === 0) {
+    // Use sender's read relays (where they want to receive zap receipts)
+    const senderReadRelays =
+      (await relayListCache.getInboxRelays(account.pubkey)) || [];
+    relays = senderReadRelays.length > 0 ? senderReadRelays : AGGREGATOR_RELAYS;
+  }
+
+  // Build tags
+  const tags: string[][] = [
+    ["p", params.recipientPubkey],
+    ["amount", params.amountMillisats.toString()],
+    ["relays", ...relays.slice(0, 10)], // Limit to 10 relays
+  ];
+
+  // Add lnurl tag if provided
+  if (params.lnurl) {
+    tags.push(["lnurl", params.lnurl]);
+  }
+
+  // Add event reference if zapping an event
+  if (params.eventPointer) {
+    if ("id" in params.eventPointer) {
+      // Regular event (e tag)
+      tags.push(["e", params.eventPointer.id]);
+      // Include author if available
+      if (params.eventPointer.author) {
+        tags.push(["p", params.eventPointer.author]);
+      }
+      // Include relay hints
+      if (params.eventPointer.relays && params.eventPointer.relays.length > 0) {
+        tags.push(["e", params.eventPointer.id, params.eventPointer.relays[0]]);
+      }
+    } else {
+      // Addressable event (a tag)
+      const coordinate = `${params.eventPointer.kind}:${params.eventPointer.pubkey}:${params.eventPointer.identifier}`;
+      tags.push(["a", coordinate]);
+      // Include relay hint if available
+      if (params.eventPointer.relays && params.eventPointer.relays.length > 0) {
+        tags.push(["a", coordinate, params.eventPointer.relays[0]]);
+      }
+    }
+  }
+
+  // Create event template
+  const template: EventTemplate = {
+    kind: 9734,
+    content: params.comment || "",
+    tags,
+    created_at: Math.floor(Date.now() / 1000),
+  };
+
+  // Sign the event
+  const factory = new EventFactory({ signer });
+  const draft = await factory.build(template);
+  const signedEvent = await factory.sign(draft);
+
+  return signedEvent as NostrEvent;
+}
+
+/**
+ * Serialize zap request event to URL-encoded JSON for LNURL callback
+ */
+export function serializeZapRequest(event: NostrEvent): string {
+  return encodeURIComponent(JSON.stringify(event));
+}

--- a/src/lib/create-zap-request.ts
+++ b/src/lib/create-zap-request.ts
@@ -9,6 +9,11 @@ import accountManager from "@/services/accounts";
 import { relayListCache } from "@/services/relay-list-cache";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
 
+export interface EmojiTag {
+  shortcode: string;
+  url: string;
+}
+
 export interface ZapRequestParams {
   /** Recipient pubkey (who receives the zap) */
   recipientPubkey: string;
@@ -22,6 +27,8 @@ export interface ZapRequestParams {
   relays?: string[];
   /** LNURL for the recipient */
   lnurl?: string;
+  /** NIP-30 custom emoji tags */
+  emojiTags?: EmojiTag[];
 }
 
 /**
@@ -84,6 +91,13 @@ export async function createZapRequest(
       if (params.eventPointer.relays && params.eventPointer.relays.length > 0) {
         tags.push(["a", coordinate, params.eventPointer.relays[0]]);
       }
+    }
+  }
+
+  // Add NIP-30 emoji tags
+  if (params.emojiTags) {
+    for (const emoji of params.emojiTags) {
+      tags.push(["emoji", emoji.shortcode, emoji.url]);
     }
   }
 

--- a/src/lib/lnurl.ts
+++ b/src/lib/lnurl.ts
@@ -1,0 +1,145 @@
+/**
+ * LNURL utilities for Lightning address resolution and zap support (NIP-57)
+ */
+
+export interface LnUrlPayResponse {
+  callback: string;
+  maxSendable: number;
+  minSendable: number;
+  metadata: string;
+  tag: "payRequest";
+  allowsNostr?: boolean;
+  nostrPubkey?: string;
+  commentAllowed?: number;
+}
+
+export interface LnUrlCallbackResponse {
+  pr: string; // BOLT11 invoice
+  successAction?: {
+    tag: string;
+    message?: string;
+  };
+  routes?: any[];
+}
+
+/**
+ * Resolve a Lightning address (lud16) to LNURL-pay endpoint data
+ * Converts user@domain.com to https://domain.com/.well-known/lnurlp/user
+ */
+export async function resolveLightningAddress(
+  address: string,
+): Promise<LnUrlPayResponse> {
+  const parts = address.split("@");
+  if (parts.length !== 2) {
+    throw new Error(
+      "Invalid Lightning address format. Expected: user@domain.com",
+    );
+  }
+
+  const [username, domain] = parts;
+  const url = `https://${domain}/.well-known/lnurlp/${username}`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch LNURL data: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as LnUrlPayResponse;
+
+    // Validate required fields
+    if (data.tag !== "payRequest") {
+      throw new Error(
+        `Invalid LNURL response: expected tag "payRequest", got "${data.tag}"`,
+      );
+    }
+
+    if (!data.callback) {
+      throw new Error("LNURL response missing callback URL");
+    }
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to resolve Lightning address: ${error}`);
+  }
+}
+
+/**
+ * Decode LNURL (bech32-encoded URL) to plain HTTPS URL
+ */
+export function decodeLnurl(lnurl: string): string {
+  // For simplicity, we'll require Lightning addresses (lud16) instead of lud06
+  // Most modern wallets use lud16 anyway
+  throw new Error(
+    "LNURL (lud06) not supported. Please use a Lightning address (lud16) instead.",
+  );
+}
+
+/**
+ * Fetch invoice from LNURL callback with zap request
+ * @param callbackUrl - The callback URL from LNURL-pay response
+ * @param amountMillisats - Amount in millisatoshis
+ * @param zapRequestEvent - Signed kind 9734 zap request event (URL-encoded JSON)
+ * @param comment - Optional comment (if allowed by LNURL service)
+ */
+export async function fetchInvoiceFromCallback(
+  callbackUrl: string,
+  amountMillisats: number,
+  zapRequestEvent: string,
+  comment?: string,
+): Promise<LnUrlCallbackResponse> {
+  // Build query parameters
+  const url = new URL(callbackUrl);
+  url.searchParams.set("amount", amountMillisats.toString());
+  url.searchParams.set("nostr", zapRequestEvent);
+  if (comment) {
+    url.searchParams.set("comment", comment);
+  }
+
+  try {
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch invoice: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const data = (await response.json()) as LnUrlCallbackResponse;
+
+    if (!data.pr) {
+      throw new Error("LNURL callback response missing invoice (pr field)");
+    }
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`Failed to fetch invoice from callback: ${error}`);
+  }
+}
+
+/**
+ * Validate that a LNURL service supports Nostr zaps (NIP-57)
+ */
+export function validateZapSupport(lnurlData: LnUrlPayResponse): void {
+  if (!lnurlData.allowsNostr) {
+    throw new Error(
+      "This Lightning address does not support Nostr zaps (allowsNostr is false)",
+    );
+  }
+
+  if (!lnurlData.nostrPubkey) {
+    throw new Error("LNURL service missing nostrPubkey (required for zaps)");
+  }
+
+  // Validate pubkey format (64 hex chars)
+  if (!/^[0-9a-f]{64}$/i.test(lnurlData.nostrPubkey)) {
+    throw new Error("Invalid nostrPubkey format in LNURL response");
+  }
+}

--- a/src/lib/lnurl.ts
+++ b/src/lib/lnurl.ts
@@ -72,7 +72,7 @@ export async function resolveLightningAddress(
 /**
  * Decode LNURL (bech32-encoded URL) to plain HTTPS URL
  */
-export function decodeLnurl(lnurl: string): string {
+export function decodeLnurl(_lnurl: string): string {
   // For simplicity, we'll require Lightning addresses (lud16) instead of lud06
   // Most modern wallets use lud16 anyway
   throw new Error(

--- a/src/lib/zap-parser.ts
+++ b/src/lib/zap-parser.ts
@@ -1,0 +1,187 @@
+import { nip19 } from "nostr-tools";
+import { isNip05, resolveNip05 } from "./nip05";
+import {
+  isValidHexPubkey,
+  isValidHexEventId,
+  normalizeHex,
+} from "./nostr-validation";
+import { normalizeRelayURL } from "./relay-url";
+import type { EventPointer, AddressPointer } from "./open-parser";
+
+export interface ParsedZapCommand {
+  /** Recipient pubkey (who receives the zap) */
+  recipientPubkey: string;
+  /** Optional event being zapped (adds context to the zap) */
+  eventPointer?: EventPointer | AddressPointer;
+}
+
+/**
+ * Parse ZAP command arguments
+ *
+ * Supports:
+ * - `zap <profile>` - Zap a person
+ * - `zap <event>` - Zap an event (recipient derived from event author)
+ * - `zap <profile> <event>` - Zap a specific person for a specific event
+ *
+ * Profile formats: npub, nprofile, hex pubkey, user@domain.com, $me
+ * Event formats: note, nevent, naddr, hex event ID
+ */
+export async function parseZapCommand(
+  args: string[],
+  activeAccountPubkey?: string,
+): Promise<ParsedZapCommand> {
+  if (args.length === 0) {
+    throw new Error(
+      "Recipient or event required. Usage: zap <profile> or zap <event> or zap <profile> <event>",
+    );
+  }
+
+  const firstArg = args[0];
+  const secondArg = args[1];
+
+  // Case 1: Two arguments - zap <profile> <event>
+  if (secondArg) {
+    const recipientPubkey = await parseProfile(firstArg, activeAccountPubkey);
+    const eventPointer = parseEventPointer(secondArg);
+    return { recipientPubkey, eventPointer };
+  }
+
+  // Case 2: One argument - try event first, then profile
+  // Events have more specific patterns (nevent, naddr, note)
+  const eventPointer = tryParseEventPointer(firstArg);
+  if (eventPointer) {
+    // For events, we'll need to fetch the event to get the author
+    // For now, we'll return a placeholder and let the component fetch it
+    return {
+      recipientPubkey: "", // Will be filled in by component from event author
+      eventPointer,
+    };
+  }
+
+  // Must be a profile
+  const recipientPubkey = await parseProfile(firstArg, activeAccountPubkey);
+  return { recipientPubkey };
+}
+
+/**
+ * Parse a profile identifier into a pubkey
+ */
+async function parseProfile(
+  identifier: string,
+  activeAccountPubkey?: string,
+): Promise<string> {
+  // Handle $me alias
+  if (identifier.toLowerCase() === "$me") {
+    if (!activeAccountPubkey) {
+      throw new Error("No active account. Please log in to use $me alias.");
+    }
+    return activeAccountPubkey;
+  }
+
+  // Try bech32 decode (npub, nprofile)
+  if (identifier.startsWith("npub") || identifier.startsWith("nprofile")) {
+    try {
+      const decoded = nip19.decode(identifier);
+      if (decoded.type === "npub") {
+        return decoded.data;
+      }
+      if (decoded.type === "nprofile") {
+        return decoded.data.pubkey;
+      }
+    } catch (error) {
+      throw new Error(`Invalid npub/nprofile: ${error}`);
+    }
+  }
+
+  // Check if it's a hex pubkey
+  if (isValidHexPubkey(identifier)) {
+    return normalizeHex(identifier);
+  }
+
+  // Check if it's a NIP-05 identifier
+  if (isNip05(identifier)) {
+    const pubkey = await resolveNip05(identifier);
+    if (!pubkey) {
+      throw new Error(`Failed to resolve NIP-05 identifier: ${identifier}`);
+    }
+    return pubkey;
+  }
+
+  throw new Error(
+    `Invalid profile identifier: ${identifier}. Supported: npub, nprofile, hex pubkey, user@domain.com`,
+  );
+}
+
+/**
+ * Parse an event identifier into a pointer
+ */
+function parseEventPointer(identifier: string): EventPointer | AddressPointer {
+  const result = tryParseEventPointer(identifier);
+  if (!result) {
+    throw new Error(
+      `Invalid event identifier: ${identifier}. Supported: note, nevent, naddr, hex ID`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Try to parse an event identifier, returning null if it doesn't match event patterns
+ */
+function tryParseEventPointer(
+  identifier: string,
+): EventPointer | AddressPointer | null {
+  // Try bech32 decode (note, nevent, naddr)
+  if (
+    identifier.startsWith("note") ||
+    identifier.startsWith("nevent") ||
+    identifier.startsWith("naddr")
+  ) {
+    try {
+      const decoded = nip19.decode(identifier);
+
+      if (decoded.type === "note") {
+        return { id: decoded.data };
+      }
+
+      if (decoded.type === "nevent") {
+        return {
+          ...decoded.data,
+          relays: decoded.data.relays
+            ?.map((url) => {
+              try {
+                return normalizeRelayURL(url);
+              } catch {
+                return null;
+              }
+            })
+            .filter((url): url is string => url !== null),
+        };
+      }
+
+      if (decoded.type === "naddr") {
+        return {
+          ...decoded.data,
+          relays: decoded.data.relays
+            ?.map((url) => {
+              try {
+                return normalizeRelayURL(url);
+              } catch {
+                return null;
+              }
+            })
+            .filter((url): url is string => url !== null),
+        };
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  // Check if it's a hex event ID
+  if (isValidHexEventId(identifier)) {
+    return { id: normalizeHex(identifier) };
+  }
+
+  return null;
+}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -22,6 +22,7 @@ export type AppId =
   | "spellbooks"
   | "blossom"
   | "wallet"
+  | "zap"
   | "win";
 
 export interface WindowInstance {

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -8,6 +8,7 @@ import { parseRelayCommand } from "@/lib/relay-parser";
 import { resolveNip05Batch, resolveDomainDirectoryBatch } from "@/lib/nip05";
 import { parseChatCommand } from "@/lib/chat-parser";
 import { parseBlossomCommand } from "@/lib/blossom-parser";
+import { parseZapCommand } from "@/lib/zap-parser";
 
 export interface ManPageEntry {
   name: string;
@@ -611,6 +612,38 @@ export const manPages: Record<string, ManPageEntry> = {
     category: "Nostr",
     argParser: async (args: string[], activeAccountPubkey?: string) => {
       const parsed = await parseProfileCommand(args, activeAccountPubkey);
+      return parsed;
+    },
+  },
+  zap: {
+    name: "zap",
+    section: "1",
+    synopsis: "zap <profile|event> [event]",
+    description:
+      "Send a Lightning zap (NIP-57) to a Nostr user or event. Zaps are Lightning payments with proof published to Nostr. Supports zapping profiles directly or events with context. Requires the recipient to have a Lightning address (lud16/lud06) configured in their profile.",
+    options: [
+      {
+        flag: "<profile>",
+        description:
+          "Recipient: npub, nprofile, hex pubkey, user@domain.com, $me",
+      },
+      {
+        flag: "<event>",
+        description: "Event to zap: note, nevent, naddr, hex ID (optional)",
+      },
+    ],
+    examples: [
+      "zap fiatjaf.com                      Zap a user by NIP-05",
+      "zap npub1...                         Zap a user by npub",
+      "zap nevent1...                       Zap an event (recipient = event author)",
+      "zap npub1... nevent1...              Zap a specific user for a specific event",
+      "zap alice@domain.com naddr1...       Zap with event context",
+    ],
+    seeAlso: ["profile", "open", "wallet"],
+    appId: "zap",
+    category: "Nostr",
+    argParser: async (args: string[], activeAccountPubkey?: string) => {
+      const parsed = await parseZapCommand(args, activeAccountPubkey);
       return parsed;
     },
   },


### PR DESCRIPTION
Implements the foundational structure for sending Lightning zaps (NIP-57) to
Nostr users and events. This commit adds the command interface, UI components,
and routing logic. The actual LNURL resolution and zap request creation will
be implemented in follow-up commits.

Components Added:
- ZapWindow: Full-featured UI for zapping with amount presets, custom amounts,
  wallet integration, and QR code fallback
- parseZapCommand: Parser supporting multiple formats (npub, nprofile, nevent,
  naddr, NIP-05, $me alias)
- Command registration in man pages with examples
- Window routing and title generation

Features:
- Preset amount buttons (21, 100, 500, 1000, 5000, 10000 sats)
- Custom amount input
- Amount usage tracking (remembers most-used amounts)
- Comment field for zap messages
- Event context rendering (shows zapped event in UI)
- Dual payment methods: NWC wallet or QR code/invoice copy
- Dynamic recipient resolution (from event author if zapping event)

Usage:
  zap fiatjaf.com                  # Zap a user by NIP-05
  zap npub1...                     # Zap a user by npub
  zap nevent1...                   # Zap an event (recipient = author)
  zap npub1... nevent1...          # Zap specific user for specific event

Next Steps:
- Implement LNURL-pay resolution (fetch callback URL and nostrPubkey)
- Create kind 9734 zap request event with applesauce factory
- Implement invoice generation via LNURL callback
- Integrate NWC wallet payment
- Add zap action to event context menus
- Implement zap receipt listening (kind 9735)