### PR TITLE
Truncate invoice descriptions in wallet dialog

### DIFF
--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -1461,11 +1461,14 @@ export default function WalletViewer() {
                       </div>
                     )}
                     {invoiceDetails?.description && (
-                      <div className="flex justify-between">
-                        <span className="text-muted-foreground">
+                      <div className="flex justify-between gap-2">
+                        <span className="text-muted-foreground flex-shrink-0">
                           Description:
                         </span>
-                        <span className="truncate ml-2">
+                        <span
+                          className="truncate text-right"
+                          title={invoiceDetails.description}
+                        >
                           {invoiceDetails.description}
                         </span>
                       </div>


### PR DESCRIPTION
Add proper truncation for long invoice descriptions in the wallet's confirm send dialog. The description label is now flex-shrink-0 to prevent it from shrinking, and a title attribute shows the full description on hover.