### PR TITLE
fix: convert zap amounts from millisats to sats in NIP-10 chat

### DIFF
--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -329,9 +329,12 @@ const MessageItem = memo(function MessageItem({
               />
               <Zap className="size-4 fill-yellow-500 text-yellow-500" />
               <span className="text-yellow-500 font-bold">
-                {(message.metadata?.zapAmount || 0).toLocaleString("en", {
-                  notation: "compact",
-                })}
+                {((message.metadata?.zapAmount || 0) / 1000).toLocaleString(
+                  "en",
+                  {
+                    notation: "compact",
+                  },
+                )}
               </span>
               {message.metadata?.zapRecipient && (
                 <UserName


### PR DESCRIPTION
The zap amount display in NIP-10 thread chats was showing millisats
instead of sats. Fixed by dividing the amount by 1000 before display,
consistent with how zap amounts are displayed elsewhere in the app.

The getZapAmount helper from applesauce returns millisats per NIP-57
spec, so the display layer needs to convert to sats for readability.