### PR TITLE
fix: remove redundant reply preview for NIP-10 root replies

### DIFF
--- a/src/lib/chat/adapters/nip-10-adapter.ts
+++ b/src/lib/chat/adapters/nip-10-adapter.ts
@@ -847,7 +847,7 @@ export class Nip10Adapter extends ChatProtocolAdapter {
   private eventToMessage(
     event: NostrEvent,
     conversationId: string,
-    _rootEventId: string,
+    rootEventId: string,
   ): Message | null {
     // Handle zap receipts (kind 9735)
     if (event.kind === 9735) {
@@ -867,12 +867,14 @@ export class Nip10Adapter extends ChatProtocolAdapter {
       let replyTo: string | undefined;
 
       if (refs.reply?.e) {
-        // Replying to another reply - show reply preview
+        // Replying to another reply
         replyTo = refs.reply.e.id;
+      } else if (refs.root?.e) {
+        // Replying directly to root
+        replyTo = refs.root.e.id;
       } else {
-        // Replying directly to root or malformed - don't show reply preview
-        // (replying to root is implied in thread chat context)
-        replyTo = undefined;
+        // Malformed or legacy reply - assume replying to root
+        replyTo = rootEventId;
       }
 
       return {

--- a/src/lib/chat/adapters/nip-10-adapter.ts
+++ b/src/lib/chat/adapters/nip-10-adapter.ts
@@ -847,7 +847,7 @@ export class Nip10Adapter extends ChatProtocolAdapter {
   private eventToMessage(
     event: NostrEvent,
     conversationId: string,
-    rootEventId: string,
+    _rootEventId: string,
   ): Message | null {
     // Handle zap receipts (kind 9735)
     if (event.kind === 9735) {
@@ -867,14 +867,12 @@ export class Nip10Adapter extends ChatProtocolAdapter {
       let replyTo: string | undefined;
 
       if (refs.reply?.e) {
-        // Replying to another reply
+        // Replying to another reply - show reply preview
         replyTo = refs.reply.e.id;
-      } else if (refs.root?.e) {
-        // Replying directly to root
-        replyTo = refs.root.e.id;
       } else {
-        // Malformed or legacy reply - assume replying to root
-        replyTo = rootEventId;
+        // Replying directly to root or malformed - don't show reply preview
+        // (replying to root is implied in thread chat context)
+        replyTo = undefined;
       }
 
       return {

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./vite.config.ts"],"version":"5.6.3"}

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./vite.config.ts"],"errors":true,"version":"5.9.3"}
+{"root":["./vite.config.ts"],"version":"5.6.3"}


### PR DESCRIPTION
In NIP-10 thread chats, messages replying directly to the thread root
no longer show a reply preview, since replying to the root is implicit
in the thread chat context.

Reply previews are still shown for replies to other messages within
the thread, maintaining proper conversation threading.

Changes:
- Modified eventToMessage() in nip-10-adapter.ts to only set replyTo
  when a message has a NIP-10 "reply" marker (replying to another message)
- Messages with only a "root" marker now have replyTo=undefined
- Prefixed unused rootEventId parameter with underscore to fix lint warning