### PR TITLE
Fix POST request error handling

### DIFF
--- a/src/components/editor/RichEditor.tsx
+++ b/src/components/editor/RichEditor.tsx
@@ -564,7 +564,8 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
           return editor?.getJSON() || null;
         },
         setContent: (json: any) => {
-          if (editor && json) {
+          // Check editor and view are ready before setting content
+          if (editor?.view?.dom && json) {
             editor.commands.setContent(json);
           }
         },
@@ -574,7 +575,8 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
 
     // Handle submit on Ctrl/Cmd+Enter
     useEffect(() => {
-      if (!editor) return;
+      // Check both editor and editor.view exist (view may not be ready immediately)
+      if (!editor?.view?.dom) return;
 
       const handleKeyDown = (event: KeyboardEvent) => {
         if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
@@ -585,7 +587,8 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(
 
       editor.view.dom.addEventListener("keydown", handleKeyDown);
       return () => {
-        editor.view.dom.removeEventListener("keydown", handleKeyDown);
+        // Also check view.dom exists in cleanup (editor might be destroyed)
+        editor.view?.dom?.removeEventListener("keydown", handleKeyDown);
       };
     }, [editor, handleSubmit]);
 


### PR DESCRIPTION
The POST command would sometimes crash with "editor view is not available" because code was accessing editor.view.dom before the editor was fully mounted. This fix:

- Adds defensive checks for editor.view?.dom in RichEditor's useEffect that attaches keyboard listeners
- Makes setContent method check editor view is ready before setting content
- Fixes PostViewer draft loading to use retry logic instead of fixed timeout
- Removes relayStates from dependency array to prevent effect re-runs
- Adds ref to track if draft was already loaded