### PR TITLE
remove unnecessary toast on popup

### DIFF
--- a/src/components/WindowToolbar.tsx
+++ b/src/components/WindowToolbar.tsx
@@ -103,8 +103,6 @@ export function WindowToolbar({
 
     // Open in a new window/tab
     globalThis.window.open(popOutUrl, "_blank");
-
-    toast.success("Window popped out");
   };
 
   // Copy functionality for NIPs


### PR DESCRIPTION
Because it gets in the way when I want to close a panel and takes too long to disappear. It's not necessary anyway as a popped out window is always immediately obvious.