### PR TITLE
fix: pass full zap request event to RichText for proper parsing

### DIFF
--- a/src/components/nostr/kinds/ZapReceiptRenderer.tsx
+++ b/src/components/nostr/kinds/ZapReceiptRenderer.tsx
@@ -36,12 +36,6 @@ export function Kind9735Renderer({ event }: BaseEventProps) {
   const zappedEvent = useNostrEvent(eventPointer || undefined);
   const zappedAddress = useNostrEvent(addressPointer || undefined);
 
-  // Get zap comment from request
-  const zapComment = useMemo(() => {
-    if (!zapRequest) return null;
-    return zapRequest.content || null;
-  }, [zapRequest]);
-
   // Format amount (convert from msats to sats)
   const amountInSats = useMemo(() => {
     if (!zapAmount) return 0;
@@ -76,9 +70,9 @@ export function Kind9735Renderer({ event }: BaseEventProps) {
         </div>
 
         {/* Zap comment */}
-        {zapComment && (
+        {zapRequest && zapRequest.content && (
           <div className="text-sm">
-            <RichText content={zapComment} />
+            <RichText event={zapRequest} />
           </div>
         )}
 


### PR DESCRIPTION
Previously, only the content string was passed to RichText when rendering zap comments. This prevented proper parsing of mentions, event references, hashtags, URLs, custom emojis, and other rich content features.

Now passing the full zapRequest event object to RichText, enabling all content transformers to work correctly on zap comments.

Changes:
- Remove zapComment variable that extracted just the content string
- Pass zapRequest event directly to RichText component
- Update condition to check zapRequest && zapRequest.content

Fixes rendering in both feed and detail views (detail falls back to feed renderer for kind 9735).