### PR TITLE
style: make kind label in event menu more subtle

### DIFF
--- a/src/components/nostr/kinds/BaseEventRenderer.tsx
+++ b/src/components/nostr/kinds/BaseEventRenderer.tsx
@@ -520,21 +520,23 @@ export function BaseEventContainer({
   const displayPubkey = authorOverride?.pubkey || event.pubkey;
 
   return (
-    <div className="flex flex-col gap-2 p-3 border-b border-border/50 last:border-0">
-      <div className="flex flex-row justify-between items-center">
-        <div className="flex flex-row gap-2 items-baseline">
-          <EventAuthor pubkey={displayPubkey} />
-          <span
-            className="text-xs text-muted-foreground cursor-help"
-            title={absoluteTime}
-          >
-            {relativeTime}
-          </span>
+    <EventContextMenu event={event}>
+      <div className="flex flex-col gap-2 p-3 border-b border-border/50 last:border-0">
+        <div className="flex flex-row justify-between items-center">
+          <div className="flex flex-row gap-2 items-baseline">
+            <EventAuthor pubkey={displayPubkey} />
+            <span
+              className="text-xs text-muted-foreground cursor-help"
+              title={absoluteTime}
+            >
+              {relativeTime}
+            </span>
+          </div>
+          <EventMenu event={event} />
         </div>
-        <EventMenu event={event} />
+        {children}
+        <EventFooter event={event} />
       </div>
-      {children}
-      <EventFooter event={event} />
-    </div>
+    </EventContextMenu>
   );
 }

--- a/src/components/nostr/kinds/BaseEventRenderer.tsx
+++ b/src/components/nostr/kinds/BaseEventRenderer.tsx
@@ -224,13 +224,19 @@ export function EventMenu({ event }: { event: NostrEvent }) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel>
-          <div className="flex flex-row items-center gap-4">
-            <KindBadge kind={event.kind} variant="compact" />
+          <div className="flex flex-row items-center gap-2 text-xs text-muted-foreground">
+            <KindBadge
+              kind={event.kind}
+              variant="compact"
+              iconClassname="text-muted-foreground/60"
+              className="opacity-60"
+            />
             <KindBadge
               kind={event.kind}
               showName
               showKindNumber
               showIcon={false}
+              className="opacity-60"
             />
           </div>
         </DropdownMenuLabel>

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -139,11 +139,7 @@ import {
   MediaStarterPackDetailRenderer,
 } from "./StarterPackRenderer";
 import { NostrEvent } from "@/types/nostr";
-import {
-  BaseEventContainer,
-  EventContextMenu,
-  type BaseEventProps,
-} from "./BaseEventRenderer";
+import { BaseEventContainer, type BaseEventProps } from "./BaseEventRenderer";
 import { P2pOrderRenderer } from "./P2pOrderRenderer";
 import { P2pOrderDetailRenderer } from "./P2pOrderDetailRenderer";
 import { BadgeDefinitionRenderer } from "./BadgeDefinitionRenderer";
@@ -240,19 +236,17 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
 /**
  * Default renderer for kinds without custom implementations
  * Shows basic event info with raw content
- * Right-click to access event menu
+ * Right-click or tap menu button to access event menu
  */
 function DefaultKindRenderer({ event }: BaseEventProps) {
   return (
-    <EventContextMenu event={event}>
-      <BaseEventContainer event={event}>
-        <div className="text-sm text-muted-foreground">
-          <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
-            {event.content || "(empty content)"}
-          </pre>
-        </div>
-      </BaseEventContainer>
-    </EventContextMenu>
+    <BaseEventContainer event={event}>
+      <div className="text-sm text-muted-foreground">
+        <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
+          {event.content || "(empty content)"}
+        </pre>
+      </div>
+    </BaseEventContainer>
   );
 }
 

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -139,7 +139,11 @@ import {
   MediaStarterPackDetailRenderer,
 } from "./StarterPackRenderer";
 import { NostrEvent } from "@/types/nostr";
-import { BaseEventContainer, type BaseEventProps } from "./BaseEventRenderer";
+import {
+  BaseEventContainer,
+  EventContextMenu,
+  type BaseEventProps,
+} from "./BaseEventRenderer";
 import { P2pOrderRenderer } from "./P2pOrderRenderer";
 import { P2pOrderDetailRenderer } from "./P2pOrderDetailRenderer";
 import { BadgeDefinitionRenderer } from "./BadgeDefinitionRenderer";
@@ -236,16 +240,19 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
 /**
  * Default renderer for kinds without custom implementations
  * Shows basic event info with raw content
+ * Right-click to access event menu
  */
 function DefaultKindRenderer({ event }: BaseEventProps) {
   return (
-    <BaseEventContainer event={event}>
-      <div className="text-sm text-muted-foreground">
-        <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
-          {event.content || "(empty content)"}
-        </pre>
-      </div>
-    </BaseEventContainer>
+    <EventContextMenu event={event}>
+      <BaseEventContainer event={event}>
+        <div className="text-sm text-muted-foreground">
+          <pre className="text-xs overflow-x-auto whitespace-pre-wrap break-words">
+            {event.content || "(empty content)"}
+          </pre>
+        </div>
+      </BaseEventContainer>
+    </EventContextMenu>
   );
 }
 
@@ -355,6 +362,7 @@ export {
   BaseEventContainer,
   EventAuthor,
   EventMenu,
+  EventContextMenu,
 } from "./BaseEventRenderer";
 export type { BaseEventProps } from "./BaseEventRenderer";
 export { Kind1Renderer } from "./NoteRenderer";


### PR DESCRIPTION
Reduced visual prominence of kind label in generic event menu:
- Smaller text size (text-xs)
- Reduced gap between elements (gap-2 instead of gap-4)
- More muted colors (text-muted-foreground, opacity-60)
- Subtler icon (text-muted-foreground/60)

The label now appears as a small informational element rather than
looking like an interactive dropdown item.