### PR TITLE
Remove Publishing copy from POST view

### DIFF
--- a/src/components/PostViewer.tsx
+++ b/src/components/PostViewer.tsx
@@ -689,10 +689,7 @@ export function PostViewer({ windowId }: PostViewerProps = {}) {
                 className="gap-2 w-32"
               >
                 {isPublishing ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Publishing...
-                  </>
+                  <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <>
                     <Send className="h-4 w-4" />


### PR DESCRIPTION
Removed the "Publishing..." text from the Publish button during posting, keeping only the loading spinner icon for a cleaner UI.