### PR TITLE
fix: convert NIP-10 chat zap amounts to sats

### DIFF
--- a/src/lib/chat/adapters/nip-10-adapter.ts
+++ b/src/lib/chat/adapters/nip-10-adapter.ts
@@ -909,6 +909,9 @@ export class Nip10Adapter extends ChatProtocolAdapter {
     const sender = getZapSender(zapReceipt);
     const recipient = getZapRecipient(zapReceipt);
 
+    // Convert from msats to sats
+    const amountInSats = amount ? Math.floor(amount / 1000) : 0;
+
     // Find what event is being zapped (e-tag in zap receipt)
     const eTag = zapReceipt.tags.find((t) => t[0] === "e");
     const replyTo = eTag?.[1];
@@ -935,7 +938,7 @@ export class Nip10Adapter extends ChatProtocolAdapter {
       replyTo,
       protocol: "nip-10",
       metadata: {
-        zapAmount: amount,
+        zapAmount: amountInSats,
         zapRecipient: recipient,
       },
       event: zapReceipt,

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"version":"5.6.3"}
+{"root":["./vite.config.ts"],"errors":true,"version":"5.9.3"}


### PR DESCRIPTION
The NIP-10 adapter was storing zap amounts in millisats instead of sats,
which was inconsistent with:
- The MessageMetadata type definition (zapAmount documented as "Amount in sats")
- Other chat adapters like NIP-53 which correctly convert to sats
- UI expectations for displaying zap amounts

This fix adds the millisat-to-sat conversion (Math.floor(amount / 1000))
matching the implementation in the NIP-53 adapter.

Without this fix, zap amounts would display 1000x larger than intended
(e.g., a 1000 sat zap would show as 1,000,000).