### PR TITLE
feat: add top monthly contributor highlight in user menu

### DIFF
--- a/src/components/GrimoireWelcome.tsx
+++ b/src/components/GrimoireWelcome.tsx
@@ -148,7 +148,7 @@ export function GrimoireWelcome({
                     <span>Monthly goal</span>
                     <span>
                       {formatSats(monthlyDonations)} /{" "}
-                      {formatSats(MONTHLY_GOAL_SATS)} sats
+                      {formatSats(MONTHLY_GOAL_SATS)}
                     </span>
                   </div>
                   <Progress value={goalProgress} className="h-1" />

--- a/src/components/GrimoireWelcome.tsx
+++ b/src/components/GrimoireWelcome.tsx
@@ -1,12 +1,11 @@
-import { Terminal, Trophy } from "lucide-react";
+import { Terminal } from "lucide-react";
 import { Button } from "./ui/button";
 import { Kbd, KbdGroup } from "./ui/kbd";
 import { Progress } from "./ui/progress";
 import supportersService, { MONTHLY_GOAL_SATS } from "@/services/supporters";
 import { useLiveQuery } from "dexie-react-hooks";
 import db from "@/services/db";
-import { useProfile } from "@/hooks/useProfile";
-import { getDisplayName } from "@/lib/nostr-utils";
+import { TopContributor } from "./nostr/TopContributor";
 
 interface GrimoireWelcomeProps {
   onLaunchCommand: () => void;
@@ -29,36 +28,6 @@ const EXAMPLE_COMMANDS = [
   },
   { command: "req -k 1 -l 20", description: "Query recent notes" },
 ];
-
-function TopContributor({
-  pubkey,
-  amount,
-}: {
-  pubkey: string;
-  amount: number;
-}) {
-  const profile = useProfile(pubkey);
-  const displayName = getDisplayName(pubkey, profile);
-
-  function formatNumber(sats: number): string {
-    if (sats >= 1_000_000) {
-      return `${(sats / 1_000_000).toFixed(1)}M`;
-    } else if (sats >= 1_000) {
-      return `${Math.floor(sats / 1_000)}k`;
-    }
-    return sats.toString();
-  }
-
-  return (
-    <div className="flex items-center gap-1.5 mt-1.5 pt-1.5 border-t border-border/30">
-      <Trophy className="size-3 text-yellow-500" />
-      <span className="text-[10px] text-muted-foreground flex-1 truncate">
-        {displayName}
-      </span>
-      <span className="text-[10px] font-medium">{formatNumber(amount)}</span>
-    </div>
-  );
-}
 
 export function GrimoireWelcome({
   onLaunchCommand,
@@ -187,6 +156,7 @@ export function GrimoireWelcome({
                     <TopContributor
                       pubkey={topContributor.pubkey}
                       amount={topContributor.totalSats}
+                      variant="compact"
                     />
                   )}
                 </div>

--- a/src/components/nostr/TopContributor.tsx
+++ b/src/components/nostr/TopContributor.tsx
@@ -1,6 +1,5 @@
 import { Trophy } from "lucide-react";
-import { useProfile } from "@/hooks/useProfile";
-import { getDisplayName } from "@/lib/nostr-utils";
+import { UserName } from "./UserName";
 
 interface TopContributorProps {
   pubkey: string;
@@ -13,9 +12,6 @@ export function TopContributor({
   amount,
   variant = "default",
 }: TopContributorProps) {
-  const profile = useProfile(pubkey);
-  const displayName = getDisplayName(pubkey, profile);
-
   function formatNumber(sats: number): string {
     if (sats >= 1_000_000) {
       return `${(sats / 1_000_000).toFixed(1)}M`;
@@ -34,11 +30,11 @@ export function TopContributor({
       <Trophy
         className={`${isCompact ? "size-3" : "size-3.5"} text-yellow-500`}
       />
-      <span
+      <div
         className={`${isCompact ? "text-[10px]" : "text-xs"} text-muted-foreground flex-1 truncate`}
       >
-        {displayName}
-      </span>
+        <UserName pubkey={pubkey} />
+      </div>
       <span className={`${isCompact ? "text-[10px]" : "text-xs"} font-medium`}>
         {formatNumber(amount)}
         {!isCompact && " sats"}

--- a/src/components/nostr/TopContributor.tsx
+++ b/src/components/nostr/TopContributor.tsx
@@ -1,0 +1,48 @@
+import { Trophy } from "lucide-react";
+import { useProfile } from "@/hooks/useProfile";
+import { getDisplayName } from "@/lib/nostr-utils";
+
+interface TopContributorProps {
+  pubkey: string;
+  amount: number;
+  variant?: "default" | "compact";
+}
+
+export function TopContributor({
+  pubkey,
+  amount,
+  variant = "default",
+}: TopContributorProps) {
+  const profile = useProfile(pubkey);
+  const displayName = getDisplayName(pubkey, profile);
+
+  function formatNumber(sats: number): string {
+    if (sats >= 1_000_000) {
+      return `${(sats / 1_000_000).toFixed(1)}M`;
+    } else if (sats >= 1_000) {
+      return `${Math.floor(sats / 1_000)}k`;
+    }
+    return sats.toString();
+  }
+
+  const isCompact = variant === "compact";
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 mt-${isCompact ? "1.5" : "2"} pt-${isCompact ? "1.5" : "2"} border-t border-border/${isCompact ? "30" : "50"}`}
+    >
+      <Trophy
+        className={`${isCompact ? "size-3" : "size-3.5"} text-yellow-500`}
+      />
+      <span
+        className={`${isCompact ? "text-[10px]" : "text-xs"} text-muted-foreground flex-1 truncate`}
+      >
+        {displayName}
+      </span>
+      <span className={`${isCompact ? "text-[10px]" : "text-xs"} font-medium`}>
+        {formatNumber(amount)}
+        {!isCompact && " sats"}
+      </span>
+    </div>
+  );
+}

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -445,7 +445,7 @@ export default function UserMenu() {
                 <span className="text-muted-foreground">Monthly goal</span>
                 <span className="font-medium">
                   {formatSats(monthlyDonations)} /{" "}
-                  {formatSats(MONTHLY_GOAL_SATS)} sats
+                  {formatSats(MONTHLY_GOAL_SATS)}
                 </span>
               </div>
               <Progress value={goalProgress} className="h-1.5" />

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -8,7 +8,6 @@ import {
   Eye,
   EyeOff,
   Zap,
-  Trophy,
 } from "lucide-react";
 import accounts from "@/services/accounts";
 import { useProfile } from "@/hooks/useProfile";
@@ -40,6 +39,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Nip05 from "./nip05";
 import { RelayLink } from "./RelayLink";
+import { TopContributor } from "./TopContributor";
 import SettingsDialog from "@/components/SettingsDialog";
 import LoginDialog from "./LoginDialog";
 import ConnectWalletDialog from "@/components/ConnectWalletDialog";
@@ -79,36 +79,6 @@ function UserLabel({ pubkey }: { pubkey: string }) {
           <Nip05 pubkey={pubkey} profile={profile} />
         </span>
       ) : null}
-    </div>
-  );
-}
-
-function TopContributor({
-  pubkey,
-  amount,
-}: {
-  pubkey: string;
-  amount: number;
-}) {
-  const profile = useProfile(pubkey);
-  const displayName = getDisplayName(pubkey, profile);
-
-  function formatSats(sats: number): string {
-    if (sats >= 1_000_000) {
-      return `${(sats / 1_000_000).toFixed(1)}M`;
-    } else if (sats >= 1_000) {
-      return `${Math.floor(sats / 1_000)}k`;
-    }
-    return sats.toString();
-  }
-
-  return (
-    <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/50">
-      <Trophy className="size-3.5 text-yellow-500" />
-      <span className="text-xs text-muted-foreground flex-1 truncate">
-        {displayName}
-      </span>
-      <span className="text-xs font-medium">{formatSats(amount)} sats</span>
     </div>
   );
 }


### PR DESCRIPTION
- Add getTopMonthlyContributor() method to SupportersService to find the supporter with the highest donations in the current calendar month
- Display top contributor below the progress bar in user menu with trophy icon, display name, and amount
- Use useLiveQuery for reactive updates when new zaps arrive
- Format amounts consistently (k/M notation for readability)
- Only show when there is at least one contributor for the month