### PR TITLE
Remove lint QA step from pipeline

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -7,24 +7,6 @@ on:
     branches: [main, master]
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run ESLint
-        run: npm run lint
-
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
The lint CI check was more annoying than helpful.