### PR TITLE
feat(user-menu): make relays and blossom servers collapsible dropdowns

### DIFF
--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -445,9 +445,13 @@ export default function UserMenu() {
                     Relays
                   </DropdownMenuLabel>
                   {relays.map((relay) => (
-                    <DropdownMenuItem key={relay.url} className="p-0" asChild>
+                    <DropdownMenuItem
+                      key={relay.url}
+                      className="p-0 cursor-crosshair"
+                      onClick={() => addWindow("relay", { url: relay.url })}
+                    >
                       <RelayLink
-                        className="px-2 py-1.5 w-full"
+                        className="px-2 py-1.5 w-full pointer-events-none"
                         urlClassname="text-sm"
                         iconClassname="size-4"
                         url={relay.url}

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -370,6 +370,7 @@ export default function UserMenu() {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-80" align="start">
+          {/* User Profile - Identity section */}
           {account && (
             <>
               <DropdownMenuGroup>
@@ -385,7 +386,7 @@ export default function UserMenu() {
             </>
           )}
 
-          {/* Wallet Section - Always show */}
+          {/* Wallet Section */}
           {nwcConnection ? (
             <DropdownMenuItem
               className="cursor-crosshair flex items-center justify-between"
@@ -423,112 +424,66 @@ export default function UserMenu() {
             </DropdownMenuItem>
           )}
 
-          {/* Support Grimoire Section */}
-          <DropdownMenuSeparator />
-          <DropdownMenuGroup>
-            <div
-              className="px-2 py-2 cursor-crosshair hover:bg-accent/50 transition-colors"
-              onClick={openDonate}
-            >
-              <div className="flex items-center gap-2 mb-3">
-                <Zap className="size-4 text-yellow-500" />
-                <span className="text-sm font-medium">Support Grimoire</span>
-              </div>
-              <Progress value={goalProgress} className="h-1.5 mb-1" />
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">
-                  <span className="text-foreground font-medium">
-                    {formatSats(monthlyDonations)}
-                  </span>
-                  {" / "}
-                  {formatSats(MONTHLY_GOAL_SATS)}
-                </span>
-                <span className="text-muted-foreground">
-                  {goalProgress.toFixed(0)}%
-                </span>
-              </div>
-            </div>
-          </DropdownMenuGroup>
-
+          {/* Account Configuration - Relays & Blossom */}
           {account && (
             <>
               {relays && relays.length > 0 && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger className="cursor-crosshair">
-                      <span className="text-sm">Relays</span>
-                      <span className="ml-auto text-xs text-muted-foreground">
-                        {relays.length}
-                      </span>
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                      {relays.map((relay) => (
-                        <RelayLink
-                          className="px-2 py-1"
-                          urlClassname="text-sm"
-                          iconClassname="size-4"
-                          key={relay.url}
-                          url={relay.url}
-                          read={relay.read}
-                          write={relay.write}
-                        />
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
-                </>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className="cursor-crosshair">
+                    <span className="text-sm">Relays</span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {relays.length}
+                    </span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+                    {relays.map((relay) => (
+                      <RelayLink
+                        className="px-2 py-1"
+                        urlClassname="text-sm"
+                        iconClassname="size-4"
+                        key={relay.url}
+                        url={relay.url}
+                        read={relay.read}
+                        write={relay.write}
+                      />
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
               )}
 
               {blossomServers && blossomServers.length > 0 && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger className="cursor-crosshair">
-                      <HardDrive className="size-4 mr-2" />
-                      <span className="text-sm">Blossom Servers</span>
-                      <span className="ml-auto text-xs text-muted-foreground">
-                        {blossomServers.length}
-                      </span>
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                      {blossomServers.map((server) => (
-                        <DropdownMenuItem
-                          key={server}
-                          className="cursor-crosshair"
-                          onClick={() => {
-                            addWindow(
-                              "blossom",
-                              { subcommand: "list", serverUrl: server },
-                              `Files on ${server}`,
-                            );
-                          }}
-                        >
-                          <HardDrive className="size-4 text-muted-foreground mr-2" />
-                          <span className="text-sm truncate">{server}</span>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
-                </>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger className="cursor-crosshair">
+                    <HardDrive className="size-4 mr-2" />
+                    <span className="text-sm">Blossom Servers</span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {blossomServers.length}
+                    </span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+                    {blossomServers.map((server) => (
+                      <DropdownMenuItem
+                        key={server}
+                        className="cursor-crosshair"
+                        onClick={() => {
+                          addWindow(
+                            "blossom",
+                            { subcommand: "list", serverUrl: server },
+                            `Files on ${server}`,
+                          );
+                        }}
+                      >
+                        <HardDrive className="size-4 text-muted-foreground mr-2" />
+                        <span className="text-sm truncate">{server}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
               )}
-
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={logout} className="cursor-crosshair">
-                Log out
-              </DropdownMenuItem>
             </>
           )}
 
-          {!account && (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setShowLogin(true)}>
-                Log in
-              </DropdownMenuItem>
-            </>
-          )}
-
-          {/* Theme Section - Always show */}
+          {/* App Preferences - Theme */}
           <DropdownMenuSeparator />
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="cursor-crosshair">
@@ -554,6 +509,43 @@ export default function UserMenu() {
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+
+          {/* Support Grimoire */}
+          <DropdownMenuSeparator />
+          <div
+            className="px-2 py-2 cursor-crosshair hover:bg-accent/50 transition-colors"
+            onClick={openDonate}
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <Zap className="size-4 text-yellow-500" />
+              <span className="text-sm font-medium">Support Grimoire</span>
+            </div>
+            <Progress value={goalProgress} className="h-1.5 mb-1" />
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">
+                <span className="text-foreground font-medium">
+                  {formatSats(monthlyDonations)}
+                </span>
+                {" / "}
+                {formatSats(MONTHLY_GOAL_SATS)}
+              </span>
+              <span className="text-muted-foreground">
+                {goalProgress.toFixed(0)}%
+              </span>
+            </div>
+          </div>
+
+          {/* Session Actions - Login/Logout at bottom */}
+          <DropdownMenuSeparator />
+          {account ? (
+            <DropdownMenuItem onClick={logout} className="cursor-crosshair">
+              Log out
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem onClick={() => setShowLogin(true)}>
+              Log in
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -1,6 +1,5 @@
 import {
   User,
-  HardDrive,
   Palette,
   Wallet,
   X,
@@ -461,9 +460,8 @@ export default function UserMenu() {
 
               {blossomServers && blossomServers.length > 0 && (
                 <DropdownMenuGroup>
-                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal flex items-center gap-1.5">
-                    <HardDrive className="size-3.5" />
-                    <span>Blossom Servers</span>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                    Blossom Servers
                   </DropdownMenuLabel>
                   {blossomServers.map((server) => (
                     <DropdownMenuItem
@@ -477,7 +475,6 @@ export default function UserMenu() {
                         );
                       }}
                     >
-                      <HardDrive className="size-4 text-muted-foreground mr-2" />
                       <span className="text-sm truncate">{server}</span>
                     </DropdownMenuItem>
                   ))}
@@ -490,7 +487,7 @@ export default function UserMenu() {
           <DropdownMenuSeparator />
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="cursor-crosshair">
-              <Palette className="size-4 mr-2" />
+              <Palette className="size-4 text-muted-foreground mr-2" />
               Theme
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -455,50 +455,60 @@ export default function UserMenu() {
               {relays && relays.length > 0 && (
                 <>
                   <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                      Relays
-                    </DropdownMenuLabel>
-                    {relays.map((relay) => (
-                      <RelayLink
-                        className="px-2 py-1"
-                        urlClassname="text-sm"
-                        iconClassname="size-4"
-                        key={relay.url}
-                        url={relay.url}
-                        read={relay.read}
-                        write={relay.write}
-                      />
-                    ))}
-                  </DropdownMenuGroup>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger className="cursor-crosshair">
+                      <span className="text-sm">Relays</span>
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {relays.length}
+                      </span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+                      {relays.map((relay) => (
+                        <RelayLink
+                          className="px-2 py-1"
+                          urlClassname="text-sm"
+                          iconClassname="size-4"
+                          key={relay.url}
+                          url={relay.url}
+                          read={relay.read}
+                          write={relay.write}
+                        />
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 </>
               )}
 
               {blossomServers && blossomServers.length > 0 && (
                 <>
                   <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel className="text-xs text-muted-foreground font-normal flex items-center gap-1.5">
-                      <HardDrive className="size-3.5" />
-                      <span>Blossom Servers</span>
-                    </DropdownMenuLabel>
-                    {blossomServers.map((server) => (
-                      <DropdownMenuItem
-                        key={server}
-                        className="cursor-crosshair"
-                        onClick={() => {
-                          addWindow(
-                            "blossom",
-                            { subcommand: "list", serverUrl: server },
-                            `Files on ${server}`,
-                          );
-                        }}
-                      >
-                        <HardDrive className="size-4 text-muted-foreground mr-2" />
-                        <span className="text-sm truncate">{server}</span>
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuGroup>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger className="cursor-crosshair">
+                      <HardDrive className="size-4 mr-2" />
+                      <span className="text-sm">Blossom Servers</span>
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {blossomServers.length}
+                      </span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+                      {blossomServers.map((server) => (
+                        <DropdownMenuItem
+                          key={server}
+                          className="cursor-crosshair"
+                          onClick={() => {
+                            addWindow(
+                              "blossom",
+                              { subcommand: "list", serverUrl: server },
+                              `Files on ${server}`,
+                            );
+                          }}
+                        >
+                          <HardDrive className="size-4 text-muted-foreground mr-2" />
+                          <span className="text-sm truncate">{server}</span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 </>
               )}
 

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -8,6 +8,8 @@ import {
   Eye,
   EyeOff,
   Zap,
+  LogIn,
+  LogOut,
 } from "lucide-react";
 import accounts from "@/services/accounts";
 import { useProfile } from "@/hooks/useProfile";
@@ -370,6 +372,17 @@ export default function UserMenu() {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-80" align="start">
+          {/* Login first for logged out users */}
+          {!account && (
+            <>
+              <DropdownMenuItem onClick={() => setShowLogin(true)}>
+                <LogIn className="size-4 text-muted-foreground mr-2" />
+                <span className="text-sm">Log in</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+
           {/* User Profile - Identity section */}
           {account && (
             <>
@@ -428,57 +441,47 @@ export default function UserMenu() {
           {account && (
             <>
               {relays && relays.length > 0 && (
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="cursor-crosshair">
-                    <span className="text-sm">Relays</span>
-                    <span className="ml-auto text-xs text-muted-foreground">
-                      {relays.length}
-                    </span>
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                    {relays.map((relay) => (
-                      <RelayLink
-                        className="px-2 py-1"
-                        urlClassname="text-sm"
-                        iconClassname="size-4"
-                        key={relay.url}
-                        url={relay.url}
-                        read={relay.read}
-                        write={relay.write}
-                      />
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+                    Relays
+                  </DropdownMenuLabel>
+                  {relays.map((relay) => (
+                    <RelayLink
+                      className="px-2 py-1"
+                      urlClassname="text-sm"
+                      iconClassname="size-4"
+                      key={relay.url}
+                      url={relay.url}
+                      read={relay.read}
+                      write={relay.write}
+                    />
+                  ))}
+                </DropdownMenuGroup>
               )}
 
               {blossomServers && blossomServers.length > 0 && (
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger className="cursor-crosshair">
-                    <HardDrive className="size-4 mr-2" />
-                    <span className="text-sm">Blossom Servers</span>
-                    <span className="ml-auto text-xs text-muted-foreground">
-                      {blossomServers.length}
-                    </span>
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                    {blossomServers.map((server) => (
-                      <DropdownMenuItem
-                        key={server}
-                        className="cursor-crosshair"
-                        onClick={() => {
-                          addWindow(
-                            "blossom",
-                            { subcommand: "list", serverUrl: server },
-                            `Files on ${server}`,
-                          );
-                        }}
-                      >
-                        <HardDrive className="size-4 text-muted-foreground mr-2" />
-                        <span className="text-sm truncate">{server}</span>
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal flex items-center gap-1.5">
+                    <HardDrive className="size-3.5" />
+                    <span>Blossom Servers</span>
+                  </DropdownMenuLabel>
+                  {blossomServers.map((server) => (
+                    <DropdownMenuItem
+                      key={server}
+                      className="cursor-crosshair"
+                      onClick={() => {
+                        addWindow(
+                          "blossom",
+                          { subcommand: "list", serverUrl: server },
+                          `Files on ${server}`,
+                        );
+                      }}
+                    >
+                      <HardDrive className="size-4 text-muted-foreground mr-2" />
+                      <span className="text-sm truncate">{server}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
               )}
             </>
           )}
@@ -535,16 +538,15 @@ export default function UserMenu() {
             </div>
           </div>
 
-          {/* Session Actions - Login/Logout at bottom */}
-          <DropdownMenuSeparator />
-          {account ? (
-            <DropdownMenuItem onClick={logout} className="cursor-crosshair">
-              Log out
-            </DropdownMenuItem>
-          ) : (
-            <DropdownMenuItem onClick={() => setShowLogin(true)}>
-              Log in
-            </DropdownMenuItem>
+          {/* Logout at bottom for logged in users */}
+          {account && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={logout} className="cursor-crosshair">
+                <LogOut className="size-4 text-muted-foreground mr-2" />
+                <span className="text-sm">Log out</span>
+              </DropdownMenuItem>
+            </>
           )}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -445,15 +445,16 @@ export default function UserMenu() {
                     Relays
                   </DropdownMenuLabel>
                   {relays.map((relay) => (
-                    <RelayLink
-                      className="px-2 py-1"
-                      urlClassname="text-sm"
-                      iconClassname="size-4"
-                      key={relay.url}
-                      url={relay.url}
-                      read={relay.read}
-                      write={relay.write}
-                    />
+                    <DropdownMenuItem key={relay.url} className="p-0" asChild>
+                      <RelayLink
+                        className="px-2 py-1.5 w-full"
+                        urlClassname="text-sm"
+                        iconClassname="size-4"
+                        url={relay.url}
+                        read={relay.read}
+                        write={relay.write}
+                      />
+                    </DropdownMenuItem>
                   ))}
                 </DropdownMenuGroup>
               )}
@@ -512,8 +513,8 @@ export default function UserMenu() {
 
           {/* Support Grimoire */}
           <DropdownMenuSeparator />
-          <div
-            className="px-2 py-2 cursor-crosshair hover:bg-accent/50 transition-colors"
+          <DropdownMenuItem
+            className="cursor-crosshair flex-col items-stretch p-2"
             onClick={openDonate}
           >
             <div className="flex items-center gap-2 mb-3">
@@ -533,7 +534,7 @@ export default function UserMenu() {
                 {goalProgress.toFixed(0)}%
               </span>
             </div>
-          </div>
+          </DropdownMenuItem>
 
           {/* Logout at bottom for logged in users */}
           {account && (


### PR DESCRIPTION
Convert the relays and blossom servers sections in the user menu from
always-expanded lists to collapsible dropdown submenus. Each section
now shows a count next to the title and expands on click to show the
full list. This saves vertical space in the menu when users have many
relays or servers configured.