### PR TITLE
feat: add Support tab to Settings with top donors and quick zap

### DIFF
--- a/src/components/GrimoireWelcome.tsx
+++ b/src/components/GrimoireWelcome.tsx
@@ -5,6 +5,7 @@ import { Progress } from "./ui/progress";
 import { MONTHLY_GOAL_SATS } from "@/services/supporters";
 import { useLiveQuery } from "dexie-react-hooks";
 import db from "@/services/db";
+import { useSettings } from "@/hooks/useSettings";
 
 interface GrimoireWelcomeProps {
   onLaunchCommand: () => void;
@@ -32,6 +33,8 @@ export function GrimoireWelcome({
   onLaunchCommand,
   onExecuteCommand,
 }: GrimoireWelcomeProps) {
+  const { settings } = useSettings();
+
   // Calculate monthly donations reactively from DB (last 30 days)
   const monthlyDonations =
     useLiveQuery(async () => {
@@ -135,7 +138,7 @@ export function GrimoireWelcome({
               <div className="text-xs text-muted-foreground mt-0.5">
                 {description}
               </div>
-              {showProgress && (
+              {showProgress && settings?.appearance?.showMonthlyGoal && (
                 <div className="mt-2 flex flex-col gap-1">
                   <Progress value={goalProgress} className="h-1" />
                   <div className="flex items-center justify-between text-[10px]">

--- a/src/components/SettingsViewer.tsx
+++ b/src/components/SettingsViewer.tsx
@@ -216,6 +216,27 @@ export function SettingsViewer() {
               </p>
             </div>
 
+            {/* Contribution Tiers */}
+            <div className="space-y-3">
+              <h4 className="text-sm font-medium">Contribute</h4>
+              <div className="grid grid-cols-3 gap-2">
+                {contributionTiers.map(({ amount, icon: Icon }) => (
+                  <Button
+                    key={amount}
+                    variant="outline"
+                    size="default"
+                    onClick={() => openSupportWindow(amount)}
+                    className="flex-col h-auto py-3 gap-1.5"
+                  >
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-base font-semibold">
+                      {formatAmount(amount)}
+                    </span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
             {/* Show Monthly Goal Toggle */}
             <div className="flex items-center justify-between gap-4">
               <div className="space-y-0.5">
@@ -259,27 +280,6 @@ export function SettingsViewer() {
                 <span className="text-muted-foreground">
                   {formatAmount(MONTHLY_GOAL_SATS)}
                 </span>
-              </div>
-            </div>
-
-            {/* Contribution Tiers */}
-            <div className="space-y-3">
-              <h4 className="text-sm font-medium">Contribute</h4>
-              <div className="grid grid-cols-3 gap-2">
-                {contributionTiers.map(({ amount, icon: Icon }) => (
-                  <Button
-                    key={amount}
-                    variant="outline"
-                    size="default"
-                    onClick={() => openSupportWindow(amount)}
-                    className="flex-col h-auto py-3 gap-1"
-                  >
-                    <Icon className="h-5 w-5" />
-                    <span className="text-sm font-semibold">
-                      {formatAmount(amount)}
-                    </span>
-                  </Button>
-                ))}
               </div>
             </div>
 

--- a/src/components/SettingsViewer.tsx
+++ b/src/components/SettingsViewer.tsx
@@ -9,7 +9,7 @@ import {
 import { Switch } from "./ui/switch";
 import { useSettings } from "@/hooks/useSettings";
 import { useTheme } from "@/lib/themes";
-import { Palette, FileEdit, Heart, Zap } from "lucide-react";
+import { Palette, FileEdit, Heart, Trophy } from "lucide-react";
 import { Button } from "./ui/button";
 import { Progress } from "./ui/progress";
 import { useLiveQuery } from "dexie-react-hooks";
@@ -51,17 +51,20 @@ export function SettingsViewer() {
   // Calculate monthly donation progress
   const goalProgress = (monthlyDonations / MONTHLY_GOAL_SATS) * 100;
 
-  // Format sats for display
-  function formatSats(sats: number): string {
-    if (sats >= 1_000_000) {
-      return `${(sats / 1_000_000).toFixed(1)}M`;
-    } else if (sats >= 1_000) {
-      return `${Math.floor(sats / 1_000)}k`;
+  // Format amount for display
+  function formatAmount(amount: number): string {
+    if (amount >= 1_000_000) {
+      return `${(amount / 1_000_000).toFixed(1)}M`;
+    } else if (amount >= 1_000) {
+      return `${Math.floor(amount / 1_000)}k`;
     }
-    return sats.toLocaleString();
+    return amount.toLocaleString();
   }
 
-  function openZapWindow() {
+  // Contribution tiers
+  const contributionTiers = [210, 2100, 21000, 42000, 210000];
+
+  function openSupportWindow() {
     addWindow(
       "zap",
       {
@@ -186,7 +189,7 @@ export function SettingsViewer() {
             <div>
               <h3 className="text-lg font-semibold mb-1">Support Grimoire</h3>
               <p className="text-sm text-muted-foreground">
-                Help support development with Lightning zaps
+                Help support development
               </p>
             </div>
 
@@ -202,57 +205,61 @@ export function SettingsViewer() {
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">
                   <span className="text-foreground font-semibold">
-                    {formatSats(monthlyDonations)} sats
+                    {formatAmount(monthlyDonations)}
                   </span>
                   {" raised"}
                 </span>
                 <span className="text-muted-foreground">
-                  {formatSats(MONTHLY_GOAL_SATS)} sats
+                  {formatAmount(MONTHLY_GOAL_SATS)}
                 </span>
               </div>
             </div>
 
-            {/* Top Donors This Month */}
+            {/* Contribution Tiers */}
+            <div className="space-y-3">
+              <h4 className="text-sm font-medium">Contribute</h4>
+              <div className="grid grid-cols-3 gap-2">
+                {contributionTiers.map((amount) => (
+                  <Button
+                    key={amount}
+                    variant="outline"
+                    size="sm"
+                    onClick={openSupportWindow}
+                  >
+                    {formatAmount(amount)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            {/* Top Contributors This Month */}
             {topDonors && topDonors.length > 0 && (
               <div className="space-y-3">
-                <h4 className="text-sm font-medium">Top Donors This Month</h4>
+                <h4 className="text-sm font-medium">Top Contributors</h4>
                 <div className="space-y-2">
                   {topDonors.map((donor, index) => (
                     <div
                       key={donor.pubkey}
-                      className="flex items-center justify-between p-3 rounded-lg border border-border bg-muted/30"
+                      className="flex items-center justify-between py-2"
                     >
                       <div className="flex items-center gap-3">
-                        <span className="text-lg font-bold text-muted-foreground w-6">
-                          #{index + 1}
-                        </span>
+                        {index === 0 ? (
+                          <Trophy className="h-5 w-5 text-yellow-500 fill-yellow-500" />
+                        ) : (
+                          <span className="text-base font-bold text-muted-foreground w-5 text-center">
+                            {index + 1}
+                          </span>
+                        )}
                         <UserName pubkey={donor.pubkey} />
                       </div>
-                      <span className="text-sm font-semibold text-yellow-500">
-                        {formatSats(donor.sats)} sats
+                      <span className="text-lg font-bold text-primary">
+                        {formatAmount(donor.sats)}
                       </span>
                     </div>
                   ))}
                 </div>
               </div>
             )}
-
-            {/* Quick Zap Button */}
-            <div className="space-y-3">
-              <h4 className="text-sm font-medium">Send Lightning Zap</h4>
-              <p className="text-xs text-muted-foreground">
-                Support Grimoire development with Bitcoin over Lightning
-              </p>
-              <Button
-                variant="default"
-                size="lg"
-                className="w-full gap-2"
-                onClick={openZapWindow}
-              >
-                <Zap className="h-5 w-5 text-yellow-400 fill-yellow-400" />
-                Send Zap
-              </Button>
-            </div>
           </TabsContent>
         </div>
       </Tabs>

--- a/src/components/SettingsViewer.tsx
+++ b/src/components/SettingsViewer.tsx
@@ -9,7 +9,18 @@ import {
 import { Switch } from "./ui/switch";
 import { useSettings } from "@/hooks/useSettings";
 import { useTheme } from "@/lib/themes";
-import { Palette, FileEdit, Heart, Trophy } from "lucide-react";
+import {
+  Palette,
+  FileEdit,
+  Heart,
+  HeartCrack,
+  Trophy,
+  Coffee,
+  Pizza,
+  Gift,
+  Star,
+  Crown,
+} from "lucide-react";
 import { Button } from "./ui/button";
 import { Progress } from "./ui/progress";
 import { useLiveQuery } from "dexie-react-hooks";
@@ -61,14 +72,22 @@ export function SettingsViewer() {
     return amount.toLocaleString();
   }
 
-  // Contribution tiers
-  const contributionTiers = [210, 2100, 21000, 42000, 210000];
+  // Contribution tiers with icons
+  const contributionTiers = [
+    { amount: 210, icon: Coffee },
+    { amount: 2100, icon: Pizza },
+    { amount: 21000, icon: Gift },
+    { amount: 42000, icon: Heart },
+    { amount: 210000, icon: Star },
+    { amount: 1000000, icon: Crown },
+  ];
 
-  function openSupportWindow() {
+  function openSupportWindow(amount: number) {
     addWindow(
       "zap",
       {
         recipientPubkey: GRIMOIRE_DONATE_PUBKEY,
+        defaultAmount: amount,
       },
       "Support Grimoire",
     );
@@ -88,7 +107,11 @@ export function SettingsViewer() {
               Post
             </TabsTrigger>
             <TabsTrigger value="support" className="gap-2">
-              <Heart className="h-4 w-4" />
+              {settings?.appearance?.showMonthlyGoal ? (
+                <Heart className="h-4 w-4" />
+              ) : (
+                <HeartCrack className="h-4 w-4" />
+              )}
               Support
             </TabsTrigger>
           </TabsList>
@@ -189,12 +212,36 @@ export function SettingsViewer() {
             <div>
               <h3 className="text-lg font-semibold mb-1">Support Grimoire</h3>
               <p className="text-sm text-muted-foreground">
-                Help support development
+                Fund grimoire development
               </p>
             </div>
 
+            {/* Show Monthly Goal Toggle */}
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-0.5">
+                <label
+                  htmlFor="show-monthly-goal"
+                  className="text-base font-medium cursor-pointer"
+                >
+                  Show monthly goal
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Display donation progress in UI
+                </p>
+              </div>
+              <Switch
+                id="show-monthly-goal"
+                checked={settings?.appearance?.showMonthlyGoal ?? true}
+                onCheckedChange={(checked: boolean) =>
+                  updateSetting("appearance", "showMonthlyGoal", checked)
+                }
+              />
+            </div>
+
             {/* Monthly Goal Progress */}
-            <div className="space-y-3">
+            <div
+              className={`space-y-3 ${!settings?.appearance?.showMonthlyGoal ? "blur-sm pointer-events-none" : ""}`}
+            >
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium">Monthly Goal</span>
                 <span className="text-sm text-muted-foreground">
@@ -219,14 +266,18 @@ export function SettingsViewer() {
             <div className="space-y-3">
               <h4 className="text-sm font-medium">Contribute</h4>
               <div className="grid grid-cols-3 gap-2">
-                {contributionTiers.map((amount) => (
+                {contributionTiers.map(({ amount, icon: Icon }) => (
                   <Button
                     key={amount}
                     variant="outline"
-                    size="sm"
-                    onClick={openSupportWindow}
+                    size="default"
+                    onClick={() => openSupportWindow(amount)}
+                    className="flex-col h-auto py-3 gap-1"
                   >
-                    {formatAmount(amount)}
+                    <Icon className="h-5 w-5" />
+                    <span className="text-sm font-semibold">
+                      {formatAmount(amount)}
+                    </span>
                   </Button>
                 ))}
               </div>

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -150,6 +150,13 @@ export function ZapWindow({
   const [paymentTimedOut, setPaymentTimedOut] = useState(false);
   const [zapAnonymously, setZapAnonymously] = useState(false);
 
+  // Update selected amount when defaultAmount prop changes
+  useEffect(() => {
+    if (defaultAmount) {
+      setSelectedAmount(defaultAmount);
+    }
+  }, [defaultAmount]);
+
   // Editor ref and search functions
   const editorRef = useRef<MentionEditorHandle>(null);
   const { searchProfiles } = useProfileSearch();

--- a/src/components/ZapWindow.tsx
+++ b/src/components/ZapWindow.tsx
@@ -70,6 +70,8 @@ export interface ZapWindowProps {
   customTags?: string[][];
   /** Relays where the zap receipt should be published */
   relays?: string[];
+  /** Optional default amount in sats to pre-select */
+  defaultAmount?: number;
 }
 
 // Default preset amounts in sats
@@ -99,6 +101,7 @@ export function ZapWindow({
   onClose,
   customTags,
   relays: propsRelays,
+  defaultAmount,
 }: ZapWindowProps) {
   // Load event if we have a pointer - supports both EventPointer and AddressPointer
   const event = useNostrEvent(eventPointer || addressPointer);
@@ -133,7 +136,9 @@ export function ZapWindow({
   // Cache LNURL data for recipient's Lightning address
   const { data: lnurlData } = useLnurlCache(recipientProfile?.lud16);
 
-  const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
+  const [selectedAmount, setSelectedAmount] = useState<number | null>(
+    defaultAmount || null,
+  );
   const [customAmount, setCustomAmount] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
   const [isPayingWithWallet, setIsPayingWithWallet] = useState(false);

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -49,6 +49,7 @@ import {
   GRIMOIRE_LIGHTNING_ADDRESS,
 } from "@/lib/grimoire-members";
 import { MONTHLY_GOAL_SATS } from "@/services/supporters";
+import { useSettings } from "@/hooks/useSettings";
 
 function UserAvatar({ pubkey }: { pubkey: string }) {
   const profile = useProfile(pubkey);
@@ -83,6 +84,7 @@ export default function UserMenu() {
   const account = use$(accounts.active$);
   const { state, addWindow, disconnectNWC, toggleWalletBalancesBlur } =
     useGrimoire();
+  const { settings } = useSettings();
   const relays = state.activeAccount?.relays;
   const blossomServers = state.activeAccount?.blossomServers;
   const nwcConnection = state.nwcConnection;
@@ -494,29 +496,33 @@ export default function UserMenu() {
           </DropdownMenuItem>
 
           {/* Support Grimoire */}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="cursor-crosshair flex-col items-stretch p-2"
-            onClick={openDonate}
-          >
-            <div className="flex items-center gap-2 mb-3">
-              <Zap className="size-4 text-yellow-500" />
-              <span className="text-sm font-medium">Support Grimoire</span>
-            </div>
-            <Progress value={goalProgress} className="h-1.5 mb-1" />
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">
-                <span className="text-foreground font-medium">
-                  {formatSats(monthlyDonations)}
-                </span>
-                {" / "}
-                {formatSats(MONTHLY_GOAL_SATS)}
-              </span>
-              <span className="text-muted-foreground">
-                {goalProgress.toFixed(0)}%
-              </span>
-            </div>
-          </DropdownMenuItem>
+          {settings?.appearance?.showMonthlyGoal && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="cursor-crosshair flex-col items-stretch p-2"
+                onClick={openDonate}
+              >
+                <div className="flex items-center gap-2 mb-3">
+                  <Zap className="size-4 text-yellow-500" />
+                  <span className="text-sm font-medium">Support Grimoire</span>
+                </div>
+                <Progress value={goalProgress} className="h-1.5 mb-1" />
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted-foreground">
+                    <span className="text-foreground font-medium">
+                      {formatSats(monthlyDonations)}
+                    </span>
+                    {" / "}
+                    {formatSats(MONTHLY_GOAL_SATS)}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {goalProgress.toFixed(0)}%
+                  </span>
+                </div>
+              </DropdownMenuItem>
+            </>
+          )}
 
           {/* Logout at bottom for logged in users */}
           {account && (

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -37,6 +37,8 @@ export interface AppearanceSettings {
   animationsEnabled: boolean;
   /** Accent color (hue value 0-360) */
   accentHue: number;
+  /** Show monthly donation goal in UI (user menu, welcome page, settings) */
+  showMonthlyGoal: boolean;
 }
 
 /**
@@ -153,6 +155,7 @@ const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
   fontSizeMultiplier: 1.0,
   animationsEnabled: true,
   accentHue: 280, // Purple
+  showMonthlyGoal: true,
 };
 
 const DEFAULT_RELAY_SETTINGS: RelaySettings = {


### PR DESCRIPTION
Add new Support tab in Settings page to highlight contributors:
- Monthly goal progress bar (210k sats target)
- Top 3 donors of the month with ranked display
- Quick zap button to support Grimoire development
- Reactive data from supporters service and DB
- Uses UserName component for consistent styling

Follows patterns from user-menu and welcome page.