### PR TITLE
feat(post): add POST command with rich text editor and relay selection

### DIFF
--- a/src/components/BlossomUploadDialog.tsx
+++ b/src/components/BlossomUploadDialog.tsx
@@ -54,6 +54,8 @@ interface BlossomUploadDialogProps {
   onError?: (error: Error) => void;
   /** File types to accept (e.g., "image/*,video/*,audio/*") */
   accept?: string;
+  /** Optional initial files to pre-select (e.g., from drag-and-drop) */
+  initialFiles?: File[];
 }
 
 /**
@@ -72,6 +74,7 @@ export function BlossomUploadDialog({
   onCancel,
   onError,
   accept = "image/*,video/*,audio/*",
+  initialFiles,
 }: BlossomUploadDialogProps) {
   const eventStore = useEventStore();
   const activeAccount = use$(accountManager.active$);
@@ -96,14 +99,29 @@ export function BlossomUploadDialog({
   // Reset state when dialog opens
   useEffect(() => {
     if (open) {
-      setSelectedFile(null);
-      setPreviewUrl(null);
+      // If initial files provided, set the first one
+      if (initialFiles && initialFiles.length > 0) {
+        const file = initialFiles[0];
+        setSelectedFile(file);
+
+        // Create preview URL for images/video
+        if (file.type.startsWith("image/") || file.type.startsWith("video/")) {
+          const url = URL.createObjectURL(file);
+          setPreviewUrl(url);
+        } else {
+          setPreviewUrl(null);
+        }
+      } else {
+        setSelectedFile(null);
+        setPreviewUrl(null);
+      }
+
       setUploadResults([]);
       setUploadErrors([]);
       setUploading(false);
       setUsingFallback(false);
     }
-  }, [open]);
+  }, [open, initialFiles]);
 
   // Helper to set fallback servers
   const applyFallbackServers = useCallback(() => {

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -1078,7 +1078,7 @@ export function ChatViewer({
                     variant="ghost"
                     size="icon"
                     className="flex-shrink-0 size-7 text-muted-foreground hover:text-foreground"
-                    onClick={openUpload}
+                    onClick={() => openUpload()}
                     disabled={isSending}
                   >
                     <Paperclip className="size-4" />
@@ -1096,6 +1096,10 @@ export function ChatViewer({
               searchEmojis={searchEmojis}
               searchCommands={searchCommands}
               onCommandExecute={handleCommandExecute}
+              onFileDrop={(files) => {
+                // Open upload dialog with dropped files
+                openUpload(files);
+              }}
               onSubmit={(content, emojiTags, blobAttachments) => {
                 if (content.trim()) {
                   handleSend(content, replyTo, emojiTags, blobAttachments);

--- a/src/components/ChatViewer.tsx
+++ b/src/components/ChatViewer.tsx
@@ -1096,8 +1096,8 @@ export function ChatViewer({
               searchEmojis={searchEmojis}
               searchCommands={searchCommands}
               onCommandExecute={handleCommandExecute}
-              onFileDrop={(files) => {
-                // Open upload dialog with dropped files
+              onFilePaste={(files) => {
+                // Open upload dialog with pasted files
                 openUpload(files);
               }}
               onSubmit={(content, emojiTags, blobAttachments) => {

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -480,8 +480,8 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
           }
         });
 
-        // Wait for all publishes to complete
-        await Promise.all(publishPromises);
+        // Wait for all publishes to complete (settled = all finished, regardless of success/failure)
+        await Promise.allSettled(publishPromises);
 
         // Add to event store for immediate local availability
         eventStore.add(event);

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -38,6 +38,7 @@ import { AGGREGATOR_RELAYS } from "@/services/loaders";
 import { normalizeRelayURL } from "@/lib/relay-url";
 import { use$ } from "applesauce-react/hooks";
 import { getAuthIcon } from "@/lib/relay-status-utils";
+import { GRIMOIRE_CLIENT_TAG } from "@/constants/app";
 
 // Per-relay publish status
 type RelayStatus = "pending" | "publishing" | "success" | "error";
@@ -392,7 +393,7 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
 
         // Add client tag (if enabled)
         if (settings.includeClientTag) {
-          tags.push(["client", "grimoire"]);
+          tags.push(GRIMOIRE_CLIENT_TAG);
         }
 
         // Add emoji tags

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -1,0 +1,374 @@
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
+import { Paperclip, Send, Loader2, Check, X, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "./ui/button";
+import { Checkbox } from "./ui/checkbox";
+import { Label } from "./ui/label";
+import { useAccount } from "@/hooks/useAccount";
+import { useProfileSearch } from "@/hooks/useProfileSearch";
+import { useEmojiSearch } from "@/hooks/useEmojiSearch";
+import { useBlossomUpload } from "@/hooks/useBlossomUpload";
+import { RichEditor, type RichEditorHandle } from "./editor/RichEditor";
+import type { BlobAttachment, EmojiTag } from "./editor/MentionEditor";
+import pool from "@/services/relay-pool";
+import eventStore from "@/services/event-store";
+import { EventFactory } from "applesauce-core/event-factory";
+import { useGrimoire } from "@/core/state";
+
+// Per-relay publish status
+type RelayStatus = "pending" | "publishing" | "success" | "error";
+
+interface RelayPublishState {
+  url: string;
+  status: RelayStatus;
+  error?: string;
+}
+
+export function PostViewer() {
+  const { pubkey, canSign, signer } = useAccount();
+  const { searchProfiles } = useProfileSearch();
+  const { searchEmojis } = useEmojiSearch();
+  const { state } = useGrimoire();
+
+  // Editor ref for programmatic control
+  const editorRef = useRef<RichEditorHandle>(null);
+
+  // Publish state
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [relayStates, setRelayStates] = useState<RelayPublishState[]>([]);
+  const [selectedRelays, setSelectedRelays] = useState<Set<string>>(new Set());
+
+  // Get active account's write relays from Grimoire state
+  const writeRelays = useMemo(() => {
+    if (!state.activeAccount?.relays) return [];
+    return state.activeAccount.relays.filter((r) => r.write).map((r) => r.url);
+  }, [state.activeAccount?.relays]);
+
+  // Update relay states when write relays change
+  const updateRelayStates = useCallback(() => {
+    setRelayStates(
+      writeRelays.map((url) => ({
+        url,
+        status: "pending" as RelayStatus,
+      })),
+    );
+    setSelectedRelays(new Set(writeRelays));
+  }, [writeRelays]);
+
+  // Initialize selected relays when write relays change
+  useEffect(() => {
+    if (writeRelays.length > 0) {
+      updateRelayStates();
+    }
+  }, [writeRelays, updateRelayStates]);
+
+  // Blossom upload for attachments
+  const { open: openUpload, dialog: uploadDialog } = useBlossomUpload({
+    accept: "image/*,video/*,audio/*",
+    onSuccess: (results) => {
+      if (results.length > 0 && editorRef.current) {
+        const { blob, server } = results[0];
+        editorRef.current.insertBlob({
+          url: blob.url,
+          sha256: blob.sha256,
+          mimeType: blob.type,
+          size: blob.size,
+          server,
+        });
+        editorRef.current.focus();
+      }
+    },
+  });
+
+  // Toggle relay selection
+  const toggleRelay = useCallback((url: string) => {
+    setSelectedRelays((prev) => {
+      const next = new Set(prev);
+      if (next.has(url)) {
+        next.delete(url);
+      } else {
+        next.add(url);
+      }
+      return next;
+    });
+  }, []);
+
+  // Publish to selected relays with per-relay status tracking
+  const handlePublish = useCallback(
+    async (
+      content: string,
+      emojiTags: EmojiTag[],
+      blobAttachments: BlobAttachment[],
+    ) => {
+      if (!canSign || !signer || !pubkey) {
+        toast.error("Please log in to publish");
+        return;
+      }
+
+      if (!content.trim()) {
+        toast.error("Cannot publish empty note");
+        return;
+      }
+
+      const selected = Array.from(selectedRelays);
+      if (selected.length === 0) {
+        toast.error("Please select at least one relay");
+        return;
+      }
+
+      setIsPublishing(true);
+
+      try {
+        // Create event factory with signer
+        const factory = new EventFactory();
+        factory.setSigner(signer);
+
+        // Build tags array
+        const tags: string[][] = [];
+
+        // Add emoji tags
+        for (const emoji of emojiTags) {
+          tags.push(["emoji", emoji.shortcode, emoji.url]);
+        }
+
+        // Add blob attachment tags (imeta)
+        for (const blob of blobAttachments) {
+          const imetaTag = [
+            "imeta",
+            `url ${blob.url}`,
+            `m ${blob.mimeType}`,
+            `x ${blob.sha256}`,
+            `size ${blob.size}`,
+          ];
+          if (blob.server) {
+            imetaTag.push(`server ${blob.server}`);
+          }
+          tags.push(imetaTag);
+        }
+
+        // Create and sign event (kind 1 note)
+        const draft = await factory.build({ kind: 1, content, tags });
+        const event = await factory.sign(draft);
+
+        // Initialize relay states
+        setRelayStates(
+          selected.map((url) => ({
+            url,
+            status: "publishing" as RelayStatus,
+          })),
+        );
+
+        // Publish to each relay individually to track status
+        const publishPromises = selected.map(async (relayUrl) => {
+          try {
+            await pool.publish([relayUrl], event);
+
+            // Update status to success
+            setRelayStates((prev) =>
+              prev.map((r) =>
+                r.url === relayUrl
+                  ? { ...r, status: "success" as RelayStatus }
+                  : r,
+              ),
+            );
+          } catch (error) {
+            console.error(`Failed to publish to ${relayUrl}:`, error);
+
+            // Update status to error
+            setRelayStates((prev) =>
+              prev.map((r) =>
+                r.url === relayUrl
+                  ? {
+                      ...r,
+                      status: "error" as RelayStatus,
+                      error:
+                        error instanceof Error
+                          ? error.message
+                          : "Unknown error",
+                    }
+                  : r,
+              ),
+            );
+          }
+        });
+
+        // Wait for all publishes to complete
+        await Promise.all(publishPromises);
+
+        // Add to event store for immediate local availability
+        eventStore.add(event);
+
+        // Clear editor on success
+        editorRef.current?.clear();
+
+        toast.success(
+          `Published to ${selected.length} relay${selected.length > 1 ? "s" : ""}`,
+        );
+      } catch (error) {
+        console.error("Failed to publish:", error);
+        toast.error(
+          error instanceof Error ? error.message : "Failed to publish note",
+        );
+
+        // Reset relay states to pending on error
+        setRelayStates((prev) =>
+          prev.map((r) => ({ ...r, status: "error" as RelayStatus })),
+        );
+      } finally {
+        setIsPublishing(false);
+      }
+    },
+    [canSign, signer, pubkey, selectedRelays],
+  );
+
+  // Handle file paste
+  const handleFilePaste = useCallback(
+    (files: File[]) => {
+      if (files.length > 0) {
+        // For pasted files, trigger upload dialog
+        openUpload();
+      }
+    },
+    [openUpload],
+  );
+
+  // Show login prompt if not logged in
+  if (!canSign) {
+    return (
+      <div className="h-full flex items-center justify-center p-8">
+        <div className="max-w-md text-center space-y-4">
+          <p className="text-muted-foreground">
+            You need to be logged in to post notes.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Click the user icon in the top right to log in.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Editor */}
+      <div className="flex-1 overflow-auto p-4">
+        <RichEditor
+          ref={editorRef}
+          placeholder="What's on your mind?"
+          onSubmit={handlePublish}
+          searchProfiles={searchProfiles}
+          searchEmojis={searchEmojis}
+          onFilePaste={handleFilePaste}
+          autoFocus
+          minHeight={200}
+          maxHeight={600}
+        />
+      </div>
+
+      {/* Bottom section: Relay selection and publish button */}
+      <div className="border-t border-border bg-muted/30 p-4 space-y-4">
+        {/* Relay selection */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">
+              Relays ({selectedRelays.size} selected)
+            </Label>
+            {writeRelays.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={updateRelayStates}
+                disabled={isPublishing}
+                className="h-6 text-xs"
+              >
+                <RefreshCw className="h-3 w-3 mr-1" />
+                Reset
+              </Button>
+            )}
+          </div>
+
+          {writeRelays.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No write relays configured. Please add relays in your profile
+              settings.
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-48 overflow-y-auto">
+              {relayStates.map((relay) => (
+                <div
+                  key={relay.url}
+                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-background p-2"
+                >
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <Checkbox
+                      id={relay.url}
+                      checked={selectedRelays.has(relay.url)}
+                      onCheckedChange={() => toggleRelay(relay.url)}
+                      disabled={isPublishing}
+                    />
+                    <label
+                      htmlFor={relay.url}
+                      className="text-sm cursor-pointer truncate flex-1"
+                    >
+                      {relay.url.replace(/^wss?:\/\//, "")}
+                    </label>
+                  </div>
+
+                  {/* Status indicator */}
+                  <div className="flex-shrink-0">
+                    {relay.status === "publishing" && (
+                      <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+                    )}
+                    {relay.status === "success" && (
+                      <Check className="h-4 w-4 text-green-500" />
+                    )}
+                    {relay.status === "error" && (
+                      <div title={relay.error || "Failed to publish"}>
+                        <X className="h-4 w-4 text-red-500" />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openUpload()}
+            disabled={isPublishing}
+            className="gap-2"
+          >
+            <Paperclip className="h-4 w-4" />
+            Upload
+          </Button>
+
+          <Button
+            onClick={() => editorRef.current?.submit()}
+            disabled={isPublishing || selectedRelays.size === 0}
+            className="gap-2"
+          >
+            {isPublishing ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Publishing...
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4" />
+                Publish
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* Upload dialog */}
+      {uploadDialog}
+    </div>
+  );
+}

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
-import { Paperclip, Send, Loader2, Check, X, RotateCcw } from "lucide-react";
+import { Paperclip, Send, Loader2, Check, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
@@ -201,6 +201,9 @@ export function PostViewer() {
           tags.push(["a", `${addr.kind}:${addr.pubkey}:${addr.identifier}`]);
         }
 
+        // Add client tag
+        tags.push(["client", "grimoire"]);
+
         // Add emoji tags
         for (const emoji of serialized.emojiTags) {
           tags.push(["emoji", emoji.shortcode, emoji.url]);
@@ -322,6 +325,9 @@ export function PostViewer() {
         for (const addr of addressRefs) {
           tags.push(["a", `${addr.kind}:${addr.pubkey}:${addr.identifier}`]);
         }
+
+        // Add client tag
+        tags.push(["client", "grimoire"]);
 
         // Add emoji tags
         for (const emoji of emojiTags) {
@@ -506,18 +512,6 @@ export function PostViewer() {
           <span className="text-sm text-muted-foreground">
             Relays ({selectedRelays.size} selected)
           </span>
-          {writeRelays.length > 0 && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={updateRelayStates}
-              disabled={isPublishing}
-              className="h-6 w-6"
-              title="Reset relay selection"
-            >
-              <RotateCcw className="h-3 w-3" />
-            </Button>
-          )}
         </div>
 
         {writeRelays.length === 0 ? (

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -503,6 +503,9 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
             localStorage.removeItem(draftKey);
           }
 
+          // Clear editor content
+          editorRef.current?.clear();
+
           // Show published preview
           setShowPublishedPreview(true);
 

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -308,13 +308,19 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
       if (editorRef.current) {
         setIsEditorEmpty(editorRef.current.isEmpty());
       }
-      // Update draft event JSON preview
-      if (settings.showEventJson) {
-        generateDraftEventJson();
-      }
     }, 2000);
     return () => clearInterval(timer);
-  }, [saveDraft, settings.showEventJson, generateDraftEventJson]);
+  }, [saveDraft]);
+
+  // Update JSON preview more frequently for responsive UI
+  useEffect(() => {
+    if (!settings.showEventJson) return;
+
+    const timer = setInterval(() => {
+      generateDraftEventJson();
+    }, 200);
+    return () => clearInterval(timer);
+  }, [settings.showEventJson, generateDraftEventJson]);
 
   // Blossom upload for attachments
   const { open: openUpload, dialog: uploadDialog } = useBlossomUpload({
@@ -763,20 +769,6 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
                 )}
               </Button>
             </div>
-
-            {/* Event JSON Preview */}
-            {settings.showEventJson && draftEventJson && (
-              <div className="rounded-lg border border-border overflow-hidden">
-                <div className="bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground border-b">
-                  Event JSON (Draft - Unsigned)
-                </div>
-                <div className="max-h-64">
-                  <CopyableJsonViewer
-                    json={JSON.stringify(draftEventJson, null, 2)}
-                  />
-                </div>
-              </div>
-            )}
           </>
         ) : (
           <>
@@ -903,6 +895,20 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
             </div>
           )}
         </div>
+
+        {/* Event JSON Preview */}
+        {!showPublishedPreview && settings.showEventJson && draftEventJson && (
+          <div className="rounded-lg border border-border overflow-hidden">
+            <div className="bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground border-b">
+              Event JSON (Draft - Unsigned)
+            </div>
+            <div className="overflow-y-auto" style={{ maxHeight: "400px" }}>
+              <CopyableJsonViewer
+                json={JSON.stringify(draftEventJson, null, 2)}
+              />
+            </div>
+          </div>
+        )}
 
         {/* Upload dialog */}
         {uploadDialog}

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -430,7 +430,7 @@ export function PostViewer() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="space-y-4 p-4">
+      <div className="max-w-2xl mx-auto space-y-4 p-4">
         {!showPublishedPreview ? (
           <>
             {/* Editor */}

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -429,139 +429,139 @@ export function PostViewer() {
   }
 
   return (
-    <div className="h-full flex flex-col p-4 gap-4">
-      {!showPublishedPreview ? (
-        <>
-          {/* Editor */}
-          <div className="flex-1 min-h-0">
-            <RichEditor
-              ref={editorRef}
-              placeholder="What's on your mind?"
-              onSubmit={handlePublish}
-              searchProfiles={searchProfiles}
-              searchEmojis={searchEmojis}
-              onFilePaste={handleFilePaste}
-              autoFocus
-              minHeight={150}
-              maxHeight={400}
-            />
-          </div>
+    <div className="h-full overflow-y-auto">
+      <div className="space-y-4 p-4">
+        {!showPublishedPreview ? (
+          <>
+            {/* Editor */}
+            <div>
+              <RichEditor
+                ref={editorRef}
+                placeholder="What's on your mind?"
+                onSubmit={handlePublish}
+                searchProfiles={searchProfiles}
+                searchEmojis={searchEmojis}
+                onFilePaste={handleFilePaste}
+                autoFocus
+                minHeight={150}
+                maxHeight={400}
+              />
+            </div>
 
-          {/* Action buttons */}
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => openUpload()}
-              disabled={isPublishing}
-              title="Upload image/video"
-            >
-              <Paperclip className="h-4 w-4" />
-            </Button>
+            {/* Action buttons */}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => openUpload()}
+                disabled={isPublishing}
+                title="Upload image/video"
+              >
+                <Paperclip className="h-4 w-4" />
+              </Button>
 
-            <Button
-              onClick={() => editorRef.current?.submit()}
-              disabled={
-                isPublishing || selectedRelays.size === 0 || isEditorEmpty
-              }
-              className="gap-2 flex-1"
-            >
-              {isPublishing ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Publishing...
-                </>
-              ) : (
-                <>
-                  <Send className="h-4 w-4" />
-                  Publish
-                </>
-              )}
-            </Button>
-          </div>
-        </>
-      ) : (
-        <>
-          {/* Published event preview */}
-          {lastPublishedEvent && (
-            <div className="flex-1 min-h-0 overflow-y-auto">
+              <Button
+                onClick={() => editorRef.current?.submit()}
+                disabled={
+                  isPublishing || selectedRelays.size === 0 || isEditorEmpty
+                }
+                className="gap-2 flex-1"
+              >
+                {isPublishing ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Publishing...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4" />
+                    Publish
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Published event preview */}
+            {lastPublishedEvent && (
               <div className="rounded-lg border border-border bg-muted/10 p-4">
                 <Kind1Renderer event={lastPublishedEvent} depth={0} />
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Reset button */}
-          <div className="flex justify-center flex-shrink-0">
-            <Button variant="outline" onClick={handleReset} className="gap-2">
-              <RotateCcw className="h-4 w-4" />
-              Compose Another Post
-            </Button>
+            {/* Reset button */}
+            <div className="flex justify-center">
+              <Button variant="outline" onClick={handleReset} className="gap-2">
+                <RotateCcw className="h-4 w-4" />
+                Compose Another Post
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Relay selection */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">
+              Relays ({selectedRelays.size} selected)
+            </span>
           </div>
-        </>
-      )}
 
-      {/* Relay selection */}
-      <div className="space-y-2 flex-shrink-0">
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">
-            Relays ({selectedRelays.size} selected)
-          </span>
-        </div>
-
-        <div className="space-y-1 max-h-64 overflow-y-auto">
-          {relayStates.map((relay) => (
-            <div
-              key={relay.url}
-              className="flex items-center justify-between gap-3 py-1"
-            >
-              <div className="flex items-center gap-2 flex-1 min-w-0">
-                <Checkbox
-                  id={relay.url}
-                  checked={selectedRelays.has(relay.url)}
-                  onCheckedChange={() => toggleRelay(relay.url)}
-                  disabled={isPublishing || showPublishedPreview}
-                />
-                <label
-                  htmlFor={relay.url}
-                  className="cursor-pointer truncate flex-1"
-                  onClick={(e) => e.preventDefault()}
-                >
-                  <RelayLink
-                    url={relay.url}
-                    write={true}
-                    showInboxOutbox={false}
-                    className="text-sm"
+          <div className="space-y-1 max-h-64 overflow-y-auto">
+            {relayStates.map((relay) => (
+              <div
+                key={relay.url}
+                className="flex items-center justify-between gap-3 py-1"
+              >
+                <div className="flex items-center gap-2 flex-1 min-w-0">
+                  <Checkbox
+                    id={relay.url}
+                    checked={selectedRelays.has(relay.url)}
+                    onCheckedChange={() => toggleRelay(relay.url)}
+                    disabled={isPublishing || showPublishedPreview}
                   />
-                </label>
-              </div>
-
-              {/* Status indicator */}
-              <div className="flex-shrink-0">
-                {relay.status === "publishing" && (
-                  <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-                )}
-                {relay.status === "success" && (
-                  <Check className="h-4 w-4 text-green-500" />
-                )}
-                {relay.status === "error" && (
-                  <button
-                    onClick={() => retryRelay(relay.url)}
-                    disabled={isPublishing}
-                    className="p-0.5 rounded hover:bg-red-500/10 transition-colors"
-                    title={`${relay.error || "Failed to publish"}. Click to retry.`}
+                  <label
+                    htmlFor={relay.url}
+                    className="cursor-pointer truncate flex-1"
+                    onClick={(e) => e.preventDefault()}
                   >
-                    <X className="h-4 w-4 text-red-500" />
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
+                    <RelayLink
+                      url={relay.url}
+                      write={true}
+                      showInboxOutbox={false}
+                      className="text-sm"
+                    />
+                  </label>
+                </div>
 
-      {/* Upload dialog */}
-      {uploadDialog}
+                {/* Status indicator */}
+                <div className="flex-shrink-0">
+                  {relay.status === "publishing" && (
+                    <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+                  )}
+                  {relay.status === "success" && (
+                    <Check className="h-4 w-4 text-green-500" />
+                  )}
+                  {relay.status === "error" && (
+                    <button
+                      onClick={() => retryRelay(relay.url)}
+                      disabled={isPublishing}
+                      className="p-0.5 rounded hover:bg-red-500/10 transition-colors"
+                      title={`${relay.error || "Failed to publish"}. Click to retry.`}
+                    >
+                      <X className="h-4 w-4 text-red-500" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Upload dialog */}
+        {uploadDialog}
+      </div>
     </div>
   );
 }

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -226,7 +226,7 @@ export function PostViewer() {
 
         const draft = await factory.build({
           kind: 1,
-          content: serialized.text,
+          content: serialized.text.trim(),
           tags,
         });
         const event = await factory.sign(draft);
@@ -350,7 +350,11 @@ export function PostViewer() {
         }
 
         // Create and sign event (kind 1 note)
-        const draft = await factory.build({ kind: 1, content, tags });
+        const draft = await factory.build({
+          kind: 1,
+          content: content.trim(),
+          tags,
+        });
         const event = await factory.sign(draft);
 
         // Update relay states - set selected to publishing, keep others as pending

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -249,9 +249,9 @@ export function PostViewer() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full overflow-auto p-4 space-y-4">
       {/* Editor */}
-      <div className="flex-1 overflow-auto p-4">
+      <div>
         <RichEditor
           ref={editorRef}
           placeholder="What's on your mind?"
@@ -260,111 +260,107 @@ export function PostViewer() {
           searchEmojis={searchEmojis}
           onFilePaste={handleFilePaste}
           autoFocus
-          minHeight={200}
-          maxHeight={600}
+          minHeight={150}
+          maxHeight={400}
         />
       </div>
 
-      {/* Bottom section: Relay selection and publish button */}
-      <div className="border-t border-border bg-muted/30 p-4 space-y-4">
-        {/* Relay selection */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <Label className="text-sm font-medium">
-              Relays ({selectedRelays.size} selected)
-            </Label>
-            {writeRelays.length > 0 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={updateRelayStates}
-                disabled={isPublishing}
-                className="h-6 text-xs"
-              >
-                <RefreshCw className="h-3 w-3 mr-1" />
-                Reset
-              </Button>
-            )}
-          </div>
+      {/* Action buttons */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => openUpload()}
+          disabled={isPublishing}
+          title="Upload image/video"
+        >
+          <Paperclip className="h-4 w-4" />
+        </Button>
 
-          {writeRelays.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No write relays configured. Please add relays in your profile
-              settings.
-            </p>
+        <Button
+          onClick={() => editorRef.current?.submit()}
+          disabled={isPublishing || selectedRelays.size === 0}
+          className="gap-2 flex-1"
+        >
+          {isPublishing ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Publishing...
+            </>
           ) : (
-            <div className="space-y-2 max-h-48 overflow-y-auto">
-              {relayStates.map((relay) => (
-                <div
-                  key={relay.url}
-                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-background p-2"
-                >
-                  <div className="flex items-center gap-2 flex-1 min-w-0">
-                    <Checkbox
-                      id={relay.url}
-                      checked={selectedRelays.has(relay.url)}
-                      onCheckedChange={() => toggleRelay(relay.url)}
-                      disabled={isPublishing}
-                    />
-                    <label
-                      htmlFor={relay.url}
-                      className="text-sm cursor-pointer truncate flex-1"
-                    >
-                      {relay.url.replace(/^wss?:\/\//, "")}
-                    </label>
-                  </div>
+            <>
+              <Send className="h-4 w-4" />
+              Publish
+            </>
+          )}
+        </Button>
+      </div>
 
-                  {/* Status indicator */}
-                  <div className="flex-shrink-0">
-                    {relay.status === "publishing" && (
-                      <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
-                    )}
-                    {relay.status === "success" && (
-                      <Check className="h-4 w-4 text-green-500" />
-                    )}
-                    {relay.status === "error" && (
-                      <div title={relay.error || "Failed to publish"}>
-                        <X className="h-4 w-4 text-red-500" />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
+      {/* Relay selection */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">
+            Relays ({selectedRelays.size} selected)
+          </Label>
+          {writeRelays.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={updateRelayStates}
+              disabled={isPublishing}
+              className="h-6 text-xs"
+            >
+              <RefreshCw className="h-3 w-3 mr-1" />
+              Reset
+            </Button>
           )}
         </div>
 
-        {/* Action buttons */}
-        <div className="flex items-center justify-between gap-3">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => openUpload()}
-            disabled={isPublishing}
-            className="gap-2"
-          >
-            <Paperclip className="h-4 w-4" />
-            Upload
-          </Button>
+        {writeRelays.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No write relays configured. Please add relays in your profile
+            settings.
+          </p>
+        ) : (
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+            {relayStates.map((relay) => (
+              <div
+                key={relay.url}
+                className="flex items-center justify-between gap-3 rounded-md border border-border bg-background p-2"
+              >
+                <div className="flex items-center gap-2 flex-1 min-w-0">
+                  <Checkbox
+                    id={relay.url}
+                    checked={selectedRelays.has(relay.url)}
+                    onCheckedChange={() => toggleRelay(relay.url)}
+                    disabled={isPublishing}
+                  />
+                  <label
+                    htmlFor={relay.url}
+                    className="text-sm cursor-pointer truncate flex-1"
+                  >
+                    {relay.url.replace(/^wss?:\/\//, "")}
+                  </label>
+                </div>
 
-          <Button
-            onClick={() => editorRef.current?.submit()}
-            disabled={isPublishing || selectedRelays.size === 0}
-            className="gap-2"
-          >
-            {isPublishing ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Publishing...
-              </>
-            ) : (
-              <>
-                <Send className="h-4 w-4" />
-                Publish
-              </>
-            )}
-          </Button>
-        </div>
+                {/* Status indicator */}
+                <div className="flex-shrink-0">
+                  {relay.status === "publishing" && (
+                    <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
+                  )}
+                  {relay.status === "success" && (
+                    <Check className="h-4 w-4 text-green-500" />
+                  )}
+                  {relay.status === "error" && (
+                    <div title={relay.error || "Failed to publish"}>
+                      <X className="h-4 w-4 text-red-500" />
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Upload dialog */}

--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -234,13 +234,13 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
       setIsEditorEmpty(editorRef.current.isEmpty());
     }
 
-    // Debounce draft save (2 seconds)
+    // Debounce draft save (500ms)
     if (draftSaveTimeoutRef.current) {
       clearTimeout(draftSaveTimeoutRef.current);
     }
     draftSaveTimeoutRef.current = setTimeout(() => {
       saveDraft();
-    }, 2000);
+    }, 500);
   }, [saveDraft]);
 
   // Cleanup timeout on unmount

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -47,6 +47,9 @@ const ZapWindow = lazy(() =>
   import("./ZapWindow").then((m) => ({ default: m.ZapWindow })),
 );
 const CountViewer = lazy(() => import("./CountViewer"));
+const PostViewer = lazy(() =>
+  import("./PostViewer").then((m) => ({ default: m.PostViewer })),
+);
 
 // Loading fallback component
 function ViewerLoading() {
@@ -240,6 +243,9 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
             onClose={onClose}
           />
         );
+        break;
+      case "post":
+        content = <PostViewer />;
         break;
       default:
         content = (

--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -245,7 +245,7 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
         );
         break;
       case "post":
-        content = <PostViewer />;
+        content = <PostViewer windowId={window.id} />;
         break;
       default:
         content = (

--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -337,43 +337,60 @@ const NostrEventPreview = Node.create({
         "nostr-event-preview inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-primary/10 border border-primary/30 text-xs align-middle";
       dom.contentEditable = "false";
 
-      // Icon based on type
+      // Helper to get kind icon
+      const getKindIcon = (kind?: number): string => {
+        if (!kind) return "📝";
+        if (kind === 0) return "👤"; // Profile
+        if (kind === 1) return "📝"; // Note
+        if (kind === 3) return "👥"; // Contacts
+        if (kind === 6) return "🔁"; // Repost
+        if (kind === 7) return "❤️"; // Reaction
+        if (kind === 9735) return "⚡"; // Zap
+        if (kind === 30023) return "📄"; // Long-form
+        if (kind === 30311) return "🎙️"; // Live event
+        if (kind === 1063) return "📦"; // File metadata
+        if (kind >= 30000 && kind < 40000) return "📌"; // Addressable
+        if (kind >= 10000 && kind < 20000) return "🔄"; // Replaceable
+        return "📝"; // Default
+      };
+
+      // Icon based on type and kind
       const icon = document.createElement("span");
       icon.className = "text-primary flex-shrink-0";
-      if (type === "npub" || type === "nprofile") {
-        icon.textContent = "👤";
-      } else if (type === "note" || type === "nevent") {
-        icon.textContent = "📝";
-      } else if (type === "naddr") {
-        icon.textContent = "📄";
-      } else {
-        icon.textContent = "🔗";
-      }
-      dom.appendChild(icon);
 
-      // Type label
-      const typeLabel = document.createElement("span");
-      typeLabel.className = "text-primary font-mono font-medium";
-      typeLabel.textContent = type.toUpperCase();
-      dom.appendChild(typeLabel);
+      // Content label
+      const label = document.createElement("span");
+      label.className = "text-muted-foreground truncate max-w-[120px]";
 
-      // ID preview (truncated)
-      const idLabel = document.createElement("span");
-      idLabel.className = "text-muted-foreground truncate max-w-[80px]";
       if (type === "npub") {
-        idLabel.textContent = `${data.slice(0, 8)}...`;
-      } else if (type === "note") {
-        idLabel.textContent = `${data.slice(0, 8)}...`;
-      } else if (type === "nevent") {
-        idLabel.textContent = `${data.id.slice(0, 8)}...`;
-      } else if (type === "naddr") {
-        idLabel.textContent = data.identifier
-          ? `${data.identifier.slice(0, 12)}...`
-          : `kind:${data.kind}`;
+        // npub: 👤 pubkey
+        icon.textContent = "👤";
+        label.textContent = data.slice(0, 8);
       } else if (type === "nprofile") {
-        idLabel.textContent = `${data.pubkey.slice(0, 8)}...`;
+        // nprofile: 👤 pubkey
+        icon.textContent = "👤";
+        label.textContent = data.pubkey.slice(0, 8);
+      } else if (type === "note") {
+        // note: 📝 event-id
+        icon.textContent = "📝";
+        label.textContent = data.slice(0, 8);
+      } else if (type === "nevent") {
+        // nevent: kind-icon event-id (or author if available)
+        icon.textContent = getKindIcon(data.kind);
+        // nevent can optionally include author
+        if (data.author) {
+          label.textContent = data.author.slice(0, 8);
+        } else {
+          label.textContent = data.id.slice(0, 8);
+        }
+      } else if (type === "naddr") {
+        // naddr: kind-icon author
+        icon.textContent = getKindIcon(data.kind);
+        label.textContent = data.pubkey.slice(0, 8);
       }
-      dom.appendChild(idLabel);
+
+      dom.appendChild(icon);
+      dom.appendChild(label);
 
       return { dom };
     };

--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -500,6 +500,19 @@ const FileDropHandler = Extension.create({
         key: new PluginKey("fileDropHandler"),
 
         props: {
+          handleDOMEvents: {
+            // Need to handle dragover to allow drops
+            dragover: (_view, event) => {
+              // Check if files are being dragged
+              if (event.dataTransfer?.types.includes("Files")) {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "copy";
+                return true;
+              }
+              return false;
+            },
+          },
+
           handleDrop: (_view, event) => {
             // Check if this is a file drop
             const files = event.dataTransfer?.files;

--- a/src/components/editor/MentionEditor.tsx
+++ b/src/components/editor/MentionEditor.tsx
@@ -68,6 +68,12 @@ export interface SerializedContent {
   emojiTags: EmojiTag[];
   /** Blob attachments for imeta tags (NIP-92) */
   blobAttachments: BlobAttachment[];
+  /** Mentioned pubkeys for p tags */
+  mentions: string[];
+  /** Referenced event IDs for e tags (from note/nevent) */
+  eventRefs: string[];
+  /** Referenced addresses for a tags (from naddr) */
+  addressRefs: Array<{ kind: number; pubkey: string; identifier: string }>;
 }
 
 export interface MentionEditorProps {
@@ -746,6 +752,9 @@ export const MentionEditor = forwardRef<
           text: text.trim(),
           emojiTags,
           blobAttachments,
+          mentions: [],
+          eventRefs: [],
+          addressRefs: [],
         };
       },
       [],
@@ -947,7 +956,15 @@ export const MentionEditor = forwardRef<
         clear: () => editor?.commands.clearContent(),
         getContent: () => editor?.getText() || "",
         getSerializedContent: () => {
-          if (!editor) return { text: "", emojiTags: [], blobAttachments: [] };
+          if (!editor)
+            return {
+              text: "",
+              emojiTags: [],
+              blobAttachments: [],
+              mentions: [],
+              eventRefs: [],
+              addressRefs: [],
+            };
           return serializeContent(editor);
         },
         isEmpty: () => editor?.isEmpty ?? true,

--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -45,6 +45,7 @@ export interface RichEditorProps {
     eventRefs: string[],
     addressRefs: Array<{ kind: number; pubkey: string; identifier: string }>,
   ) => void;
+  onChange?: () => void;
   searchProfiles: (query: string) => Promise<ProfileSearchResult[]>;
   searchEmojis?: (query: string) => Promise<EmojiSearchResult[]>;
   onFilePaste?: (files: File[]) => void;
@@ -230,6 +231,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
     {
       placeholder = "Write your note...",
       onSubmit,
+      onChange,
       searchProfiles,
       searchEmojis,
       onFilePaste,
@@ -521,6 +523,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
         },
       },
       autofocus: autoFocus,
+      onUpdate: () => {
+        onChange?.();
+      },
     });
 
     // Expose editor methods

--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -25,6 +25,7 @@ import {
 } from "./EmojiSuggestionList";
 import type { ProfileSearchResult } from "@/services/profile-search";
 import type { EmojiSearchResult } from "@/services/emoji-search";
+import { nip19 } from "nostr-tools";
 import { NostrPasteHandler } from "./extensions/nostr-paste-handler";
 import { FilePasteHandler } from "./extensions/file-paste-handler";
 import { BlobAttachmentRichNode } from "./extensions/blob-attachment-rich";
@@ -435,7 +436,17 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
             keepMarks: false,
           },
         }),
-        Mention.configure({
+        Mention.extend({
+          renderText({ node }) {
+            // Serialize to nostr: URI for plain text export
+            try {
+              return `nostr:${nip19.npubEncode(node.attrs.id)}`;
+            } catch (err) {
+              console.error("[Mention] Failed to encode pubkey:", err);
+              return `@${node.attrs.label}`;
+            }
+          },
+        }).configure({
           HTMLAttributes: {
             class: "mention",
           },

--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -402,7 +402,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
             serialized.eventRefs,
             serialized.addressRefs,
           );
-          editorInstance.commands.clearContent();
+          // Don't clear content here - let the parent component decide when to clear
         }
       },
       [onSubmit],

--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -1,0 +1,536 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useCallback,
+  useRef,
+} from "react";
+import { useEditor, EditorContent, ReactRenderer } from "@tiptap/react";
+import { Extension } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Mention from "@tiptap/extension-mention";
+import Placeholder from "@tiptap/extension-placeholder";
+import type { SuggestionOptions } from "@tiptap/suggestion";
+import tippy from "tippy.js";
+import type { Instance as TippyInstance } from "tippy.js";
+import "tippy.js/dist/tippy.css";
+import {
+  ProfileSuggestionList,
+  type ProfileSuggestionListHandle,
+} from "./ProfileSuggestionList";
+import {
+  EmojiSuggestionList,
+  type EmojiSuggestionListHandle,
+} from "./EmojiSuggestionList";
+import type { ProfileSearchResult } from "@/services/profile-search";
+import type { EmojiSearchResult } from "@/services/emoji-search";
+import { NostrPasteHandler } from "./extensions/nostr-paste-handler";
+import { FilePasteHandler } from "./extensions/file-paste-handler";
+import { BlobAttachmentRichNode } from "./extensions/blob-attachment-rich";
+import { NostrEventPreviewRichNode } from "./extensions/nostr-event-preview-rich";
+import type {
+  EmojiTag,
+  BlobAttachment,
+  SerializedContent,
+} from "./MentionEditor";
+
+export interface RichEditorProps {
+  placeholder?: string;
+  onSubmit?: (
+    content: string,
+    emojiTags: EmojiTag[],
+    blobAttachments: BlobAttachment[],
+  ) => void;
+  searchProfiles: (query: string) => Promise<ProfileSearchResult[]>;
+  searchEmojis?: (query: string) => Promise<EmojiSearchResult[]>;
+  onFilePaste?: (files: File[]) => void;
+  autoFocus?: boolean;
+  className?: string;
+  /** Minimum height in pixels */
+  minHeight?: number;
+  /** Maximum height in pixels */
+  maxHeight?: number;
+}
+
+export interface RichEditorHandle {
+  focus: () => void;
+  clear: () => void;
+  getContent: () => string;
+  getSerializedContent: () => SerializedContent;
+  isEmpty: () => boolean;
+  submit: () => void;
+  /** Insert text at the current cursor position */
+  insertText: (text: string) => void;
+  /** Insert a blob attachment with rich preview */
+  insertBlob: (blob: BlobAttachment) => void;
+}
+
+// Create emoji extension by extending Mention with a different name and custom node view
+const EmojiMention = Mention.extend({
+  name: "emoji",
+
+  // Add custom attributes for emoji (url and source)
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      url: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-url"),
+        renderHTML: (attributes) => {
+          if (!attributes.url) return {};
+          return { "data-url": attributes.url };
+        },
+      },
+      source: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-source"),
+        renderHTML: (attributes) => {
+          if (!attributes.source) return {};
+          return { "data-source": attributes.source };
+        },
+      },
+    };
+  },
+
+  // Override renderText to return empty string (nodeView handles display)
+  renderText({ node }) {
+    // Return the emoji character for unicode, or empty for custom
+    // This is what gets copied to clipboard
+    if (node.attrs.source === "unicode") {
+      return node.attrs.url || "";
+    }
+    return `:${node.attrs.id}:`;
+  },
+
+  addNodeView() {
+    return ({ node }) => {
+      const { url, source, id } = node.attrs;
+      const isUnicode = source === "unicode";
+
+      // Create wrapper span
+      const dom = document.createElement("span");
+      dom.className = "emoji-node";
+      dom.setAttribute("data-emoji", id || "");
+
+      if (isUnicode && url) {
+        // Unicode emoji - render as text span
+        const span = document.createElement("span");
+        span.className = "emoji-unicode";
+        span.textContent = url;
+        span.title = `:${id}:`;
+        dom.appendChild(span);
+      } else if (url) {
+        // Custom emoji - render as image
+        const img = document.createElement("img");
+        img.src = url;
+        img.alt = `:${id}:`;
+        img.title = `:${id}:`;
+        img.className = "emoji-image";
+        img.draggable = false;
+        img.onerror = () => {
+          // Fallback to shortcode if image fails to load
+          dom.textContent = `:${id}:`;
+        };
+        dom.appendChild(img);
+      } else {
+        // Fallback if no url - show shortcode
+        dom.textContent = `:${id}:`;
+      }
+
+      return {
+        dom,
+      };
+    };
+  },
+});
+
+/**
+ * Serialize editor content to plain text with nostr: URIs
+ */
+function serializeContent(editor: any): SerializedContent {
+  const emojiTags: EmojiTag[] = [];
+  const blobAttachments: BlobAttachment[] = [];
+  const seenEmojis = new Set<string>();
+  const seenBlobs = new Set<string>();
+
+  // Get plain text representation
+  const text = editor.getText();
+
+  // Walk the document to collect emoji and blob data
+  editor.state.doc.descendants((node: any) => {
+    if (node.type.name === "emoji") {
+      const { id, url, source } = node.attrs;
+      // Only add custom emojis (not unicode) and avoid duplicates
+      if (source !== "unicode" && !seenEmojis.has(id)) {
+        seenEmojis.add(id);
+        emojiTags.push({ shortcode: id, url });
+      }
+    } else if (node.type.name === "blobAttachment") {
+      const { url, sha256, mimeType, size, server } = node.attrs;
+      // Avoid duplicates
+      if (!seenBlobs.has(sha256)) {
+        seenBlobs.add(sha256);
+        blobAttachments.push({ url, sha256, mimeType, size, server });
+      }
+    }
+  });
+
+  return { text, emojiTags, blobAttachments };
+}
+
+export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
+  (
+    {
+      placeholder = "Write your note...",
+      onSubmit,
+      searchProfiles,
+      searchEmojis,
+      onFilePaste,
+      autoFocus = false,
+      className = "",
+      minHeight = 200,
+      maxHeight = 600,
+    },
+    ref,
+  ) => {
+    // Ref to access handleSubmit from keyboard shortcuts
+    const handleSubmitRef = useRef<(editor: any) => void>(() => {});
+
+    // Create mention suggestion configuration for @ mentions
+    const mentionSuggestion: Omit<SuggestionOptions, "editor"> = useMemo(
+      () => ({
+        char: "@",
+        allowSpaces: false,
+        items: async ({ query }) => {
+          return await searchProfiles(query);
+        },
+        render: () => {
+          let component: ReactRenderer<ProfileSuggestionListHandle>;
+          let popup: TippyInstance[];
+
+          return {
+            onStart: (props) => {
+              component = new ReactRenderer(ProfileSuggestionList, {
+                props: { items: [], command: props.command },
+                editor: props.editor,
+              });
+
+              if (!props.clientRect) {
+                return;
+              }
+
+              popup = tippy("body", {
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+                appendTo: () => document.body,
+                content: component.element,
+                showOnCreate: true,
+                interactive: true,
+                trigger: "manual",
+                placement: "bottom-start",
+                theme: "mention",
+              });
+            },
+
+            onUpdate(props) {
+              component.updateProps({
+                items: props.items,
+                command: props.command,
+              });
+
+              if (!props.clientRect) {
+                return;
+              }
+
+              popup[0].setProps({
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+              });
+            },
+
+            onKeyDown(props) {
+              if (props.event.key === "Escape") {
+                popup[0].hide();
+                return true;
+              }
+              return component.ref?.onKeyDown(props.event) || false;
+            },
+
+            onExit() {
+              popup[0].destroy();
+              component.destroy();
+            },
+          };
+        },
+      }),
+      [searchProfiles],
+    );
+
+    // Create emoji suggestion configuration for : emojis
+    const emojiSuggestion: Omit<SuggestionOptions, "editor"> | undefined =
+      useMemo(() => {
+        if (!searchEmojis) return undefined;
+
+        return {
+          char: ":",
+          allowSpaces: false,
+          items: async ({ query }) => {
+            return await searchEmojis(query);
+          },
+          render: () => {
+            let component: ReactRenderer<EmojiSuggestionListHandle>;
+            let popup: TippyInstance[];
+
+            return {
+              onStart: (props) => {
+                component = new ReactRenderer(EmojiSuggestionList, {
+                  props: { items: [], command: props.command },
+                  editor: props.editor,
+                });
+
+                if (!props.clientRect) {
+                  return;
+                }
+
+                popup = tippy("body", {
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                  appendTo: () => document.body,
+                  content: component.element,
+                  showOnCreate: true,
+                  interactive: true,
+                  trigger: "manual",
+                  placement: "bottom-start",
+                  theme: "mention",
+                });
+              },
+
+              onUpdate(props) {
+                component.updateProps({
+                  items: props.items,
+                  command: props.command,
+                });
+
+                if (!props.clientRect) {
+                  return;
+                }
+
+                popup[0].setProps({
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                });
+              },
+
+              onKeyDown(props) {
+                if (props.event.key === "Escape") {
+                  popup[0].hide();
+                  return true;
+                }
+                return component.ref?.onKeyDown(props.event) || false;
+              },
+
+              onExit() {
+                popup[0].destroy();
+                component.destroy();
+              },
+            };
+          },
+        };
+      }, [searchEmojis]);
+
+    // Handle submit
+    const handleSubmit = useCallback(
+      (editorInstance: any) => {
+        if (editorInstance.isEmpty) {
+          return;
+        }
+
+        const serialized = serializeContent(editorInstance);
+
+        if (onSubmit) {
+          onSubmit(
+            serialized.text,
+            serialized.emojiTags,
+            serialized.blobAttachments,
+          );
+          editorInstance.commands.clearContent();
+        }
+      },
+      [onSubmit],
+    );
+
+    // Keep ref updated with latest handleSubmit
+    handleSubmitRef.current = handleSubmit;
+
+    // Build extensions array
+    const extensions = useMemo(() => {
+      // Custom extension for keyboard shortcuts
+      const SubmitShortcut = Extension.create({
+        name: "submitShortcut",
+        addKeyboardShortcuts() {
+          return {
+            // Ctrl/Cmd+Enter submits
+            "Mod-Enter": ({ editor }) => {
+              handleSubmitRef.current(editor);
+              return true;
+            },
+            // Plain Enter creates a new line (default behavior)
+          };
+        },
+      });
+
+      const exts = [
+        SubmitShortcut,
+        StarterKit.configure({
+          // Enable paragraph, hardBreak, etc. for multi-line
+          hardBreak: {
+            keepMarks: false,
+          },
+        }),
+        Mention.configure({
+          HTMLAttributes: {
+            class: "mention",
+          },
+          suggestion: {
+            ...mentionSuggestion,
+            command: ({ editor, range, props }: any) => {
+              // props is the ProfileSearchResult
+              editor
+                .chain()
+                .focus()
+                .insertContentAt(range, [
+                  {
+                    type: "mention",
+                    attrs: {
+                      id: props.pubkey,
+                      label: props.displayName,
+                    },
+                  },
+                  { type: "text", text: " " },
+                ])
+                .run();
+            },
+          },
+          renderLabel({ node }) {
+            return `@${node.attrs.label}`;
+          },
+        }),
+        Placeholder.configure({
+          placeholder,
+        }),
+        // Add blob attachment extension for full-size media previews
+        BlobAttachmentRichNode,
+        // Add nostr event preview extension for full event rendering
+        NostrEventPreviewRichNode,
+        // Add paste handler to transform bech32 strings into previews
+        NostrPasteHandler,
+        // Add file paste handler for clipboard file uploads
+        FilePasteHandler.configure({
+          onFilePaste,
+        }),
+      ];
+
+      // Add emoji extension if search is provided
+      if (emojiSuggestion) {
+        exts.push(
+          EmojiMention.configure({
+            HTMLAttributes: {
+              class: "emoji",
+            },
+            suggestion: {
+              ...emojiSuggestion,
+              command: ({ editor, range, props }: any) => {
+                // props is the EmojiSearchResult
+                editor
+                  .chain()
+                  .focus()
+                  .insertContentAt(range, [
+                    {
+                      type: "emoji",
+                      attrs: {
+                        id: props.shortcode,
+                        label: props.shortcode,
+                        url: props.url,
+                        source: props.source,
+                      },
+                    },
+                    { type: "text", text: " " },
+                  ])
+                  .run();
+              },
+            },
+          }),
+        );
+      }
+
+      return exts;
+    }, [mentionSuggestion, emojiSuggestion, onFilePaste, placeholder]);
+
+    const editor = useEditor({
+      extensions,
+      editorProps: {
+        attributes: {
+          class: "prose prose-sm max-w-none focus:outline-none",
+          style: `min-height: ${minHeight}px; max-height: ${maxHeight}px; overflow-y: auto;`,
+        },
+      },
+      autofocus: autoFocus,
+    });
+
+    // Expose editor methods
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => editor?.commands.focus(),
+        clear: () => editor?.commands.clearContent(),
+        getContent: () => editor?.getText() || "",
+        getSerializedContent: () => {
+          if (!editor) return { text: "", emojiTags: [], blobAttachments: [] };
+          return serializeContent(editor);
+        },
+        isEmpty: () => editor?.isEmpty ?? true,
+        submit: () => {
+          if (editor) {
+            handleSubmit(editor);
+          }
+        },
+        insertText: (text: string) => {
+          editor?.commands.insertContent(text);
+        },
+        insertBlob: (blob: BlobAttachment) => {
+          editor?.commands.insertContent({
+            type: "blobAttachment",
+            attrs: blob,
+          });
+        },
+      }),
+      [editor, handleSubmit],
+    );
+
+    // Handle submit on Ctrl/Cmd+Enter
+    useEffect(() => {
+      if (!editor) return;
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+          event.preventDefault();
+          handleSubmit(editor);
+        }
+      };
+
+      editor.view.dom.addEventListener("keydown", handleKeyDown);
+      return () => {
+        editor.view.dom.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [editor, handleSubmit]);
+
+    if (!editor) {
+      return null;
+    }
+
+    return (
+      <div className={`rich-editor ${className}`}>
+        <EditorContent editor={editor} />
+      </div>
+    );
+  },
+);
+
+RichEditor.displayName = "RichEditor";

--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -64,6 +64,10 @@ export interface RichEditorHandle {
   insertText: (text: string) => void;
   /** Insert a blob attachment with rich preview */
   insertBlob: (blob: BlobAttachment) => void;
+  /** Get editor state as JSON (for persistence) */
+  getJSON: () => any;
+  /** Set editor content from JSON (for restoration) */
+  setContent: (json: any) => void;
 }
 
 // Create emoji extension by extending Mention with a different name and custom node view
@@ -499,6 +503,14 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
             type: "blobAttachment",
             attrs: blob,
           });
+        },
+        getJSON: () => {
+          return editor?.getJSON() || null;
+        },
+        setContent: (json: any) => {
+          if (editor && json) {
+            editor.commands.setContent(json);
+          }
         },
       }),
       [editor, handleSubmit],

--- a/src/components/editor/extensions/blob-attachment-rich.ts
+++ b/src/components/editor/extensions/blob-attachment-rich.ts
@@ -38,6 +38,11 @@ export const BlobAttachmentRichNode = Node.create({
     ];
   },
 
+  renderText({ node }) {
+    // Serialize to URL for plain text export
+    return node.attrs.url || "";
+  },
+
   addNodeView() {
     return ReactNodeViewRenderer(BlobAttachmentRich);
   },

--- a/src/components/editor/extensions/blob-attachment-rich.ts
+++ b/src/components/editor/extensions/blob-attachment-rich.ts
@@ -1,0 +1,44 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { BlobAttachmentRich } from "../node-views/BlobAttachmentRich";
+
+/**
+ * Rich blob attachment node for long-form editors
+ *
+ * Uses React components to render full-size image/video previews
+ */
+export const BlobAttachmentRichNode = Node.create({
+  name: "blobAttachment",
+  group: "block",
+  inline: false,
+  atom: true,
+
+  addAttributes() {
+    return {
+      url: { default: null },
+      sha256: { default: null },
+      mimeType: { default: null },
+      size: { default: null },
+      server: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-blob-attachment="true"]',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-blob-attachment": "true" }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(BlobAttachmentRich);
+  },
+});

--- a/src/components/editor/extensions/file-paste-handler.ts
+++ b/src/components/editor/extensions/file-paste-handler.ts
@@ -1,0 +1,54 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+/**
+ * File paste handler extension to intercept file pastes and trigger upload
+ *
+ * Handles clipboard paste events with files (e.g., pasting images from clipboard)
+ * and triggers a callback to open the upload dialog.
+ */
+export const FilePasteHandler = Extension.create<{
+  onFilePaste?: (files: File[]) => void;
+}>({
+  name: "filePasteHandler",
+
+  addOptions() {
+    return {
+      onFilePaste: undefined,
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const onFilePaste = this.options.onFilePaste;
+
+    return [
+      new Plugin({
+        key: new PluginKey("filePasteHandler"),
+
+        props: {
+          handlePaste: (_view, event) => {
+            // Handle paste events with files (e.g., pasting images from clipboard)
+            const files = event.clipboardData?.files;
+            if (!files || files.length === 0) return false;
+
+            // Check if files are images, videos, or audio
+            const validFiles = Array.from(files).filter((file) =>
+              file.type.match(/^(image|video|audio)\//),
+            );
+
+            if (validFiles.length === 0) return false;
+
+            // Trigger the file paste callback
+            if (onFilePaste) {
+              onFilePaste(validFiles);
+              event.preventDefault();
+              return true; // Prevent default paste behavior
+            }
+
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/editor/extensions/nostr-event-preview-rich.ts
+++ b/src/components/editor/extensions/nostr-event-preview-rich.ts
@@ -1,0 +1,59 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { NostrEventPreviewRich } from "../node-views/NostrEventPreviewRich";
+import { nip19 } from "nostr-tools";
+
+/**
+ * Rich Nostr event preview node for long-form editors
+ *
+ * Uses React components to render full event previews with KindRenderer
+ */
+export const NostrEventPreviewRichNode = Node.create({
+  name: "nostrEventPreview",
+  group: "block",
+  inline: false,
+  atom: true,
+
+  addAttributes() {
+    return {
+      type: { default: null }, // 'note' | 'nevent' | 'naddr'
+      data: { default: null }, // Decoded bech32 data (varies by type)
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-nostr-preview="true"]',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, { "data-nostr-preview": "true" }),
+    ];
+  },
+
+  renderText({ node }) {
+    // Serialize back to nostr: URI for plain text export
+    const { type, data } = node.attrs;
+    try {
+      if (type === "note") {
+        return `nostr:${nip19.noteEncode(data)}`;
+      } else if (type === "nevent") {
+        return `nostr:${nip19.neventEncode(data)}`;
+      } else if (type === "naddr") {
+        return `nostr:${nip19.naddrEncode(data)}`;
+      }
+    } catch (err) {
+      console.error("[NostrEventPreviewRich] Failed to encode:", err);
+    }
+    return "";
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(NostrEventPreviewRich);
+  },
+});

--- a/src/components/editor/extensions/nostr-paste-handler.ts
+++ b/src/components/editor/extensions/nostr-paste-handler.ts
@@ -1,0 +1,170 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { nip19 } from "nostr-tools";
+import eventStore from "@/services/event-store";
+import { getProfileContent } from "applesauce-core/helpers";
+import { getDisplayName } from "@/lib/nostr-utils";
+
+/**
+ * Helper to get display name for a pubkey (synchronous lookup from cache)
+ */
+function getDisplayNameForPubkey(pubkey: string): string {
+  try {
+    // Try to get profile from event store (check if it's a BehaviorSubject with .value)
+    const profile$ = eventStore.replaceable(0, pubkey) as any;
+    if (profile$ && profile$.value) {
+      const profileEvent = profile$.value;
+      if (profileEvent) {
+        const content = getProfileContent(profileEvent);
+        if (content) {
+          // Use the Grimoire helper which handles fallbacks
+          return getDisplayName(pubkey, content);
+        }
+      }
+    }
+  } catch (err) {
+    // Ignore errors, fall through to default
+    console.debug(
+      "[NostrPasteHandler] Could not get profile for",
+      pubkey.slice(0, 8),
+      err,
+    );
+  }
+  // Fallback to short pubkey
+  return pubkey.slice(0, 8);
+}
+
+/**
+ * Paste handler extension to transform bech32 strings into preview nodes
+ *
+ * Detects and transforms:
+ * - npub/nprofile → @mention nodes
+ * - note/nevent/naddr → nostrEventPreview nodes
+ */
+export const NostrPasteHandler = Extension.create({
+  name: "nostrPasteHandler",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("nostrPasteHandler"),
+
+        props: {
+          handlePaste: (view, event) => {
+            const text = event.clipboardData?.getData("text/plain");
+            if (!text) return false;
+
+            // Regex to detect nostr bech32 strings (with or without nostr: prefix)
+            const bech32Regex =
+              /(?:nostr:)?(npub1[\w]{58,}|note1[\w]{58,}|nevent1[\w]+|naddr1[\w]+|nprofile1[\w]+)/g;
+            const matches = Array.from(text.matchAll(bech32Regex));
+
+            if (matches.length === 0) return false; // No bech32 found, use default paste
+
+            // Build content with text and preview nodes
+            const nodes: any[] = [];
+            let lastIndex = 0;
+
+            for (const match of matches) {
+              const matchedText = match[0];
+              const matchIndex = match.index!;
+              const bech32 = match[1]; // The bech32 without nostr: prefix
+
+              // Add text before this match
+              if (lastIndex < matchIndex) {
+                const textBefore = text.slice(lastIndex, matchIndex);
+                if (textBefore) {
+                  nodes.push(view.state.schema.text(textBefore));
+                }
+              }
+
+              // Try to decode bech32 and create preview node
+              try {
+                const decoded = nip19.decode(bech32);
+
+                // For npub/nprofile, create regular mention nodes (reuse existing infrastructure)
+                if (decoded.type === "npub") {
+                  const pubkey = decoded.data as string;
+                  const displayName = getDisplayNameForPubkey(pubkey);
+                  nodes.push(
+                    view.state.schema.nodes.mention.create({
+                      id: pubkey,
+                      label: displayName,
+                    }),
+                  );
+                } else if (decoded.type === "nprofile") {
+                  const pubkey = (decoded.data as any).pubkey;
+                  const displayName = getDisplayNameForPubkey(pubkey);
+                  nodes.push(
+                    view.state.schema.nodes.mention.create({
+                      id: pubkey,
+                      label: displayName,
+                    }),
+                  );
+                } else if (decoded.type === "note") {
+                  nodes.push(
+                    view.state.schema.nodes.nostrEventPreview.create({
+                      type: "note",
+                      data: decoded.data,
+                    }),
+                  );
+                } else if (decoded.type === "nevent") {
+                  nodes.push(
+                    view.state.schema.nodes.nostrEventPreview.create({
+                      type: "nevent",
+                      data: decoded.data,
+                    }),
+                  );
+                } else if (decoded.type === "naddr") {
+                  nodes.push(
+                    view.state.schema.nodes.nostrEventPreview.create({
+                      type: "naddr",
+                      data: decoded.data,
+                    }),
+                  );
+                }
+
+                // Add space after preview node
+                nodes.push(view.state.schema.text(" "));
+              } catch (err) {
+                // Invalid bech32, insert as plain text
+                console.warn(
+                  "[NostrPasteHandler] Failed to decode:",
+                  bech32,
+                  err,
+                );
+                nodes.push(view.state.schema.text(matchedText));
+              }
+
+              lastIndex = matchIndex + matchedText.length;
+            }
+
+            // Add remaining text after last match
+            if (lastIndex < text.length) {
+              const textAfter = text.slice(lastIndex);
+              if (textAfter) {
+                nodes.push(view.state.schema.text(textAfter));
+              }
+            }
+
+            // Insert all nodes at cursor position
+            if (nodes.length > 0) {
+              const { tr } = view.state;
+              const { from } = view.state.selection;
+
+              // Insert content
+              nodes.forEach((node, index) => {
+                tr.insert(from + index, node);
+              });
+
+              view.dispatch(tr);
+              return true; // Prevent default paste
+            }
+
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/components/editor/extensions/nostr-paste-handler.ts
+++ b/src/components/editor/extensions/nostr-paste-handler.ts
@@ -1,5 +1,5 @@
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { nip19 } from "nostr-tools";
 import eventStore from "@/services/event-store";
 import { getProfileContent } from "applesauce-core/helpers";
@@ -152,10 +152,15 @@ export const NostrPasteHandler = Extension.create({
               const { tr } = view.state;
               const { from } = view.state.selection;
 
-              // Insert content
-              nodes.forEach((node, index) => {
-                tr.insert(from + index, node);
+              // Insert content and track position
+              let insertPos = from;
+              nodes.forEach((node) => {
+                tr.insert(insertPos, node);
+                insertPos += node.nodeSize;
               });
+
+              // Move cursor to end of inserted content
+              tr.setSelection(TextSelection.near(tr.doc.resolve(insertPos)));
 
               view.dispatch(tr);
               return true; // Prevent default paste

--- a/src/components/editor/node-views/BlobAttachmentRich.tsx
+++ b/src/components/editor/node-views/BlobAttachmentRich.tsx
@@ -33,7 +33,7 @@ export function BlobAttachmentRich({ node, deleteNode }: ReactNodeViewProps) {
             <img
               src={url}
               alt="attachment"
-              className="max-w-full h-auto"
+              className="max-w-full h-auto max-h-96 object-contain"
               draggable={false}
             />
             {deleteNode && (
@@ -53,7 +53,7 @@ export function BlobAttachmentRich({ node, deleteNode }: ReactNodeViewProps) {
             <video
               src={url}
               controls
-              className="max-w-full h-auto"
+              className="max-w-full h-auto max-h-96"
               preload="metadata"
             />
             {deleteNode && (

--- a/src/components/editor/node-views/BlobAttachmentRich.tsx
+++ b/src/components/editor/node-views/BlobAttachmentRich.tsx
@@ -1,0 +1,123 @@
+import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
+import { X, FileIcon, Music, Film } from "lucide-react";
+
+function formatBlobSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/**
+ * Rich preview component for blob attachments in the editor
+ *
+ * Shows full-size images and videos with remove button
+ */
+export function BlobAttachmentRich({ node, deleteNode }: ReactNodeViewProps) {
+  const { url, mimeType, size } = node.attrs as {
+    url: string;
+    sha256: string;
+    mimeType: string;
+    size: number;
+    server: string;
+  };
+
+  const isImage = mimeType?.startsWith("image/");
+  const isVideo = mimeType?.startsWith("video/");
+  const isAudio = mimeType?.startsWith("audio/");
+
+  return (
+    <NodeViewWrapper className="my-3 relative group">
+      <div className="rounded-lg border border-border bg-background overflow-hidden">
+        {isImage && url && (
+          <div className="relative">
+            <img
+              src={url}
+              alt="attachment"
+              className="max-w-full h-auto"
+              draggable={false}
+            />
+            {deleteNode && (
+              <button
+                onClick={deleteNode}
+                className="absolute top-2 right-2 p-1.5 rounded-full bg-background/90 hover:bg-background border border-border opacity-0 group-hover:opacity-100 transition-opacity"
+                contentEditable={false}
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {isVideo && url && (
+          <div className="relative">
+            <video
+              src={url}
+              controls
+              className="max-w-full h-auto"
+              preload="metadata"
+            />
+            {deleteNode && (
+              <button
+                onClick={deleteNode}
+                className="absolute top-2 right-2 p-1.5 rounded-full bg-background/90 hover:bg-background border border-border opacity-0 group-hover:opacity-100 transition-opacity"
+                contentEditable={false}
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {isAudio && url && (
+          <div className="p-4 flex items-center gap-3">
+            <div className="p-3 rounded-lg bg-muted">
+              <Music className="size-6 text-muted-foreground" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <audio src={url} controls className="w-full" />
+              <p className="text-xs text-muted-foreground mt-1">
+                Audio • {formatBlobSize(size || 0)}
+              </p>
+            </div>
+            {deleteNode && (
+              <button
+                onClick={deleteNode}
+                className="p-1.5 rounded-full hover:bg-muted transition-colors"
+                contentEditable={false}
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {!isImage && !isVideo && !isAudio && (
+          <div className="p-4 flex items-center gap-3">
+            <div className="p-3 rounded-lg bg-muted">
+              {isVideo ? (
+                <Film className="size-6 text-muted-foreground" />
+              ) : (
+                <FileIcon className="size-6 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">{url}</p>
+              <p className="text-xs text-muted-foreground">
+                {mimeType || "Unknown"} • {formatBlobSize(size || 0)}
+              </p>
+            </div>
+            {deleteNode && (
+              <button
+                onClick={deleteNode}
+                className="p-1.5 rounded-full hover:bg-muted transition-colors"
+                contentEditable={false}
+              >
+                <X className="size-4" />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}

--- a/src/components/editor/node-views/NostrEventPreviewRich.tsx
+++ b/src/components/editor/node-views/NostrEventPreviewRich.tsx
@@ -2,7 +2,7 @@ import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { DetailKindRenderer } from "@/components/nostr/kinds";
 import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
-import { Loader2 } from "lucide-react";
+import { EventDetailSkeleton } from "@/components/ui/skeleton";
 
 /**
  * Rich preview component for Nostr events in the editor
@@ -41,12 +41,9 @@ export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
 
   return (
     <NodeViewWrapper className="my-2">
-      <div className="rounded-lg border border-border bg-muted/30 p-3">
+      <div className="rounded-lg border border-border bg-muted/30 p-3 pointer-events-none">
         {!event ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="size-4 animate-spin" />
-            <span>Loading event...</span>
-          </div>
+          <EventDetailSkeleton className="py-2" />
         ) : (
           <DetailKindRenderer event={event} />
         )}

--- a/src/components/editor/node-views/NostrEventPreviewRich.tsx
+++ b/src/components/editor/node-views/NostrEventPreviewRich.tsx
@@ -1,0 +1,56 @@
+import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { DetailKindRenderer } from "@/components/nostr/kinds";
+import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
+import { Loader2 } from "lucide-react";
+
+/**
+ * Rich preview component for Nostr events in the editor
+ *
+ * Uses the full DetailKindRenderer to show event content
+ */
+export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
+  const { type, data } = node.attrs as {
+    type: "note" | "nevent" | "naddr";
+    data: any;
+  };
+
+  // Build pointer for useNostrEvent hook
+  let pointer: EventPointer | AddressPointer | string | null = null;
+
+  if (type === "note") {
+    pointer = data; // Just the event ID
+  } else if (type === "nevent") {
+    pointer = {
+      id: data.id,
+      relays: data.relays || [],
+      author: data.author,
+      kind: data.kind,
+    } as EventPointer;
+  } else if (type === "naddr") {
+    pointer = {
+      kind: data.kind,
+      pubkey: data.pubkey,
+      identifier: data.identifier || "",
+      relays: data.relays || [],
+    } as AddressPointer;
+  }
+
+  // Fetch the event (only if we have a valid pointer)
+  const event = useNostrEvent(pointer || undefined);
+
+  return (
+    <NodeViewWrapper className="my-2">
+      <div className="rounded-lg border border-border bg-muted/30 p-3">
+        {!event ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" />
+            <span>Loading event...</span>
+          </div>
+        ) : (
+          <DetailKindRenderer event={event} />
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}

--- a/src/components/editor/node-views/NostrEventPreviewRich.tsx
+++ b/src/components/editor/node-views/NostrEventPreviewRich.tsx
@@ -1,13 +1,13 @@
 import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { DetailKindRenderer } from "@/components/nostr/kinds";
+import { KindRenderer } from "@/components/nostr/kinds";
 import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
-import { EventDetailSkeleton } from "@/components/ui/skeleton";
+import { EventCardSkeleton } from "@/components/ui/skeleton";
 
 /**
  * Rich preview component for Nostr events in the editor
  *
- * Uses the full DetailKindRenderer to show event content
+ * Uses the feed KindRenderer to show event content inline
  */
 export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
   const { type, data } = node.attrs as {
@@ -43,9 +43,9 @@ export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
     <NodeViewWrapper className="my-2">
       <div className="rounded-lg border border-border bg-muted/30 p-3 pointer-events-none">
         {!event ? (
-          <EventDetailSkeleton className="py-2" />
+          <EventCardSkeleton className="py-2" />
         ) : (
-          <DetailKindRenderer event={event} />
+          <KindRenderer event={event} depth={0} />
         )}
       </div>
     </NodeViewWrapper>

--- a/src/components/editor/node-views/NostrEventPreviewRich.tsx
+++ b/src/components/editor/node-views/NostrEventPreviewRich.tsx
@@ -1,4 +1,5 @@
 import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
+import { X } from "lucide-react";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { KindRenderer } from "@/components/nostr/kinds";
 import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
@@ -9,7 +10,10 @@ import { EventCardSkeleton } from "@/components/ui/skeleton";
  *
  * Uses the feed KindRenderer to show event content inline
  */
-export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
+export function NostrEventPreviewRich({
+  node,
+  deleteNode,
+}: ReactNodeViewProps) {
   const { type, data } = node.attrs as {
     type: "note" | "nevent" | "naddr";
     data: any;
@@ -40,7 +44,7 @@ export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
   const event = useNostrEvent(pointer || undefined);
 
   return (
-    <NodeViewWrapper className="my-2">
+    <NodeViewWrapper className="my-2 relative group">
       <div className="rounded-lg border border-border bg-muted/30 p-3 pointer-events-none">
         {!event ? (
           <EventCardSkeleton className="py-2" />
@@ -48,6 +52,15 @@ export function NostrEventPreviewRich({ node }: ReactNodeViewProps) {
           <KindRenderer event={event} depth={0} />
         )}
       </div>
+      {deleteNode && (
+        <button
+          onClick={deleteNode}
+          className="absolute top-2 right-2 p-1.5 rounded-full bg-background/90 hover:bg-background border border-border opacity-0 group-hover:opacity-100 transition-opacity"
+          contentEditable={false}
+        >
+          <X className="size-4" />
+        </button>
+      )}
     </NodeViewWrapper>
   );
 }

--- a/src/hooks/useBlossomUpload.tsx
+++ b/src/hooks/useBlossomUpload.tsx
@@ -14,8 +14,8 @@ export interface UseBlossomUploadOptions {
 }
 
 export interface UseBlossomUploadReturn {
-  /** Open the upload dialog */
-  open: () => void;
+  /** Open the upload dialog, optionally with pre-selected files */
+  open: (files?: File[]) => void;
   /** Close the upload dialog */
   close: () => void;
   /** Whether the dialog is currently open */
@@ -50,9 +50,20 @@ export function useBlossomUpload(
   options: UseBlossomUploadOptions = {},
 ): UseBlossomUploadReturn {
   const [isOpen, setIsOpen] = useState(false);
+  const [initialFiles, setInitialFiles] = useState<File[] | undefined>(
+    undefined,
+  );
 
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
+  const open = useCallback((files?: File[]) => {
+    setInitialFiles(files);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    // Clear initial files when closing
+    setInitialFiles(undefined);
+  }, []);
 
   const handleSuccess = useCallback(
     (results: UploadResult[]) => {
@@ -84,9 +95,17 @@ export function useBlossomUpload(
         onCancel={handleCancel}
         onError={handleError}
         accept={options.accept}
+        initialFiles={initialFiles}
       />
     ),
-    [isOpen, handleSuccess, handleCancel, handleError, options.accept],
+    [
+      isOpen,
+      handleSuccess,
+      handleCancel,
+      handleError,
+      options.accept,
+      initialFiles,
+    ],
   );
 
   return { open, close, isOpen, dialog };

--- a/src/index.css
+++ b/src/index.css
@@ -414,6 +414,25 @@ body.animating-layout
   vertical-align: middle;
 }
 
+/* Nostr event preview styles */
+.ProseMirror .nostr-event-preview {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  background-color: hsl(var(--primary) / 0.1);
+  border: 1px solid hsl(var(--primary) / 0.3);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  vertical-align: middle;
+  cursor: default;
+  transition: background-color 0.2s;
+}
+
+.ProseMirror .nostr-event-preview:hover {
+  background-color: hsl(var(--primary) / 0.15);
+}
+
 /* Hide scrollbar utility */
 .hide-scrollbar {
   scrollbar-width: none; /* Firefox */

--- a/src/index.css
+++ b/src/index.css
@@ -442,3 +442,13 @@ body.animating-layout
 .hide-scrollbar::-webkit-scrollbar {
   display: none; /* Chrome/Safari/Opera */
 }
+
+/* Hide scrollbar in RichEditor */
+.rich-editor .ProseMirror {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.rich-editor .ProseMirror::-webkit-scrollbar {
+  display: none; /* Chrome/Safari/Opera */
+}

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -23,6 +23,7 @@ export type AppId =
   | "blossom"
   | "wallet"
   | "zap"
+  | "post"
   | "win";
 
 export interface WindowInstance {

--- a/src/types/man.ts
+++ b/src/types/man.ts
@@ -843,4 +843,16 @@ export const manPages: Record<string, ManPageEntry> = {
     category: "Nostr",
     defaultProps: {},
   },
+  post: {
+    name: "post",
+    section: "1",
+    synopsis: "post",
+    description:
+      "Compose and publish a Nostr note (kind 1). Features a rich text editor with @mentions, :emoji: autocomplete, and image/video attachments. Select which relays to publish to, with write relays pre-selected by default. Track per-relay publish status (loading/success/error).",
+    examples: ["post    Open post composer"],
+    seeAlso: ["req", "profile", "blossom"],
+    appId: "post",
+    category: "Nostr",
+    defaultProps: {},
+  },
 };


### PR DESCRIPTION
Phase 3: Create POST command for publishing kind 1 notes

Features:
- RichEditor component with @mentions, :emoji: autocomplete
- Image/video upload via Blossom with drag-and-drop
- Relay selection UI with write relays pre-selected by default
- Per-relay publish status tracking (loading/success/error)
- Submit with Ctrl/Cmd+Enter keyboard shortcut
- Multi-line editing with rich previews for attachments
- NIP-30 emoji tags and NIP-92 imeta tags for attachments

Implementation:
- Add 'post' to AppId type
- Add POST command to man pages
- Create PostViewer component using RichEditor
- Wire PostViewer into WindowRenderer
- Publish events using EventFactory and RelayPool
- Track per-relay status with visual indicators

Usage:
- Run 'post' command to open the composer
- Type content with @mentions and :emoji:
- Upload media via button or drag-and-drop
- Select/deselect relays before publishing
- Press Publish button or Ctrl/Cmd+Enter to post
- View per-relay publish status in real-time