### PR TITLE
Fix emoji rendering in compact zap preview

### DIFF
--- a/src/components/nostr/compact/ZapCompactPreview.tsx
+++ b/src/components/nostr/compact/ZapCompactPreview.tsx
@@ -30,6 +30,16 @@ export function ZapCompactPreview({ event }: { event: NostrEvent }) {
   const zappedByAddress = useNostrEvent(addressPointer || undefined);
   const zappedEvent = zappedByAddress || zappedByEvent;
 
+  // If zapped event is a zap receipt (kind 9735), extract its zap request
+  // The actual content with emoji tags is in the zap request, not the receipt
+  const zappedEventForPreview = useMemo(() => {
+    if (zappedEvent?.kind === 9735) {
+      const innerZapRequest = getZapRequest(zappedEvent);
+      return innerZapRequest || zappedEvent;
+    }
+    return zappedEvent;
+  }, [zappedEvent]);
+
   // Convert from msats to sats
   const amountInSats = useMemo(() => {
     if (!zapAmount) return 0;
@@ -52,10 +62,10 @@ export function ZapCompactPreview({ event }: { event: NostrEvent }) {
           />
         </span>
       )}
-      {zappedEvent && (
+      {zappedEventForPreview && (
         <span className="text-muted-foreground truncate line-clamp-1">
           <RichText
-            event={zappedEvent}
+            event={zappedEventForPreview}
             className="inline text-sm leading-none"
             options={{ showMedia: false, showEventEmbeds: false }}
           />


### PR DESCRIPTION
…act view

When displaying a zap that targets another zap (kind 9735), the compact preview was passing the inner zap receipt directly to RichText. Since a zap receipt's content is empty (the user's message with emoji tags is in the embedded zap request), custom emojis weren't rendering.

Now when the zapped event is a zap receipt, we extract its zap request using getZapRequest() and use that for the preview, matching how the full renderer handles this via recursive KindRenderer.