### PR TITLE
Fix nostr entity matching in paste handler

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -392,6 +392,11 @@ body.animating-layout
   top: 0;
 }
 
+/* Disable link navigation in editor - allow editing instead of clicking */
+.ProseMirror a {
+  pointer-events: none;
+}
+
 /* Mention styles */
 .ProseMirror .mention {
   color: hsl(var(--primary));


### PR DESCRIPTION
Updates the paste handler regex to only match nostr bech32 entities (npub, note, nevent, naddr, nprofile) when surrounded by whitespace or at string boundaries. This prevents URLs containing nostr entities (e.g., https://njump.me/npub1...) from being incorrectly converted to mentions.

Uses a capture group (^|\s) instead of lookbehind assertion for Safari compatibility (lookbehind only supported in Safari 16.4+).