### PR TITLE
Add readable names for wiki kinds

### DIFF
--- a/src/constants/kinds.ts
+++ b/src/constants/kinds.ts
@@ -843,6 +843,20 @@ export const EVENT_KINDS: Record<number | string, EventKind> = {
     nip: "96",
     icon: Cloud,
   },
+  10101: {
+    kind: 10101,
+    name: "Wiki Authors",
+    description: "Good wiki authors",
+    nip: "54",
+    icon: Users,
+  },
+  10102: {
+    kind: 10102,
+    name: "Wiki Relays",
+    description: "Good wiki relays",
+    nip: "54",
+    icon: Radio,
+  },
   10166: {
     kind: 10166,
     name: "Relay Monitor",


### PR DESCRIPTION
Add EVENT_KINDS entries for kind 10101 (Wiki Authors) and kind 10102 (Wiki Relays) so getKindName() returns human-readable names instead of fallback "Kind 10101" / "Kind 10102".