### PR TITLE
fix: remove double URL encoding in zap requests

### DIFF
--- a/src/lib/create-zap-request.ts
+++ b/src/lib/create-zap-request.ts
@@ -118,8 +118,9 @@ export async function createZapRequest(
 }
 
 /**
- * Serialize zap request event to URL-encoded JSON for LNURL callback
+ * Serialize zap request event to JSON string for LNURL callback
+ * Note: Do NOT encodeURIComponent here - URLSearchParams.set() will handle encoding
  */
 export function serializeZapRequest(event: NostrEvent): string {
-  return encodeURIComponent(JSON.stringify(event));
+  return JSON.stringify(event);
 }


### PR DESCRIPTION
The zap request JSON was being encoded twice:
1. Manually via encodeURIComponent in serializeZapRequest()
2. Automatically by URLSearchParams.set() when building callback URL

This caused overly-encoded URLs (e.g., '{' → '%7B' → '%257B').

Fix: Remove manual encoding and let URLSearchParams handle it.
Verified: Tests pass, build succeeds