### PR TITLE
feat: add inline nostr: URI preview in chat composer

### DIFF
--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -318,8 +318,7 @@ const EventMentionNode = Node.create({
 
   addNodeView() {
     return ({ node }) => {
-      const { decodedType, kind, nostrUri, eventId, pubkey, identifier } =
-        node.attrs;
+      const { decodedType, kind, eventId, pubkey, identifier } = node.attrs;
 
       // Create wrapper span
       const dom = document.createElement("span");
@@ -397,10 +396,10 @@ const EventMentionNode = Node.create({
 
               const matchedText = matches[0];
               // Strip "nostr:" prefix if present for decoding
-              const identifier = matchedText.replace(/^nostr:/i, "");
+              const nip19String = matchedText.replace(/^nostr:/i, "");
 
               try {
-                const decoded = nip19.decode(identifier);
+                const decoded = nip19.decode(nip19String);
 
                 // Handle profile identifiers (npub/nprofile) - convert to @ mention
                 if (decoded.type === "npub") {
@@ -443,7 +442,7 @@ const EventMentionNode = Node.create({
                 // Always store with "nostr:" prefix for consistency
                 const nostrUri = matchedText.startsWith("nostr:")
                   ? matchedText
-                  : `nostr:${identifier}`;
+                  : `nostr:${nip19String}`;
 
                 let decodedType: string;
                 let eventId: string | null = null;

--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -37,6 +37,7 @@ import { getKindName } from "@/constants/kinds";
 import { eventStore } from "@/services/event-store";
 import { MemoizedInlineEventPreview } from "../nostr/InlineEventPreview";
 import type { NostrEvent } from "@/types/nostr";
+import { FileText } from "lucide-react";
 
 /**
  * Represents an emoji tag for NIP-30
@@ -355,12 +356,12 @@ const EventMentionNode = Node.create({
         // Event not found - render compact fallback
         const kindName = kind !== null ? getKindName(kind) : "event";
         root.render(
-          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 border border-primary/20 text-xs align-middle pointer-events-none">
-            <span>📝</span>
-            <span className="text-foreground font-medium text-[10px]">
+          <span className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded bg-primary/10 border border-primary/20 align-middle pointer-events-none whitespace-nowrap max-w-[180px]">
+            <FileText className="size-3 text-muted-foreground shrink-0" />
+            <span className="text-foreground font-medium text-[10px] truncate">
               {kindName}
             </span>
-            <span className="text-muted-foreground text-[9px]">
+            <span className="text-muted-foreground text-[9px] shrink-0">
               {decodedType || "note"}
             </span>
           </span>,

--- a/src/components/nostr/InlineEventPreview.tsx
+++ b/src/components/nostr/InlineEventPreview.tsx
@@ -1,0 +1,70 @@
+import { memo } from "react";
+import type { NostrEvent } from "@/types/nostr";
+import { kinds } from "nostr-tools";
+import { formatTimestamp } from "@/hooks/useLocale";
+import { getZapSender } from "applesauce-common/helpers/zap";
+import { KindBadge } from "@/components/KindBadge";
+import { UserName } from "./UserName";
+import { compactRenderers, DefaultCompactPreview } from "./compact";
+import { useGrimoire } from "@/core/state";
+
+interface InlineEventPreviewProps {
+  event: NostrEvent;
+}
+
+/**
+ * Inline event preview for use in chat composer
+ * Similar to CompactEventRow but optimized for inline display
+ * - No click handlers (pointer events disabled)
+ * - More compact styling
+ * - Designed to fit in a single line within text
+ */
+export function InlineEventPreview({ event }: InlineEventPreviewProps) {
+  const { locale } = useGrimoire();
+
+  // Get the compact preview renderer for this kind, or use default
+  const PreviewRenderer = compactRenderers[event.kind] || DefaultCompactPreview;
+
+  // Format relative time
+  const relativeTime = formatTimestamp(
+    event.created_at,
+    "relative",
+    locale.locale,
+  );
+
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 border border-primary/20 text-xs align-middle max-w-[320px] pointer-events-none">
+      {/* Kind badge - icon only */}
+      <KindBadge kind={event.kind} variant="compact" className="shrink-0" />
+
+      {/* Author */}
+      {event.kind === kinds.Zap && getZapSender(event) ? (
+        <UserName
+          pubkey={getZapSender(event) as string}
+          className="shrink-0 truncate text-foreground font-medium text-[10px]"
+        />
+      ) : (
+        <UserName
+          pubkey={event.pubkey}
+          className="shrink-0 truncate text-foreground font-medium text-[10px]"
+        />
+      )}
+
+      {/* Kind-specific or default preview */}
+      <span className="flex-1 min-w-0 truncate text-muted-foreground text-[10px]">
+        <PreviewRenderer event={event} />
+      </span>
+
+      {/* Timestamp */}
+      <span className="text-[9px] text-muted-foreground/70 shrink-0">
+        {relativeTime}
+      </span>
+    </span>
+  );
+}
+
+// Memoized version
+export const MemoizedInlineEventPreview = memo(
+  InlineEventPreview,
+  (prev, next) => prev.event.id === next.event.id,
+);

--- a/src/components/nostr/InlineEventPreview.tsx
+++ b/src/components/nostr/InlineEventPreview.tsx
@@ -1,12 +1,10 @@
 import { memo } from "react";
 import type { NostrEvent } from "@/types/nostr";
 import { kinds } from "nostr-tools";
-import { formatTimestamp } from "@/hooks/useLocale";
 import { getZapSender } from "applesauce-common/helpers/zap";
 import { KindBadge } from "@/components/KindBadge";
 import { UserName } from "./UserName";
 import { compactRenderers, DefaultCompactPreview } from "./compact";
-import { useGrimoire } from "@/core/state";
 
 interface InlineEventPreviewProps {
   event: NostrEvent;
@@ -16,48 +14,39 @@ interface InlineEventPreviewProps {
  * Inline event preview for use in chat composer
  * Similar to CompactEventRow but optimized for inline display
  * - No click handlers (pointer events disabled)
- * - More compact styling
- * - Designed to fit in a single line within text
+ * - Ultra-compact single-line styling
+ * - Designed to fit inline within text
  */
 export function InlineEventPreview({ event }: InlineEventPreviewProps) {
-  const { locale } = useGrimoire();
-
   // Get the compact preview renderer for this kind, or use default
   const PreviewRenderer = compactRenderers[event.kind] || DefaultCompactPreview;
 
-  // Format relative time
-  const relativeTime = formatTimestamp(
-    event.created_at,
-    "relative",
-    locale.locale,
-  );
-
   return (
-    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 border border-primary/20 text-xs align-middle max-w-[320px] pointer-events-none">
+    <span className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded bg-primary/10 border border-primary/20 align-middle max-w-[180px] pointer-events-none whitespace-nowrap">
       {/* Kind badge - icon only */}
-      <KindBadge kind={event.kind} variant="compact" className="shrink-0" />
+      <KindBadge
+        kind={event.kind}
+        variant="compact"
+        className="shrink-0"
+        iconClassname="size-3 text-muted-foreground"
+      />
 
       {/* Author */}
       {event.kind === kinds.Zap && getZapSender(event) ? (
         <UserName
           pubkey={getZapSender(event) as string}
-          className="shrink-0 truncate text-foreground font-medium text-[10px]"
+          className="shrink-0 truncate text-foreground font-medium text-[10px] max-w-[60px]"
         />
       ) : (
         <UserName
           pubkey={event.pubkey}
-          className="shrink-0 truncate text-foreground font-medium text-[10px]"
+          className="shrink-0 truncate text-foreground font-medium text-[10px] max-w-[60px]"
         />
       )}
 
       {/* Kind-specific or default preview */}
       <span className="flex-1 min-w-0 truncate text-muted-foreground text-[10px]">
         <PreviewRenderer event={event} />
-      </span>
-
-      {/* Timestamp */}
-      <span className="text-[9px] text-muted-foreground/70 shrink-0">
-        {relativeTime}
       </span>
     </span>
   );


### PR DESCRIPTION
Add EventMentionNode TipTap extension that shows compact inline previews
when users paste nostr: URIs (note/nevent/naddr) in the chat composer.

Features:
- Detects pasted nostr: URIs and converts them to rich preview chips
- Shows event kind name and URI type (note/nevent/naddr)
- Serializes back to original nostr: URI when message is sent
- Styled consistently with existing blob attachment previews
- Non-editable inline atoms prevent accidental modification

The preview displays as a compact chip with:
- Icon (📝)
- Event kind name (from getKindName)
- URI type indicator
- Hover state for better UX