### PR TITLE
feat: NIP-34 status events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,18 @@ if (canSign) {
 - **Path Alias**: `@/` = `./src/`
 - **Styling**: Tailwind + HSL CSS variables (theme tokens defined in `index.css`)
 - **Types**: Prefer types from `applesauce-core`, extend in `src/types/` when needed
+- **Locale-Aware Formatting** (`src/hooks/useLocale.ts`): All date, time, number, and currency formatting MUST use the user's locale:
+  - **`useLocale()` hook**: Returns `{ locale, language, region, timezone, timeFormat }` - use in components that need locale config
+  - **`formatTimestamp(timestamp, style)`**: Preferred utility for all timestamp formatting:
+    - `"relative"` → "2h ago", "3d ago"
+    - `"long"` → "January 15, 2025" (human-readable date)
+    - `"date"` → "01/15/2025" (short date)
+    - `"datetime"` → "January 15, 2025, 2:30 PM" (date with time)
+    - `"absolute"` → "2025-01-15 14:30" (ISO-8601 style)
+    - `"time"` → "14:30"
+  - Use `Intl.NumberFormat` for numbers and currencies
+  - NEVER hardcode locale strings like "en-US" or date formats like "MM/DD/YYYY"
+  - Example: `formatTimestamp(event.created_at, "long")` instead of manual `toLocaleDateString()`
 - **File Organization**: By domain (`nostr/`, `ui/`, `services/`, `hooks/`, `lib/`)
 - **State Logic**: All UI state mutations go through `src/core/logic.ts` pure functions
 

--- a/src/components/nostr/StatusIndicator.tsx
+++ b/src/components/nostr/StatusIndicator.tsx
@@ -35,8 +35,8 @@ function getStatusColorClass(kind: number): string {
       return "text-foreground";
     case 1631: // Resolved/Merged - positive
       return "text-accent";
-    case 1632: // Closed - negative
-      return "text-destructive";
+    case 1632: // Closed - warning (less aggressive than destructive)
+      return "text-warning";
     case 1633: // Draft - muted
       return "text-muted-foreground";
     default:
@@ -54,8 +54,8 @@ function getStatusBadgeClasses(kind: number): string {
       return "bg-muted/50 text-foreground border-border";
     case 1631: // Resolved/Merged - positive
       return "bg-accent/20 text-accent border-accent/30";
-    case 1632: // Closed - negative
-      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1632: // Closed - warning (less aggressive than destructive)
+      return "bg-warning/20 text-warning border-warning/30";
     case 1633: // Draft - muted
       return "bg-muted text-muted-foreground border-muted-foreground/30";
     default:

--- a/src/components/nostr/StatusIndicator.tsx
+++ b/src/components/nostr/StatusIndicator.tsx
@@ -113,7 +113,7 @@ export function StatusIndicator({
     const badgeClasses = getStatusBadgeClasses(effectiveKind);
     return (
       <span
-        className={`inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium border rounded-sm ${badgeClasses} ${className}`}
+        className={`inline-flex w-fit items-center gap-1.5 px-2 py-1 text-xs font-medium border rounded-sm ${badgeClasses} ${className}`}
       >
         <StatusIcon className="size-3.5" />
         <span className="capitalize">{statusText}</span>

--- a/src/components/nostr/StatusIndicator.tsx
+++ b/src/components/nostr/StatusIndicator.tsx
@@ -1,0 +1,135 @@
+import {
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  FileEdit,
+  Loader2,
+} from "lucide-react";
+import { getStatusType } from "@/lib/nip34-helpers";
+
+/**
+ * Get the icon component for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color class for a status kind
+ * Uses theme semantic colors
+ */
+function getStatusColorClass(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "text-foreground";
+    case 1631: // Resolved/Merged - positive
+      return "text-accent";
+    case 1632: // Closed - negative
+      return "text-destructive";
+    case 1633: // Draft - muted
+      return "text-muted-foreground";
+    default:
+      return "text-foreground";
+  }
+}
+
+/**
+ * Get the background/border classes for a status badge
+ * Uses theme semantic colors
+ */
+function getStatusBadgeClasses(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "bg-muted/50 text-foreground border-border";
+    case 1631: // Resolved/Merged - positive
+      return "bg-accent/20 text-accent border-accent/30";
+    case 1632: // Closed - negative
+      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1633: // Draft - muted
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+    default:
+      return "bg-muted/50 text-foreground border-border";
+  }
+}
+
+export interface StatusIndicatorProps {
+  /** The status event kind (1630-1633) or undefined for default "open" */
+  statusKind?: number;
+  /** Whether status is loading */
+  loading?: boolean;
+  /** Event type for appropriate labeling (affects "resolved" vs "merged") */
+  eventType?: "issue" | "patch" | "pr";
+  /** Display variant */
+  variant?: "inline" | "badge";
+  /** Optional custom class */
+  className?: string;
+}
+
+/**
+ * Reusable status indicator for NIP-34 events (issues, patches, PRs)
+ * Displays status icon and text with appropriate styling
+ */
+export function StatusIndicator({
+  statusKind,
+  loading = false,
+  eventType = "issue",
+  variant = "inline",
+  className = "",
+}: StatusIndicatorProps) {
+  if (loading) {
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 text-sm text-muted-foreground ${className}`}
+      >
+        <Loader2 className="size-3.5 animate-spin" />
+        <span>Loading...</span>
+      </span>
+    );
+  }
+
+  // Default to "open" if no status
+  const effectiveKind = statusKind ?? 1630;
+
+  // For patches/PRs, kind 1631 means "merged" not "resolved"
+  const statusText =
+    effectiveKind === 1631 && (eventType === "patch" || eventType === "pr")
+      ? "merged"
+      : getStatusType(effectiveKind) || "open";
+
+  const StatusIcon = getStatusIcon(effectiveKind);
+
+  if (variant === "badge") {
+    const badgeClasses = getStatusBadgeClasses(effectiveKind);
+    return (
+      <span
+        className={`inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium border rounded-sm ${badgeClasses} ${className}`}
+      >
+        <StatusIcon className="size-3.5" />
+        <span className="capitalize">{statusText}</span>
+      </span>
+    );
+  }
+
+  // Inline variant (default)
+  const colorClass = getStatusColorClass(effectiveKind);
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs ${className}`}>
+      <StatusIcon className={`size-3 ${colorClass}`} />
+      <span className={colorClass}>{statusText}</span>
+    </span>
+  );
+}
+
+// Re-export utilities for use in feed renderers that need just the icon/color
+export { getStatusIcon, getStatusColorClass, getStatusBadgeClasses };

--- a/src/components/nostr/kinds/ArticleDetailRenderer.tsx
+++ b/src/components/nostr/kinds/ArticleDetailRenderer.tsx
@@ -8,6 +8,7 @@ import {
 import { UserName } from "../UserName";
 import { MediaEmbed } from "../MediaEmbed";
 import { MarkdownContent } from "../MarkdownContent";
+import { formatTimestamp } from "@/hooks/useLocale";
 import type { NostrEvent } from "@/types/nostr";
 
 /**
@@ -26,14 +27,8 @@ export function Kind30023DetailRenderer({ event }: { event: NostrEvent }) {
     return rTag?.[1] || null;
   }, [event]);
 
-  // Format published date
-  const publishedDate = published
-    ? new Date(published * 1000).toLocaleDateString("en-US", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      })
-    : null;
+  // Format published date using locale utility
+  const publishedDate = published ? formatTimestamp(published, "long") : null;
 
   // Resolve article image URL
   const resolvedImageUrl = useMemo(() => {

--- a/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
+++ b/src/components/nostr/kinds/CommunityNIPDetailRenderer.tsx
@@ -5,6 +5,7 @@ import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import { Button } from "@/components/ui/button";
 import { useCopy } from "@/hooks/useCopy";
+import { formatTimestamp } from "@/hooks/useLocale";
 import { toast } from "sonner";
 import type { NostrEvent } from "@/types/nostr";
 
@@ -23,15 +24,8 @@ export function CommunityNIPDetailRenderer({ event }: { event: NostrEvent }) {
     return getTagValue(event, "r");
   }, [event]);
 
-  // Format created date
-  const createdDate = new Date(event.created_at * 1000).toLocaleDateString(
-    "en-US",
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
-  );
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "long");
 
   // Copy functionality
   const { copy, copied } = useCopy();

--- a/src/components/nostr/kinds/HighlightDetailRenderer.tsx
+++ b/src/components/nostr/kinds/HighlightDetailRenderer.tsx
@@ -11,6 +11,7 @@ import {
 import { EmbeddedEvent } from "../EmbeddedEvent";
 import { UserName } from "../UserName";
 import { useGrimoire } from "@/core/state";
+import { formatTimestamp } from "@/hooks/useLocale";
 import { RichText } from "../RichText";
 
 /**
@@ -29,15 +30,8 @@ export function Kind9802DetailRenderer({ event }: { event: NostrEvent }) {
   const eventPointer = getHighlightSourceEventPointer(event);
   const addressPointer = getHighlightSourceAddressPointer(event);
 
-  // Format created date
-  const createdDate = new Date(event.created_at * 1000).toLocaleDateString(
-    "en-US",
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
-  );
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "long");
 
   // Create synthetic event for comment rendering (preserves emoji tags)
   const commentEvent = comment

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -46,19 +46,20 @@ function getStatusIcon(kind: number) {
 
 /**
  * Get the color classes for a status badge
+ * Uses theme semantic colors
  */
 function getStatusBadgeClasses(kind: number): string {
   switch (kind) {
-    case 1630: // Open
-      return "bg-green-500/20 text-green-500 border-green-500/30";
-    case 1631: // Resolved/Merged
-      return "bg-purple-500/20 text-purple-500 border-purple-500/30";
-    case 1632: // Closed
-      return "bg-red-500/20 text-red-500 border-red-500/30";
-    case 1633: // Draft
+    case 1630: // Open - neutral
+      return "bg-muted/50 text-foreground border-border";
+    case 1631: // Resolved/Merged - positive
+      return "bg-accent/20 text-accent border-accent/30";
+    case 1632: // Closed - negative
+      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1633: // Draft - muted
       return "bg-muted text-muted-foreground border-muted-foreground/30";
     default:
-      return "bg-muted text-muted-foreground border-muted-foreground/30";
+      return "bg-muted/50 text-foreground border-border";
   }
 }
 
@@ -128,7 +129,7 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
     : CircleDot;
   const statusBadgeClasses = currentStatus
     ? getStatusBadgeClasses(currentStatus.kind)
-    : "bg-green-500/20 text-green-500 border-green-500/30";
+    : "bg-muted/50 text-foreground border-border";
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -14,6 +14,7 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
+  getRepositoryRelays,
   getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
@@ -24,7 +25,6 @@ import { RepositoryLink } from "../RepositoryLink";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { formatTimestamp } from "@/hooks/useLocale";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
 
 /**
  * Get the icon for a status kind
@@ -90,6 +90,12 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
 
   const repositoryEvent = useNostrEvent(repoPointer);
 
+  // Get relays configured in the repository for fetching status events
+  const statusRelays = useMemo(
+    () => (repositoryEvent ? getRepositoryRelays(repositoryEvent) : []),
+    [repositoryEvent],
+  );
+
   // Fetch status events that reference this issue
   // Status events use e tag with root marker to reference the issue
   const statusFilter = useMemo(
@@ -103,7 +109,7 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
   const { events: statusEvents, loading: statusLoading } = useTimeline(
     `issue-status-${event.id}`,
     statusFilter,
-    AGGREGATOR_RELAYS,
+    statusRelays,
     { limit: 20 },
   );
 

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -1,5 +1,12 @@
 import { useMemo } from "react";
-import { Tag } from "lucide-react";
+import {
+  Tag,
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  FileEdit,
+  Loader2,
+} from "lucide-react";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import type { NostrEvent } from "@/types/nostr";
@@ -7,33 +14,143 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { formatTimestamp } from "@/hooks/useLocale";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color classes for a status badge
+ */
+function getStatusBadgeClasses(kind: number): string {
+  switch (kind) {
+    case 1630: // Open
+      return "bg-green-500/20 text-green-500 border-green-500/30";
+    case 1631: // Resolved/Merged
+      return "bg-purple-500/20 text-purple-500 border-purple-500/30";
+    case 1632: // Closed
+      return "bg-red-500/20 text-red-500 border-red-500/30";
+    case 1633: // Draft
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+    default:
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+  }
+}
 
 /**
  * Detail renderer for Kind 1621 - Issue (NIP-34)
  * Full view with repository context and markdown description
  */
 export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
-  const title = useMemo(() => getIssueTitle(event), [event]);
-  const labels = useMemo(() => getIssueLabels(event), [event]);
-  const repoAddress = useMemo(() => getIssueRepositoryAddress(event), [event]);
+  const title = getIssueTitle(event);
+  const labels = getIssueLabels(event);
+  const repoAddress = getIssueRepositoryAddress(event);
 
-  // Format created date
-  const createdDate = new Date(event.created_at * 1000).toLocaleDateString(
-    "en-US",
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
   );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch status events that reference this issue
+  // Status events use e tag with root marker to reference the issue
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents, loading: statusLoading } = useTimeline(
+    `issue-status-${event.id}`,
+    statusFilter,
+    AGGREGATOR_RELAYS,
+    { limit: 20 },
+  );
+
+  // Get valid status authors (issue author + repo owner + maintainers)
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
+  );
+
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "long");
+
+  // Get status display info
+  const statusType = currentStatus ? getStatusType(currentStatus.kind) : null;
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusBadgeClasses = currentStatus
+    ? getStatusBadgeClasses(currentStatus.kind)
+    : "bg-green-500/20 text-green-500 border-green-500/30";
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* Issue Header */}
       <header className="flex flex-col gap-4 pb-4 border-b border-border">
+        {/* Status Badge */}
+        <div className="flex items-center gap-3">
+          {statusLoading ? (
+            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Loading status...</span>
+            </span>
+          ) : (
+            <span
+              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
+            >
+              <StatusIcon className="size-4" />
+              <span className="capitalize">{statusType || "open"}</span>
+            </span>
+          )}
+        </div>
+
         {/* Title */}
         <h1 className="text-3xl font-bold">{title || "Untitled Issue"}</h1>
 
@@ -79,6 +196,30 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
         <p className="text-sm text-muted-foreground italic">
           (No description provided)
         </p>
+      )}
+
+      {/* Status History (if there are status events) */}
+      {currentStatus && (
+        <section className="flex flex-col gap-2 pt-4 border-t border-border">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            Last Status Update
+          </h2>
+          <div className="flex items-center gap-2 text-sm">
+            <UserName pubkey={currentStatus.pubkey} />
+            <span className="text-muted-foreground">
+              {getStatusType(currentStatus.kind) || "updated"} this issue
+            </span>
+            <span className="text-muted-foreground">•</span>
+            <time className="text-muted-foreground">
+              {formatTimestamp(currentStatus.created_at, "date")}
+            </time>
+          </div>
+          {currentStatus.content && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {currentStatus.content}
+            </p>
+          )}
+        </section>
       )}
     </div>
   );

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -1,12 +1,5 @@
 import { useMemo } from "react";
-import {
-  Tag,
-  CircleDot,
-  CheckCircle2,
-  XCircle,
-  FileEdit,
-  Loader2,
-} from "lucide-react";
+import { Tag } from "lucide-react";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import type { NostrEvent } from "@/types/nostr";
@@ -23,47 +16,11 @@ import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { formatTimestamp } from "@/hooks/useLocale";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color classes for a status badge
- * Uses theme semantic colors
- */
-function getStatusBadgeClasses(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "bg-muted/50 text-foreground border-border";
-    case 1631: // Resolved/Merged - positive
-      return "bg-accent/20 text-accent border-accent/30";
-    case 1632: // Closed - negative
-      return "bg-destructive/20 text-destructive border-destructive/30";
-    case 1633: // Draft - muted
-      return "bg-muted text-muted-foreground border-muted-foreground/30";
-    default:
-      return "bg-muted/50 text-foreground border-border";
-  }
-}
 
 /**
  * Detail renderer for Kind 1621 - Issue (NIP-34)
@@ -153,38 +110,20 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
   // Format created date using locale utility
   const createdDate = formatTimestamp(event.created_at, "long");
 
-  // Get status display info
-  const statusType = currentStatus ? getStatusType(currentStatus.kind) : null;
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusBadgeClasses = currentStatus
-    ? getStatusBadgeClasses(currentStatus.kind)
-    : "bg-muted/50 text-foreground border-border";
-
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* Issue Header */}
-      <header className="flex flex-col gap-4 pb-4 border-b border-border">
-        {/* Status Badge */}
-        <div className="flex items-center gap-3">
-          {statusLoading ? (
-            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-              <span>Loading status...</span>
-            </span>
-          ) : (
-            <span
-              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
-            >
-              <StatusIcon className="size-4" />
-              <span className="capitalize">{statusType || "open"}</span>
-            </span>
-          )}
-        </div>
-
+      <header className="flex flex-col gap-3 pb-4 border-b border-border">
         {/* Title */}
-        <h1 className="text-3xl font-bold">{title || "Untitled Issue"}</h1>
+        <h1 className="text-2xl font-bold">{title || "Untitled Issue"}</h1>
+
+        {/* Status Badge (below title) */}
+        <StatusIndicator
+          statusKind={currentStatus?.kind}
+          loading={statusLoading}
+          eventType="issue"
+          variant="badge"
+        />
 
         {/* Repository Link */}
         {repoAddress && (

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -186,9 +186,9 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
             </time>
           </div>
           {currentStatus.content && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {currentStatus.content}
-            </p>
+            <div className="text-sm mt-1">
+              <MarkdownContent content={currentStatus.content} />
+            </div>
           )}
         </section>
       )}

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -9,6 +9,7 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
+  getRepositoryRelays,
   getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
@@ -18,7 +19,6 @@ import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
 
 /**
  * Get the icon for a status kind
@@ -84,6 +84,12 @@ export function IssueRenderer({ event }: BaseEventProps) {
 
   const repositoryEvent = useNostrEvent(repoPointer);
 
+  // Get relays configured in the repository for fetching status events
+  const statusRelays = useMemo(
+    () => (repositoryEvent ? getRepositoryRelays(repositoryEvent) : []),
+    [repositoryEvent],
+  );
+
   // Fetch status events that reference this issue
   const statusFilter = useMemo(
     () => ({
@@ -96,7 +102,7 @@ export function IssueRenderer({ event }: BaseEventProps) {
   const { events: statusEvents } = useTimeline(
     `issue-status-${event.id}`,
     statusFilter,
-    AGGREGATOR_RELAYS,
+    statusRelays,
     { limit: 10 },
   );
 

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
@@ -10,7 +9,6 @@ import {
   getIssueLabels,
   getIssueRepositoryAddress,
   getRepositoryRelays,
-  getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
@@ -18,46 +16,10 @@ import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color class for a status kind
- * Uses theme semantic colors
- */
-function getStatusColorClass(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "text-foreground";
-    case 1631: // Resolved/Merged - positive
-      return "text-accent";
-    case 1632: // Closed - negative
-      return "text-destructive";
-    case 1633: // Draft - muted
-      return "text-muted-foreground";
-    default:
-      return "text-foreground";
-  }
-}
 
 /**
  * Renderer for Kind 1621 - Issue
@@ -143,52 +105,31 @@ export function IssueRenderer({ event }: BaseEventProps) {
     [statusEvents, validAuthors],
   );
 
-  // Status display
-  const statusType = currentStatus ? getStatusType(currentStatus.kind) : "open";
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusColorClass = currentStatus
-    ? getStatusColorClass(currentStatus.kind)
-    : "text-foreground";
-
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-1">
-          {/* Status and Title */}
-          <div className="flex items-center gap-2">
-            <StatusIcon
-              className={`size-4 flex-shrink-0 ${statusColorClass}`}
-            />
-            <ClickableEventTitle
-              event={event}
-              className="font-semibold text-foreground"
-            >
-              {title || "Untitled Issue"}
-            </ClickableEventTitle>
-          </div>
+        {/* Title */}
+        <ClickableEventTitle
+          event={event}
+          className="font-semibold text-foreground"
+        >
+          {title || "Untitled Issue"}
+        </ClickableEventTitle>
 
-          {/* Status label (compact) */}
-          <div className="flex items-center gap-2 text-xs">
-            <span className={statusColorClass}>{statusType}</span>
-            {repoAddress && (
-              <>
-                <span className="text-muted-foreground">in</span>
-                <RepositoryLink repoAddress={repoAddress} />
-              </>
-            )}
-          </div>
+        {/* Status and Repository */}
+        <div className="flex items-center gap-2 text-xs">
+          <StatusIndicator statusKind={currentStatus?.kind} eventType="issue" />
+          {repoAddress && (
+            <>
+              <span className="text-muted-foreground">in</span>
+              <RepositoryLink repoAddress={repoAddress} />
+            </>
+          )}
         </div>
 
         {/* Labels */}
         {labels.length > 0 && (
-          <div
-            className="flex
-            flex-wrap
-            line-clamp-2
-            items-center gap-1 overflow-x-scroll my-1"
-          >
+          <div className="flex flex-wrap line-clamp-2 items-center gap-1 overflow-x-scroll my-1">
             {labels.map((label, idx) => (
               <Label key={idx}>{label}</Label>
             ))}

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -15,10 +15,12 @@ import {
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
 import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
 
 /**
  * Get the icon for a status kind
@@ -84,11 +86,34 @@ export function IssueRenderer({ event }: BaseEventProps) {
 
   const repositoryEvent = useNostrEvent(repoPointer);
 
-  // Get relays configured in the repository for fetching status events
-  const statusRelays = useMemo(
-    () => (repositoryEvent ? getRepositoryRelays(repositoryEvent) : []),
-    [repositoryEvent],
-  );
+  // Fetch repo author's relay list for fallback
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  // Build relay list with fallbacks:
+  // 1. Repository configured relays
+  // 2. Repo author's outbox (write) relays
+  // 3. AGGREGATOR_RELAYS as final fallback
+  const statusRelays = useMemo(() => {
+    // Try repository relays first
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+
+    // Try repo author's outbox relays
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+
+    // Fallback to aggregator relays
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
 
   // Fetch status events that reference this issue
   const statusFilter = useMemo(

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
@@ -7,37 +9,144 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color class for a status kind
+ */
+function getStatusColorClass(kind: number): string {
+  switch (kind) {
+    case 1630: // Open
+      return "text-green-500";
+    case 1631: // Resolved/Merged
+      return "text-purple-500";
+    case 1632: // Closed
+      return "text-red-500";
+    case 1633: // Draft
+      return "text-muted-foreground";
+    default:
+      return "text-green-500";
+  }
+}
 
 /**
  * Renderer for Kind 1621 - Issue
- * Displays as a compact issue card in feed view
+ * Displays as a compact issue card in feed view with status
  */
 export function IssueRenderer({ event }: BaseEventProps) {
   const title = getIssueTitle(event);
   const labels = getIssueLabels(event);
   const repoAddress = getIssueRepositoryAddress(event);
 
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch status events that reference this issue
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents } = useTimeline(
+    `issue-status-${event.id}`,
+    statusFilter,
+    AGGREGATOR_RELAYS,
+    { limit: 10 },
+  );
+
+  // Get valid status authors (issue author + repo owner + maintainers)
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
+  );
+
+  // Status display
+  const statusType = currentStatus ? getStatusType(currentStatus.kind) : "open";
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusColorClass = currentStatus
+    ? getStatusColorClass(currentStatus.kind)
+    : "text-green-500";
+
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
         <div className="flex flex-col gap-1">
-          {/* Issue Title */}
-          <ClickableEventTitle
-            event={event}
-            className="font-semibold text-foreground"
-          >
-            {title || "Untitled Issue"}
-          </ClickableEventTitle>
+          {/* Status and Title */}
+          <div className="flex items-center gap-2">
+            <StatusIcon
+              className={`size-4 flex-shrink-0 ${statusColorClass}`}
+            />
+            <ClickableEventTitle
+              event={event}
+              className="font-semibold text-foreground"
+            >
+              {title || "Untitled Issue"}
+            </ClickableEventTitle>
+          </div>
 
-          {/* Repository Reference */}
-          {repoAddress && (
-            <div className="text-xs line-clamp-1">
-              <RepositoryLink repoAddress={repoAddress} />
-            </div>
-          )}
+          {/* Status label (compact) */}
+          <div className="flex items-center gap-2 text-xs">
+            <span className={statusColorClass}>{statusType}</span>
+            {repoAddress && (
+              <>
+                <span className="text-muted-foreground">in</span>
+                <RepositoryLink repoAddress={repoAddress} />
+              </>
+            )}
+          </div>
         </div>
 
         {/* Labels */}

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -40,19 +40,20 @@ function getStatusIcon(kind: number) {
 
 /**
  * Get the color class for a status kind
+ * Uses theme semantic colors
  */
 function getStatusColorClass(kind: number): string {
   switch (kind) {
-    case 1630: // Open
-      return "text-green-500";
-    case 1631: // Resolved/Merged
-      return "text-purple-500";
-    case 1632: // Closed
-      return "text-red-500";
-    case 1633: // Draft
+    case 1630: // Open - neutral
+      return "text-foreground";
+    case 1631: // Resolved/Merged - positive
+      return "text-accent";
+    case 1632: // Closed - negative
+      return "text-destructive";
+    case 1633: // Draft - muted
       return "text-muted-foreground";
     default:
-      return "text-green-500";
+      return "text-foreground";
   }
 }
 
@@ -118,7 +119,7 @@ export function IssueRenderer({ event }: BaseEventProps) {
     : CircleDot;
   const statusColorClass = currentStatus
     ? getStatusColorClass(currentStatus.kind)
-    : "text-green-500";
+    : "text-foreground";
 
   return (
     <BaseEventContainer event={event}>

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -107,7 +107,7 @@ export function IssueRenderer({ event }: BaseEventProps) {
 
   return (
     <BaseEventContainer event={event}>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1">
         {/* Title */}
         <ClickableEventTitle
           event={event}
@@ -116,20 +116,20 @@ export function IssueRenderer({ event }: BaseEventProps) {
           {title || "Untitled Issue"}
         </ClickableEventTitle>
 
-        {/* Status and Repository */}
-        <div className="flex items-center gap-2 text-xs">
-          <StatusIndicator statusKind={currentStatus?.kind} eventType="issue" />
-          {repoAddress && (
-            <>
-              <span className="text-muted-foreground">in</span>
-              <RepositoryLink repoAddress={repoAddress} />
-            </>
-          )}
-        </div>
+        {/* Status */}
+        <StatusIndicator statusKind={currentStatus?.kind} eventType="issue" />
+
+        {/* Repository */}
+        {repoAddress && (
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">in</span>
+            <RepositoryLink repoAddress={repoAddress} />
+          </div>
+        )}
 
         {/* Labels */}
         {labels.length > 0 && (
-          <div className="flex flex-wrap line-clamp-2 items-center gap-1 overflow-x-scroll my-1">
+          <div className="flex flex-wrap line-clamp-2 items-center gap-1 overflow-x-scroll mt-1">
             {labels.map((label, idx) => (
               <Label key={idx}>{label}</Label>
             ))}

--- a/src/components/nostr/kinds/IssueStatusDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueStatusDetailRenderer.tsx
@@ -1,0 +1,148 @@
+import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
+import type { NostrEvent } from "@/types/nostr";
+import type { EventPointer } from "nostr-tools/nip19";
+import { UserName } from "../UserName";
+import { MarkdownContent } from "../MarkdownContent";
+import { EmbeddedEvent } from "../EmbeddedEvent";
+import { RepositoryLink } from "../RepositoryLink";
+import { useGrimoire } from "@/core/state";
+import { formatTimestamp } from "@/hooks/useLocale";
+import {
+  getStatusRootEventId,
+  getStatusRootRelayHint,
+  getStatusRepositoryAddress,
+  getStatusLabel,
+  getStatusType,
+} from "@/lib/nip34-helpers";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color classes for a status badge
+ */
+function getStatusBadgeClasses(kind: number): string {
+  switch (kind) {
+    case 1630: // Open
+      return "bg-green-500/20 text-green-500 border-green-500/30";
+    case 1631: // Resolved/Merged
+      return "bg-purple-500/20 text-purple-500 border-purple-500/30";
+    case 1632: // Closed
+      return "bg-red-500/20 text-red-500 border-red-500/30";
+    case 1633: // Draft
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+    default:
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+  }
+}
+
+/**
+ * Detail renderer for Kind 1630-1633 - Issue/Patch/PR Status Events
+ * Full view with status info, referenced event, and optional comment
+ */
+export function IssueStatusDetailRenderer({ event }: { event: NostrEvent }) {
+  const { addWindow } = useGrimoire();
+
+  const rootEventId = getStatusRootEventId(event);
+  const relayHint = getStatusRootRelayHint(event);
+  const repoAddress = getStatusRepositoryAddress(event);
+  const statusLabel = getStatusLabel(event.kind);
+  const statusType = getStatusType(event.kind);
+
+  const StatusIcon = getStatusIcon(event.kind);
+  const badgeClasses = getStatusBadgeClasses(event.kind);
+
+  // Build event pointer with relay hint if available
+  const eventPointer: EventPointer | undefined = rootEventId
+    ? {
+        id: rootEventId,
+        relays: relayHint ? [relayHint] : undefined,
+      }
+    : undefined;
+
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "datetime");
+
+  return (
+    <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
+      {/* Status Header */}
+      <header className="flex flex-col gap-4 pb-4 border-b border-border">
+        {/* Status Badge */}
+        <div className="flex items-center gap-3">
+          <span
+            className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${badgeClasses}`}
+          >
+            <StatusIcon className="size-4" />
+            <span className="capitalize">{statusType || statusLabel}</span>
+          </span>
+        </div>
+
+        {/* Title */}
+        <h1 className="text-2xl font-bold">Status Update</h1>
+
+        {/* Repository Link */}
+        {repoAddress && (
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Repository:</span>
+            <RepositoryLink
+              repoAddress={repoAddress}
+              iconSize="size-4"
+              className="font-mono"
+            />
+          </div>
+        )}
+
+        {/* Metadata */}
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <span>By</span>
+            <UserName pubkey={event.pubkey} className="font-semibold" />
+          </div>
+          <span>•</span>
+          <time>{createdDate}</time>
+        </div>
+      </header>
+
+      {/* Comment/Reason (if any) */}
+      {event.content && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold">Comment</h2>
+          <MarkdownContent content={event.content} />
+        </section>
+      )}
+
+      {/* Referenced Event */}
+      {eventPointer && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold">Referenced Event</h2>
+          <EmbeddedEvent
+            eventPointer={eventPointer}
+            onOpen={(id) => {
+              addWindow(
+                "open",
+                { id: id as string },
+                `Event ${(id as string).slice(0, 8)}...`,
+              );
+            }}
+            className="border border-muted rounded overflow-hidden"
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/nostr/kinds/IssueStatusDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueStatusDetailRenderer.tsx
@@ -35,19 +35,20 @@ function getStatusIcon(kind: number) {
 
 /**
  * Get the color classes for a status badge
+ * Uses theme semantic colors
  */
 function getStatusBadgeClasses(kind: number): string {
   switch (kind) {
-    case 1630: // Open
-      return "bg-green-500/20 text-green-500 border-green-500/30";
-    case 1631: // Resolved/Merged
-      return "bg-purple-500/20 text-purple-500 border-purple-500/30";
-    case 1632: // Closed
-      return "bg-red-500/20 text-red-500 border-red-500/30";
-    case 1633: // Draft
+    case 1630: // Open - neutral
+      return "bg-muted/50 text-foreground border-border";
+    case 1631: // Resolved/Merged - positive
+      return "bg-accent/20 text-accent border-accent/30";
+    case 1632: // Closed - negative
+      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1633: // Draft - muted
       return "bg-muted text-muted-foreground border-muted-foreground/30";
     default:
-      return "bg-muted text-muted-foreground border-muted-foreground/30";
+      return "bg-muted/50 text-foreground border-border";
   }
 }
 

--- a/src/components/nostr/kinds/IssueStatusRenderer.tsx
+++ b/src/components/nostr/kinds/IssueStatusRenderer.tsx
@@ -33,19 +33,20 @@ function getStatusIcon(kind: number) {
 
 /**
  * Get the color classes for a status kind
+ * Uses theme semantic colors
  */
 function getStatusColorClass(kind: number): string {
   switch (kind) {
-    case 1630: // Open
-      return "text-green-500";
-    case 1631: // Resolved/Merged
-      return "text-purple-500";
-    case 1632: // Closed
-      return "text-red-500";
-    case 1633: // Draft
+    case 1630: // Open - neutral
+      return "text-foreground";
+    case 1631: // Resolved/Merged - positive
+      return "text-accent";
+    case 1632: // Closed - negative
+      return "text-destructive";
+    case 1633: // Draft - muted
       return "text-muted-foreground";
     default:
-      return "text-muted-foreground";
+      return "text-foreground";
   }
 }
 

--- a/src/components/nostr/kinds/IssueStatusRenderer.tsx
+++ b/src/components/nostr/kinds/IssueStatusRenderer.tsx
@@ -1,0 +1,115 @@
+import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
+import {
+  BaseEventContainer,
+  type BaseEventProps,
+  ClickableEventTitle,
+} from "./BaseEventRenderer";
+import { EmbeddedEvent } from "../EmbeddedEvent";
+import { useGrimoire } from "@/core/state";
+import {
+  getStatusRootEventId,
+  getStatusRootRelayHint,
+  getStatusLabel,
+} from "@/lib/nip34-helpers";
+import type { EventPointer } from "nostr-tools/nip19";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color classes for a status kind
+ */
+function getStatusColorClass(kind: number): string {
+  switch (kind) {
+    case 1630: // Open
+      return "text-green-500";
+    case 1631: // Resolved/Merged
+      return "text-purple-500";
+    case 1632: // Closed
+      return "text-red-500";
+    case 1633: // Draft
+      return "text-muted-foreground";
+    default:
+      return "text-muted-foreground";
+  }
+}
+
+/**
+ * Renderer for Kind 1630-1633 - Issue/Patch/PR Status Events
+ * Displays status action with embedded reference to the issue/patch/PR
+ */
+export function IssueStatusRenderer({ event }: BaseEventProps) {
+  const { addWindow } = useGrimoire();
+
+  const rootEventId = getStatusRootEventId(event);
+  const relayHint = getStatusRootRelayHint(event);
+  const statusLabel = getStatusLabel(event.kind);
+
+  const StatusIcon = getStatusIcon(event.kind);
+  const colorClass = getStatusColorClass(event.kind);
+
+  // Build event pointer with relay hint if available
+  const eventPointer: EventPointer | undefined = rootEventId
+    ? {
+        id: rootEventId,
+        relays: relayHint ? [relayHint] : undefined,
+      }
+    : undefined;
+
+  return (
+    <BaseEventContainer event={event}>
+      <div className="flex flex-col gap-3">
+        {/* Status action header */}
+        <div className={`flex items-center gap-2 text-sm ${colorClass}`}>
+          <StatusIcon className="size-4" />
+          <ClickableEventTitle event={event}>
+            <span>{statusLabel}</span>
+          </ClickableEventTitle>
+        </div>
+
+        {/* Optional comment from the status event */}
+        {event.content && (
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {event.content}
+          </p>
+        )}
+
+        {/* Embedded referenced issue/patch/PR */}
+        {eventPointer && (
+          <EmbeddedEvent
+            eventPointer={eventPointer}
+            onOpen={(id) => {
+              addWindow(
+                "open",
+                { id: id as string },
+                `Event ${(id as string).slice(0, 8)}...`,
+              );
+            }}
+            className="border border-muted rounded overflow-hidden"
+          />
+        )}
+      </div>
+    </BaseEventContainer>
+  );
+}
+
+// Export aliases for each status kind
+export { IssueStatusRenderer as Kind1630Renderer };
+export { IssueStatusRenderer as Kind1631Renderer };
+export { IssueStatusRenderer as Kind1632Renderer };
+export { IssueStatusRenderer as Kind1633Renderer };

--- a/src/components/nostr/kinds/IssueStatusRenderer.tsx
+++ b/src/components/nostr/kinds/IssueStatusRenderer.tsx
@@ -1,54 +1,17 @@
-import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
   ClickableEventTitle,
 } from "./BaseEventRenderer";
 import { EmbeddedEvent } from "../EmbeddedEvent";
+import { StatusIndicator } from "../StatusIndicator";
+import { MarkdownContent } from "../MarkdownContent";
 import { useGrimoire } from "@/core/state";
 import {
   getStatusRootEventId,
   getStatusRootRelayHint,
-  getStatusLabel,
 } from "@/lib/nip34-helpers";
 import type { EventPointer } from "nostr-tools/nip19";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color classes for a status kind
- * Uses theme semantic colors
- */
-function getStatusColorClass(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "text-foreground";
-    case 1631: // Resolved/Merged - positive
-      return "text-accent";
-    case 1632: // Closed - negative
-      return "text-destructive";
-    case 1633: // Draft - muted
-      return "text-muted-foreground";
-    default:
-      return "text-foreground";
-  }
-}
 
 /**
  * Renderer for Kind 1630-1633 - Issue/Patch/PR Status Events
@@ -59,10 +22,6 @@ export function IssueStatusRenderer({ event }: BaseEventProps) {
 
   const rootEventId = getStatusRootEventId(event);
   const relayHint = getStatusRootRelayHint(event);
-  const statusLabel = getStatusLabel(event.kind);
-
-  const StatusIcon = getStatusIcon(event.kind);
-  const colorClass = getStatusColorClass(event.kind);
 
   // Build event pointer with relay hint if available
   const eventPointer: EventPointer | undefined = rootEventId
@@ -74,20 +33,17 @@ export function IssueStatusRenderer({ event }: BaseEventProps) {
 
   return (
     <BaseEventContainer event={event}>
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
         {/* Status action header */}
-        <div className={`flex items-center gap-2 text-sm ${colorClass}`}>
-          <StatusIcon className="size-4" />
-          <ClickableEventTitle event={event}>
-            <span>{statusLabel}</span>
-          </ClickableEventTitle>
-        </div>
+        <ClickableEventTitle event={event}>
+          <StatusIndicator statusKind={event.kind} eventType="issue" />
+        </ClickableEventTitle>
 
         {/* Optional comment from the status event */}
         {event.content && (
-          <p className="text-sm text-muted-foreground line-clamp-2">
-            {event.content}
-          </p>
+          <div className="text-xs text-muted-foreground line-clamp-2">
+            <MarkdownContent content={event.content} />
+          </div>
         )}
 
         {/* Embedded referenced issue/patch/PR */}

--- a/src/components/nostr/kinds/PatchDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PatchDetailRenderer.tsx
@@ -3,6 +3,7 @@ import { GitCommit, User, Copy, CopyCheck } from "lucide-react";
 import { UserName } from "../UserName";
 import { CodeCopyButton } from "@/components/CodeCopyButton";
 import { useCopy } from "@/hooks/useCopy";
+import { formatTimestamp } from "@/hooks/useLocale";
 import { SyntaxHighlight } from "@/components/SyntaxHighlight";
 import type { NostrEvent } from "@/types/nostr";
 import {
@@ -31,15 +32,8 @@ export function PatchDetailRenderer({ event }: { event: NostrEvent }) {
   const isRoot = useMemo(() => isPatchRoot(event), [event]);
   const isRootRevision = useMemo(() => isPatchRootRevision(event), [event]);
 
-  // Format created date
-  const createdDate = new Date(event.created_at * 1000).toLocaleDateString(
-    "en-US",
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
-  );
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "long");
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">

--- a/src/components/nostr/kinds/PatchDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PatchDetailRenderer.tsx
@@ -1,5 +1,15 @@
 import { useMemo } from "react";
-import { GitCommit, User, Copy, CopyCheck } from "lucide-react";
+import {
+  GitCommit,
+  User,
+  Copy,
+  CopyCheck,
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  FileEdit,
+  Loader2,
+} from "lucide-react";
 import { UserName } from "../UserName";
 import { CodeCopyButton } from "@/components/CodeCopyButton";
 import { useCopy } from "@/hooks/useCopy";
@@ -14,49 +24,188 @@ import {
   getPatchRepositoryAddress,
   isPatchRoot,
   isPatchRootRevision,
+  getRepositoryRelays,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color classes for a status badge
+ * Uses theme semantic colors
+ */
+function getStatusBadgeClasses(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "bg-muted/50 text-foreground border-border";
+    case 1631: // Merged - positive
+      return "bg-accent/20 text-accent border-accent/30";
+    case 1632: // Closed - negative
+      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1633: // Draft - muted
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+    default:
+      return "bg-muted/50 text-foreground border-border";
+  }
+}
 
 /**
  * Detail renderer for Kind 1617 - Patch
- * Displays full patch metadata and content
+ * Displays full patch metadata and content with status
  */
 export function PatchDetailRenderer({ event }: { event: NostrEvent }) {
   const { copy, copied } = useCopy();
 
-  const subject = useMemo(() => getPatchSubject(event), [event]);
-  const commitId = useMemo(() => getPatchCommitId(event), [event]);
-  const parentCommit = useMemo(() => getPatchParentCommit(event), [event]);
-  const committer = useMemo(() => getPatchCommitter(event), [event]);
-  const repoAddress = useMemo(() => getPatchRepositoryAddress(event), [event]);
-  const isRoot = useMemo(() => isPatchRoot(event), [event]);
-  const isRootRevision = useMemo(() => isPatchRootRevision(event), [event]);
+  const subject = getPatchSubject(event);
+  const commitId = getPatchCommitId(event);
+  const parentCommit = getPatchParentCommit(event);
+  const committer = getPatchCommitter(event);
+  const repoAddress = getPatchRepositoryAddress(event);
+  const isRoot = isPatchRoot(event);
+  const isRootRevision = isPatchRootRevision(event);
+
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch repo author's relay list for fallback
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  // Build relay list with fallbacks
+  const statusRelays = useMemo(() => {
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
+
+  // Fetch status events
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents, loading: statusLoading } = useTimeline(
+    `patch-status-${event.id}`,
+    statusFilter,
+    statusRelays,
+    { limit: 20 },
+  );
+
+  // Get valid status authors
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
+  );
 
   // Format created date using locale utility
   const createdDate = formatTimestamp(event.created_at, "long");
+
+  // Status display - for patches, 1631 means "merged"
+  const statusType = currentStatus
+    ? currentStatus.kind === 1631
+      ? "merged"
+      : getStatusType(currentStatus.kind)
+    : "open";
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusBadgeClasses = currentStatus
+    ? getStatusBadgeClasses(currentStatus.kind)
+    : "bg-muted/50 text-foreground border-border";
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* Patch Header */}
       <header className="flex flex-col gap-4 pb-4 border-b border-border">
+        {/* Status Badge */}
+        <div className="flex items-center gap-3">
+          {statusLoading ? (
+            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Loading status...</span>
+            </span>
+          ) : (
+            <span
+              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
+            >
+              <StatusIcon className="size-4" />
+              <span className="capitalize">{statusType}</span>
+            </span>
+          )}
+
+          {/* Root badges */}
+          {isRoot && (
+            <span className="px-3 py-1 bg-accent/20 text-accent text-sm border border-accent/30">
+              Root Patch
+            </span>
+          )}
+          {isRootRevision && (
+            <span className="px-3 py-1 bg-primary/20 text-primary text-sm border border-primary/30">
+              Root Revision
+            </span>
+          )}
+        </div>
+
         {/* Title */}
         <h1 className="text-3xl font-bold">{subject || "Untitled Patch"}</h1>
-
-        {/* Status Badges */}
-        {(isRoot || isRootRevision) && (
-          <div className="flex flex-wrap items-center gap-2">
-            {isRoot && (
-              <span className="px-3 py-1 bg-accent/20 text-accent text-sm border border-accent/30">
-                Root Patch
-              </span>
-            )}
-            {isRootRevision && (
-              <span className="px-3 py-1 bg-primary/20 text-primary text-sm border border-primary/30">
-                Root Revision
-              </span>
-            )}
-          </div>
-        )}
 
         {/* Repository Link */}
         {repoAddress && (
@@ -167,6 +316,33 @@ export function PatchDetailRenderer({ event }: { event: NostrEvent }) {
               label="Copy patch"
             />
           </div>
+        </section>
+      )}
+
+      {/* Status History */}
+      {currentStatus && (
+        <section className="flex flex-col gap-2 pt-4 border-t border-border">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            Last Status Update
+          </h2>
+          <div className="flex items-center gap-2 text-sm">
+            <UserName pubkey={currentStatus.pubkey} />
+            <span className="text-muted-foreground">
+              {currentStatus.kind === 1631
+                ? "merged"
+                : getStatusType(currentStatus.kind) || "updated"}{" "}
+              this patch
+            </span>
+            <span className="text-muted-foreground">•</span>
+            <time className="text-muted-foreground">
+              {formatTimestamp(currentStatus.created_at, "date")}
+            </time>
+          </div>
+          {currentStatus.content && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {currentStatus.content}
+            </p>
+          )}
         </section>
       )}
     </div>

--- a/src/components/nostr/kinds/PatchDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PatchDetailRenderer.tsx
@@ -1,15 +1,5 @@
 import { useMemo } from "react";
-import {
-  GitCommit,
-  User,
-  Copy,
-  CopyCheck,
-  CircleDot,
-  CheckCircle2,
-  XCircle,
-  FileEdit,
-  Loader2,
-} from "lucide-react";
+import { GitCommit, User, Copy, CopyCheck } from "lucide-react";
 import { UserName } from "../UserName";
 import { CodeCopyButton } from "@/components/CodeCopyButton";
 import { useCopy } from "@/hooks/useCopy";
@@ -32,46 +22,10 @@ import {
 import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color classes for a status badge
- * Uses theme semantic colors
- */
-function getStatusBadgeClasses(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "bg-muted/50 text-foreground border-border";
-    case 1631: // Merged - positive
-      return "bg-accent/20 text-accent border-accent/30";
-    case 1632: // Closed - negative
-      return "bg-destructive/20 text-destructive border-destructive/30";
-    case 1633: // Draft - muted
-      return "bg-muted text-muted-foreground border-muted-foreground/30";
-    default:
-      return "bg-muted/50 text-foreground border-border";
-  }
-}
 
 /**
  * Detail renderer for Kind 1617 - Patch
@@ -158,54 +112,32 @@ export function PatchDetailRenderer({ event }: { event: NostrEvent }) {
   // Format created date using locale utility
   const createdDate = formatTimestamp(event.created_at, "long");
 
-  // Status display - for patches, 1631 means "merged"
-  const statusType = currentStatus
-    ? currentStatus.kind === 1631
-      ? "merged"
-      : getStatusType(currentStatus.kind)
-    : "open";
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusBadgeClasses = currentStatus
-    ? getStatusBadgeClasses(currentStatus.kind)
-    : "bg-muted/50 text-foreground border-border";
-
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* Patch Header */}
-      <header className="flex flex-col gap-4 pb-4 border-b border-border">
-        {/* Status Badge */}
-        <div className="flex items-center gap-3">
-          {statusLoading ? (
-            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-              <span>Loading status...</span>
-            </span>
-          ) : (
-            <span
-              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
-            >
-              <StatusIcon className="size-4" />
-              <span className="capitalize">{statusType}</span>
-            </span>
-          )}
+      <header className="flex flex-col gap-3 pb-4 border-b border-border">
+        {/* Title */}
+        <h1 className="text-2xl font-bold">{subject || "Untitled Patch"}</h1>
 
-          {/* Root badges */}
+        {/* Status and Root badges (below title) */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <StatusIndicator
+            statusKind={currentStatus?.kind}
+            loading={statusLoading}
+            eventType="patch"
+            variant="badge"
+          />
           {isRoot && (
-            <span className="px-3 py-1 bg-accent/20 text-accent text-sm border border-accent/30">
+            <span className="px-2 py-1 bg-accent/20 text-accent text-xs border border-accent/30 rounded-sm">
               Root Patch
             </span>
           )}
           {isRootRevision && (
-            <span className="px-3 py-1 bg-primary/20 text-primary text-sm border border-primary/30">
+            <span className="px-2 py-1 bg-primary/20 text-primary text-xs border border-primary/30 rounded-sm">
               Root Revision
             </span>
           )}
         </div>
-
-        {/* Title */}
-        <h1 className="text-3xl font-bold">{subject || "Untitled Patch"}</h1>
 
         {/* Repository Link */}
         {repoAddress && (

--- a/src/components/nostr/kinds/PatchDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PatchDetailRenderer.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { GitCommit, User, Copy, CopyCheck } from "lucide-react";
 import { UserName } from "../UserName";
+import { MarkdownContent } from "../MarkdownContent";
 import { CodeCopyButton } from "@/components/CodeCopyButton";
 import { useCopy } from "@/hooks/useCopy";
 import { formatTimestamp } from "@/hooks/useLocale";
@@ -271,9 +272,9 @@ export function PatchDetailRenderer({ event }: { event: NostrEvent }) {
             </time>
           </div>
           {currentStatus.content && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {currentStatus.content}
-            </p>
+            <div className="text-sm mt-1">
+              <MarkdownContent content={currentStatus.content} />
+            </div>
           )}
         </section>
       )}

--- a/src/components/nostr/kinds/PatchRenderer.tsx
+++ b/src/components/nostr/kinds/PatchRenderer.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
@@ -7,12 +9,58 @@ import {
   getPatchSubject,
   getPatchCommitId,
   getPatchRepositoryAddress,
+  getRepositoryRelays,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color class for a status kind
+ * Uses theme semantic colors
+ */
+function getStatusColorClass(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "text-foreground";
+    case 1631: // Merged - positive
+      return "text-accent";
+    case 1632: // Closed - negative
+      return "text-destructive";
+    case 1633: // Draft - muted
+      return "text-muted-foreground";
+    default:
+      return "text-foreground";
+  }
+}
 
 /**
  * Renderer for Kind 1617 - Patch
- * Displays as a compact patch card in feed view
+ * Displays as a compact patch card in feed view with status
  */
 export function PatchRenderer({ event }: BaseEventProps) {
   const subject = getPatchSubject(event);
@@ -22,22 +70,117 @@ export function PatchRenderer({ event }: BaseEventProps) {
   // Shorten commit ID for display
   const shortCommitId = commitId ? commitId.slice(0, 7) : undefined;
 
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch repo author's relay list for fallback
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  // Build relay list with fallbacks:
+  // 1. Repository configured relays
+  // 2. Repo author's outbox (write) relays
+  // 3. AGGREGATOR_RELAYS as final fallback
+  const statusRelays = useMemo(() => {
+    // Try repository relays first
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+
+    // Try repo author's outbox relays
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+
+    // Fallback to aggregator relays
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
+
+  // Fetch status events that reference this patch
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents } = useTimeline(
+    `patch-status-${event.id}`,
+    statusFilter,
+    statusRelays,
+    { limit: 10 },
+  );
+
+  // Get valid status authors (patch author + repo owner + maintainers)
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
+  );
+
+  // Status display - for patches, 1631 means "merged" not "resolved"
+  const statusType = currentStatus
+    ? currentStatus.kind === 1631
+      ? "merged"
+      : getStatusType(currentStatus.kind)
+    : "open";
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusColorClass = currentStatus
+    ? getStatusColorClass(currentStatus.kind)
+    : "text-foreground";
+
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
-        {/* Patch Subject */}
-        <ClickableEventTitle
-          event={event}
-          className="font-semibold text-foreground"
-        >
-          {subject || "Untitled Patch"}
-        </ClickableEventTitle>
+        {/* Status and Subject */}
+        <div className="flex items-center gap-2">
+          <StatusIcon className={`size-4 flex-shrink-0 ${statusColorClass}`} />
+          <ClickableEventTitle
+            event={event}
+            className="font-semibold text-foreground"
+          >
+            {subject || "Untitled Patch"}
+          </ClickableEventTitle>
+        </div>
 
         {/* Metadata */}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-          <span>in</span>
-          {/* Repository */}
-          {repoAddress && <RepositoryLink repoAddress={repoAddress} />}
+          <span className={statusColorClass}>{statusType}</span>
+          {repoAddress && (
+            <>
+              <span className="text-muted-foreground">in</span>
+              <RepositoryLink repoAddress={repoAddress} />
+            </>
+          )}
 
           {/* Commit ID */}
           {shortCommitId && (

--- a/src/components/nostr/kinds/PatchRenderer.tsx
+++ b/src/components/nostr/kinds/PatchRenderer.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { CircleDot, CheckCircle2, XCircle, FileEdit } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
@@ -10,53 +9,16 @@ import {
   getPatchCommitId,
   getPatchRepositoryAddress,
   getRepositoryRelays,
-  getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
 import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color class for a status kind
- * Uses theme semantic colors
- */
-function getStatusColorClass(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "text-foreground";
-    case 1631: // Merged - positive
-      return "text-accent";
-    case 1632: // Closed - negative
-      return "text-destructive";
-    case 1633: // Draft - muted
-      return "text-muted-foreground";
-    default:
-      return "text-foreground";
-  }
-}
 
 /**
  * Renderer for Kind 1617 - Patch
@@ -145,36 +107,20 @@ export function PatchRenderer({ event }: BaseEventProps) {
     [statusEvents, validAuthors],
   );
 
-  // Status display - for patches, 1631 means "merged" not "resolved"
-  const statusType = currentStatus
-    ? currentStatus.kind === 1631
-      ? "merged"
-      : getStatusType(currentStatus.kind)
-    : "open";
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusColorClass = currentStatus
-    ? getStatusColorClass(currentStatus.kind)
-    : "text-foreground";
-
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
-        {/* Status and Subject */}
-        <div className="flex items-center gap-2">
-          <StatusIcon className={`size-4 flex-shrink-0 ${statusColorClass}`} />
-          <ClickableEventTitle
-            event={event}
-            className="font-semibold text-foreground"
-          >
-            {subject || "Untitled Patch"}
-          </ClickableEventTitle>
-        </div>
+        {/* Subject/Title */}
+        <ClickableEventTitle
+          event={event}
+          className="font-semibold text-foreground"
+        >
+          {subject || "Untitled Patch"}
+        </ClickableEventTitle>
 
-        {/* Metadata */}
+        {/* Status and Metadata */}
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-          <span className={statusColorClass}>{statusType}</span>
+          <StatusIndicator statusKind={currentStatus?.kind} eventType="patch" />
           {repoAddress && (
             <>
               <span className="text-muted-foreground">in</span>

--- a/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
@@ -298,9 +298,9 @@ export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
             </time>
           </div>
           {currentStatus.content && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {currentStatus.content}
-            </p>
+            <div className="text-sm mt-1">
+              <MarkdownContent content={currentStatus.content} />
+            </div>
           )}
         </section>
       )}

--- a/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
@@ -1,15 +1,5 @@
 import { useMemo } from "react";
-import {
-  GitBranch,
-  Tag,
-  Copy,
-  CopyCheck,
-  CircleDot,
-  CheckCircle2,
-  XCircle,
-  FileEdit,
-  Loader2,
-} from "lucide-react";
+import { GitBranch, Tag, Copy, CopyCheck } from "lucide-react";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import { useCopy } from "@/hooks/useCopy";
@@ -32,46 +22,10 @@ import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color classes for a status badge
- * Uses theme semantic colors
- */
-function getStatusBadgeClasses(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "bg-muted/50 text-foreground border-border";
-    case 1631: // Merged - positive
-      return "bg-accent/20 text-accent border-accent/30";
-    case 1632: // Closed - negative
-      return "bg-destructive/20 text-destructive border-destructive/30";
-    case 1633: // Draft - muted
-      return "bg-muted text-muted-foreground border-muted-foreground/30";
-    default:
-      return "bg-muted/50 text-foreground border-border";
-  }
-}
 
 /**
  * Detail renderer for Kind 1618 - Pull Request
@@ -158,44 +112,22 @@ export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
   // Format created date using locale utility
   const createdDate = formatTimestamp(event.created_at, "long");
 
-  // Status display - for PRs, 1631 means "merged"
-  const statusType = currentStatus
-    ? currentStatus.kind === 1631
-      ? "merged"
-      : getStatusType(currentStatus.kind)
-    : "open";
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusBadgeClasses = currentStatus
-    ? getStatusBadgeClasses(currentStatus.kind)
-    : "bg-muted/50 text-foreground border-border";
-
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* PR Header */}
-      <header className="flex flex-col gap-4 pb-4 border-b border-border">
-        {/* Status Badge */}
-        <div className="flex items-center gap-3">
-          {statusLoading ? (
-            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-              <span>Loading status...</span>
-            </span>
-          ) : (
-            <span
-              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
-            >
-              <StatusIcon className="size-4" />
-              <span className="capitalize">{statusType}</span>
-            </span>
-          )}
-        </div>
-
+      <header className="flex flex-col gap-3 pb-4 border-b border-border">
         {/* Title */}
-        <h1 className="text-3xl font-bold">
+        <h1 className="text-2xl font-bold">
           {subject || "Untitled Pull Request"}
         </h1>
+
+        {/* Status Badge (below title) */}
+        <StatusIndicator
+          statusKind={currentStatus?.kind}
+          loading={statusLoading}
+          eventType="pr"
+          variant="badge"
+        />
 
         {/* Repository Link */}
         {repoAddress && (

--- a/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
@@ -3,6 +3,7 @@ import { GitBranch, Tag, Copy, CopyCheck } from "lucide-react";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import { useCopy } from "@/hooks/useCopy";
+import { formatTimestamp } from "@/hooks/useLocale";
 import type { NostrEvent } from "@/types/nostr";
 import {
   getPullRequestSubject,
@@ -34,15 +35,8 @@ export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
     [event],
   );
 
-  // Format created date
-  const createdDate = new Date(event.created_at * 1000).toLocaleDateString(
-    "en-US",
-    {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    },
-  );
+  // Format created date using locale utility
+  const createdDate = formatTimestamp(event.created_at, "long");
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">

--- a/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
@@ -1,5 +1,15 @@
 import { useMemo } from "react";
-import { GitBranch, Tag, Copy, CopyCheck } from "lucide-react";
+import {
+  GitBranch,
+  Tag,
+  Copy,
+  CopyCheck,
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  FileEdit,
+  Loader2,
+} from "lucide-react";
 import { UserName } from "../UserName";
 import { MarkdownContent } from "../MarkdownContent";
 import { useCopy } from "@/hooks/useCopy";
@@ -13,35 +23,175 @@ import {
   getPullRequestCloneUrls,
   getPullRequestMergeBase,
   getPullRequestRepositoryAddress,
+  getRepositoryRelays,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color classes for a status badge
+ * Uses theme semantic colors
+ */
+function getStatusBadgeClasses(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "bg-muted/50 text-foreground border-border";
+    case 1631: // Merged - positive
+      return "bg-accent/20 text-accent border-accent/30";
+    case 1632: // Closed - negative
+      return "bg-destructive/20 text-destructive border-destructive/30";
+    case 1633: // Draft - muted
+      return "bg-muted text-muted-foreground border-muted-foreground/30";
+    default:
+      return "bg-muted/50 text-foreground border-border";
+  }
+}
 
 /**
  * Detail renderer for Kind 1618 - Pull Request
- * Displays full PR content with markdown rendering
+ * Displays full PR content with markdown rendering and status
  */
 export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
   const { copy, copied } = useCopy();
 
-  const subject = useMemo(() => getPullRequestSubject(event), [event]);
-  const labels = useMemo(() => getPullRequestLabels(event), [event]);
-  const commitId = useMemo(() => getPullRequestCommitId(event), [event]);
-  const branchName = useMemo(() => getPullRequestBranchName(event), [event]);
-  const cloneUrls = useMemo(() => getPullRequestCloneUrls(event), [event]);
-  const mergeBase = useMemo(() => getPullRequestMergeBase(event), [event]);
-  const repoAddress = useMemo(
-    () => getPullRequestRepositoryAddress(event),
-    [event],
+  const subject = getPullRequestSubject(event);
+  const labels = getPullRequestLabels(event);
+  const commitId = getPullRequestCommitId(event);
+  const branchName = getPullRequestBranchName(event);
+  const cloneUrls = getPullRequestCloneUrls(event);
+  const mergeBase = getPullRequestMergeBase(event);
+  const repoAddress = getPullRequestRepositoryAddress(event);
+
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch repo author's relay list for fallback
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  // Build relay list with fallbacks
+  const statusRelays = useMemo(() => {
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
+
+  // Fetch status events
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents, loading: statusLoading } = useTimeline(
+    `pr-status-${event.id}`,
+    statusFilter,
+    statusRelays,
+    { limit: 20 },
+  );
+
+  // Get valid status authors
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
   );
 
   // Format created date using locale utility
   const createdDate = formatTimestamp(event.created_at, "long");
 
+  // Status display - for PRs, 1631 means "merged"
+  const statusType = currentStatus
+    ? currentStatus.kind === 1631
+      ? "merged"
+      : getStatusType(currentStatus.kind)
+    : "open";
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusBadgeClasses = currentStatus
+    ? getStatusBadgeClasses(currentStatus.kind)
+    : "bg-muted/50 text-foreground border-border";
+
   return (
     <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
       {/* PR Header */}
       <header className="flex flex-col gap-4 pb-4 border-b border-border">
+        {/* Status Badge */}
+        <div className="flex items-center gap-3">
+          {statusLoading ? (
+            <span className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              <span>Loading status...</span>
+            </span>
+          ) : (
+            <span
+              className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium border ${statusBadgeClasses}`}
+            >
+              <StatusIcon className="size-4" />
+              <span className="capitalize">{statusType}</span>
+            </span>
+          )}
+        </div>
+
         {/* Title */}
         <h1 className="text-3xl font-bold">
           {subject || "Untitled Pull Request"}
@@ -194,6 +344,33 @@ export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
         <p className="text-sm text-muted-foreground italic">
           (No description provided)
         </p>
+      )}
+
+      {/* Status History */}
+      {currentStatus && (
+        <section className="flex flex-col gap-2 pt-4 border-t border-border">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            Last Status Update
+          </h2>
+          <div className="flex items-center gap-2 text-sm">
+            <UserName pubkey={currentStatus.pubkey} />
+            <span className="text-muted-foreground">
+              {currentStatus.kind === 1631
+                ? "merged"
+                : getStatusType(currentStatus.kind) || "updated"}{" "}
+              this pull request
+            </span>
+            <span className="text-muted-foreground">•</span>
+            <time className="text-muted-foreground">
+              {formatTimestamp(currentStatus.created_at, "date")}
+            </time>
+          </div>
+          {currentStatus.content && (
+            <p className="text-sm text-muted-foreground mt-1">
+              {currentStatus.content}
+            </p>
+          )}
+        </section>
       )}
     </div>
   );

--- a/src/components/nostr/kinds/PullRequestRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestRenderer.tsx
@@ -1,11 +1,5 @@
 import { useMemo } from "react";
-import {
-  CircleDot,
-  CheckCircle2,
-  XCircle,
-  FileEdit,
-  GitBranch,
-} from "lucide-react";
+import { GitBranch } from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
@@ -17,7 +11,6 @@ import {
   getPullRequestBranchName,
   getPullRequestRepositoryAddress,
   getRepositoryRelays,
-  getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
@@ -25,46 +18,10 @@ import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { AGGREGATOR_RELAYS } from "@/services/loaders";
-
-/**
- * Get the icon for a status kind
- */
-function getStatusIcon(kind: number) {
-  switch (kind) {
-    case 1630:
-      return CircleDot;
-    case 1631:
-      return CheckCircle2;
-    case 1632:
-      return XCircle;
-    case 1633:
-      return FileEdit;
-    default:
-      return CircleDot;
-  }
-}
-
-/**
- * Get the color class for a status kind
- * Uses theme semantic colors
- */
-function getStatusColorClass(kind: number): string {
-  switch (kind) {
-    case 1630: // Open - neutral
-      return "text-foreground";
-    case 1631: // Merged - positive
-      return "text-accent";
-    case 1632: // Closed - negative
-      return "text-destructive";
-    case 1633: // Draft - muted
-      return "text-muted-foreground";
-    default:
-      return "text-foreground";
-  }
-}
 
 /**
  * Renderer for Kind 1618 - Pull Request
@@ -151,37 +108,21 @@ export function PullRequestRenderer({ event }: BaseEventProps) {
     [statusEvents, validAuthors],
   );
 
-  // Status display - for PRs, 1631 means "merged" not "resolved"
-  const statusType = currentStatus
-    ? currentStatus.kind === 1631
-      ? "merged"
-      : getStatusType(currentStatus.kind)
-    : "open";
-  const StatusIcon = currentStatus
-    ? getStatusIcon(currentStatus.kind)
-    : CircleDot;
-  const statusColorClass = currentStatus
-    ? getStatusColorClass(currentStatus.kind)
-    : "text-foreground";
-
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
-        {/* Status and PR Title */}
-        <div className="flex items-center gap-2">
-          <StatusIcon className={`size-4 flex-shrink-0 ${statusColorClass}`} />
-          <ClickableEventTitle
-            event={event}
-            className="font-semibold text-foreground"
-          >
-            {subject || "Untitled Pull Request"}
-          </ClickableEventTitle>
-        </div>
+        {/* PR Title */}
+        <ClickableEventTitle
+          event={event}
+          className="font-semibold text-foreground"
+        >
+          {subject || "Untitled Pull Request"}
+        </ClickableEventTitle>
 
         <div className="flex flex-col gap-1">
           {/* Status and Repository */}
           <div className="flex items-center gap-2 text-xs">
-            <span className={statusColorClass}>{statusType}</span>
+            <StatusIndicator statusKind={currentStatus?.kind} eventType="pr" />
             {repoAddress && (
               <>
                 <span className="text-muted-foreground">in</span>

--- a/src/components/nostr/kinds/PullRequestRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestRenderer.tsx
@@ -1,21 +1,74 @@
+import { useMemo } from "react";
+import {
+  CircleDot,
+  CheckCircle2,
+  XCircle,
+  FileEdit,
+  GitBranch,
+} from "lucide-react";
 import {
   BaseEventContainer,
   type BaseEventProps,
   ClickableEventTitle,
 } from "./BaseEventRenderer";
-import { GitBranch } from "lucide-react";
 import {
   getPullRequestSubject,
   getPullRequestLabels,
   getPullRequestBranchName,
   getPullRequestRepositoryAddress,
+  getRepositoryRelays,
+  getStatusType,
+  getValidStatusAuthors,
+  findCurrentStatus,
 } from "@/lib/nip34-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Get the icon for a status kind
+ */
+function getStatusIcon(kind: number) {
+  switch (kind) {
+    case 1630:
+      return CircleDot;
+    case 1631:
+      return CheckCircle2;
+    case 1632:
+      return XCircle;
+    case 1633:
+      return FileEdit;
+    default:
+      return CircleDot;
+  }
+}
+
+/**
+ * Get the color class for a status kind
+ * Uses theme semantic colors
+ */
+function getStatusColorClass(kind: number): string {
+  switch (kind) {
+    case 1630: // Open - neutral
+      return "text-foreground";
+    case 1631: // Merged - positive
+      return "text-accent";
+    case 1632: // Closed - negative
+      return "text-destructive";
+    case 1633: // Draft - muted
+      return "text-muted-foreground";
+    default:
+      return "text-foreground";
+  }
+}
 
 /**
  * Renderer for Kind 1618 - Pull Request
- * Displays as a compact PR card in feed view
+ * Displays as a compact PR card in feed view with status
  */
 export function PullRequestRenderer({ event }: BaseEventProps) {
   const subject = getPullRequestSubject(event);
@@ -23,25 +76,122 @@ export function PullRequestRenderer({ event }: BaseEventProps) {
   const branchName = getPullRequestBranchName(event);
   const repoAddress = getPullRequestRepositoryAddress(event);
 
+  // Parse repository address for fetching repo event
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  // Fetch repository event to get maintainers list
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  // Fetch repo author's relay list for fallback
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  // Build relay list with fallbacks:
+  // 1. Repository configured relays
+  // 2. Repo author's outbox (write) relays
+  // 3. AGGREGATOR_RELAYS as final fallback
+  const statusRelays = useMemo(() => {
+    // Try repository relays first
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+
+    // Try repo author's outbox relays
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+
+    // Fallback to aggregator relays
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
+
+  // Fetch status events that reference this PR
+  const statusFilter = useMemo(
+    () => ({
+      kinds: [1630, 1631, 1632, 1633],
+      "#e": [event.id],
+    }),
+    [event.id],
+  );
+
+  const { events: statusEvents } = useTimeline(
+    `pr-status-${event.id}`,
+    statusFilter,
+    statusRelays,
+    { limit: 10 },
+  );
+
+  // Get valid status authors (PR author + repo owner + maintainers)
+  const validAuthors = useMemo(
+    () => getValidStatusAuthors(event, repositoryEvent),
+    [event, repositoryEvent],
+  );
+
+  // Get the most recent valid status event
+  const currentStatus = useMemo(
+    () => findCurrentStatus(statusEvents, validAuthors),
+    [statusEvents, validAuthors],
+  );
+
+  // Status display - for PRs, 1631 means "merged" not "resolved"
+  const statusType = currentStatus
+    ? currentStatus.kind === 1631
+      ? "merged"
+      : getStatusType(currentStatus.kind)
+    : "open";
+  const StatusIcon = currentStatus
+    ? getStatusIcon(currentStatus.kind)
+    : CircleDot;
+  const statusColorClass = currentStatus
+    ? getStatusColorClass(currentStatus.kind)
+    : "text-foreground";
+
   return (
     <BaseEventContainer event={event}>
       <div className="flex flex-col gap-2">
-        {/* PR Title */}
-        <ClickableEventTitle
-          event={event}
-          className="font-semibold text-foreground"
-        >
-          {subject || "Untitled Pull Request"}
-        </ClickableEventTitle>
+        {/* Status and PR Title */}
+        <div className="flex items-center gap-2">
+          <StatusIcon className={`size-4 flex-shrink-0 ${statusColorClass}`} />
+          <ClickableEventTitle
+            event={event}
+            className="font-semibold text-foreground"
+          >
+            {subject || "Untitled Pull Request"}
+          </ClickableEventTitle>
+        </div>
 
         <div className="flex flex-col gap-1">
-          {/* Repository */}
-          {repoAddress && (
-            <RepositoryLink
-              repoAddress={repoAddress}
-              className="truncate line-clamp-1 text-xs"
-            />
-          )}
+          {/* Status and Repository */}
+          <div className="flex items-center gap-2 text-xs">
+            <span className={statusColorClass}>{statusType}</span>
+            {repoAddress && (
+              <>
+                <span className="text-muted-foreground">in</span>
+                <RepositoryLink
+                  repoAddress={repoAddress}
+                  className="truncate line-clamp-1"
+                />
+              </>
+            )}
+          </div>
           {/* Branch Name */}
           {branchName && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground">

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -17,6 +17,8 @@ import { Kind1337Renderer } from "./CodeSnippetRenderer";
 import { Kind1337DetailRenderer } from "./CodeSnippetDetailRenderer";
 import { IssueRenderer } from "./IssueRenderer";
 import { IssueDetailRenderer } from "./IssueDetailRenderer";
+import { IssueStatusRenderer } from "./IssueStatusRenderer";
+import { IssueStatusDetailRenderer } from "./IssueStatusDetailRenderer";
 import { PatchRenderer } from "./PatchRenderer";
 import { PatchDetailRenderer } from "./PatchDetailRenderer";
 import { PullRequestRenderer } from "./PullRequestRenderer";
@@ -187,6 +189,10 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
   1617: PatchRenderer, // Patch (NIP-34)
   1618: PullRequestRenderer, // Pull Request (NIP-34)
   1621: IssueRenderer, // Issue (NIP-34)
+  1630: IssueStatusRenderer, // Open Status (NIP-34)
+  1631: IssueStatusRenderer, // Applied/Merged/Resolved Status (NIP-34)
+  1632: IssueStatusRenderer, // Closed Status (NIP-34)
+  1633: IssueStatusRenderer, // Draft Status (NIP-34)
   9041: GoalRenderer, // Zap Goal (NIP-75)
   9735: Kind9735Renderer, // Zap Receipt
   9802: Kind9802Renderer, // Highlight
@@ -296,6 +302,10 @@ const detailRenderers: Record<
   1617: PatchDetailRenderer, // Patch Detail (NIP-34)
   1618: PullRequestDetailRenderer, // Pull Request Detail (NIP-34)
   1621: IssueDetailRenderer, // Issue Detail (NIP-34)
+  1630: IssueStatusDetailRenderer, // Open Status Detail (NIP-34)
+  1631: IssueStatusDetailRenderer, // Applied/Merged/Resolved Status Detail (NIP-34)
+  1632: IssueStatusDetailRenderer, // Closed Status Detail (NIP-34)
+  1633: IssueStatusDetailRenderer, // Draft Status Detail (NIP-34)
   9041: GoalDetailRenderer, // Zap Goal Detail (NIP-75)
   9802: Kind9802DetailRenderer, // Highlight Detail
   8000: AddUserDetailRenderer, // Add User Detail (NIP-43)

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -50,11 +50,20 @@ export function useLocale(): LocaleConfig {
 /**
  * Format a timestamp according to locale preferences
  * @param timestamp - Unix timestamp in seconds
- * @param style - 'relative' for "2h ago", 'absolute' for full date/time, 'date' for date only, 'time' for time only
+ * @param style - 'relative' for "2h ago", 'absolute' for full date/time, 'date' for date only,
+ *                'long' for full readable date (e.g., "January 15, 2025"), 'time' for time only,
+ *                'datetime' for date with time (e.g., "January 15, 2025, 2:30 PM")
+ * @param locale - Optional locale override (defaults to browser locale)
  */
 export function formatTimestamp(
   timestamp: number,
-  style: "relative" | "absolute" | "date" | "time" = "relative",
+  style:
+    | "relative"
+    | "absolute"
+    | "date"
+    | "long"
+    | "time"
+    | "datetime" = "relative",
   locale?: string,
 ): string {
   const browserLocale = locale || navigator.language || "en-US";
@@ -99,6 +108,26 @@ export function formatTimestamp(
       year: "numeric",
       month: "2-digit",
       day: "2-digit",
+    });
+  }
+
+  if (style === "long") {
+    // Human-readable long format: "January 15, 2025"
+    return date.toLocaleDateString(browserLocale, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+
+  if (style === "datetime") {
+    // Full date with time: "January 15, 2025, 2:30 PM"
+    return date.toLocaleString(browserLocale, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,7 @@
     --muted-foreground: 215 20.2% 70%;
     --accent: 270 100% 70%;
     --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 72% 50%;
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,7 @@
     --muted-foreground: 215 20.2% 70%;
     --accent: 270 100% 70%;
     --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 0 72% 50%;
+    --destructive: 0 90% 65%;
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;

--- a/src/index.css
+++ b/src/index.css
@@ -122,9 +122,9 @@
     --ring: 212.7 26.8% 83.9%;
 
     /* Status colors */
-    --success: 142 76% 36%;
-    --warning: 45 93% 47%;
-    --info: 199 89% 48%;
+    --success: 142 76% 46%;
+    --warning: 38 92% 60%;
+    --info: 199 89% 58%;
 
     /* Nostr-specific colors */
     --zap: 45 93% 58%;

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,7 @@
     --muted-foreground: 215 20.2% 70%;
     --accent: 270 100% 70%;
     --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 0 85% 70%;
+    --destructive: 0 75% 75%;
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,7 @@
     --muted-foreground: 215 20.2% 70%;
     --accent: 270 100% 70%;
     --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 0 90% 65%;
+    --destructive: 0 85% 70%;
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;

--- a/src/lib/nip34-helpers.ts
+++ b/src/lib/nip34-helpers.ts
@@ -1,5 +1,6 @@
 import type { NostrEvent } from "@/types/nostr";
 import { getTagValue } from "applesauce-core/helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 
 /**
  * NIP-34 Helper Functions
@@ -468,10 +469,6 @@ export function getStatusLabel(kind: number, forIssue = true): string {
       return "updated";
   }
 }
-
-// Import parseReplaceableAddress from applesauce-core for address parsing
-// This parses "kind:pubkey:identifier" format strings into AddressPointer objects
-import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 
 /**
  * Get all valid pubkeys that can set status for an issue/patch/PR


### PR DESCRIPTION
## Summary
This PR adds comprehensive locale-aware date/time formatting throughout the application and implements full support for NIP-34 status events (kinds 1630-1633) for issues, patches, and pull requests.

## Key Changes

### Locale-Aware Formatting
- **Enhanced `useLocale.ts`**: Added new formatting styles to `formatTimestamp()`:
  - `"long"` → Human-readable date format (e.g., "January 15, 2025")
  - `"datetime"` → Date with time (e.g., "January 15, 2025, 2:30 PM")
  - Respects user's browser locale instead of hardcoding "en-US"
- **Updated CLAUDE.md**: Documented locale formatting requirements and best practices
- **Refactored all date formatting**: Replaced hardcoded `toLocaleDateString("en-US", {...})` calls with `formatTimestamp()` utility in:
  - `ArticleDetailRenderer`
  - `CommunityNIPDetailRenderer`
  - `HighlightDetailRenderer`
  - `PatchDetailRenderer`
  - `PullRequestDetailRenderer`

### NIP-34 Status Event Support
- **New renderers**:
  - `IssueStatusRenderer` - Compact feed view for status events (kinds 1630-1633)
  - `IssueStatusDetailRenderer` - Full detail view with referenced issue/patch/PR
- **Enhanced issue renderers**:
  - `IssueRenderer` - Now displays current status with icon and color coding
  - `IssueDetailRenderer` - Shows status badge and last status update history
- **New helper functions in `nip34-helpers.ts`**:
  - `getStatusType()` - Map kind to status type (open/resolved/closed/draft)
  - `getStatusRootEventId()` / `getStatusRootRelayHint()` - Extract referenced event
  - `getStatusRepositoryAddress()` - Get repository context
  - `getStatusLabel()` - Human-readable status labels
  - `getValidStatusAuthors()` - Determine who can set status (event author, repo owner, maintainers)
  - `findCurrentStatus()` - Find most recent valid status from a list
  - `isStatusKind()` - Check if kind is a status event
- **Status event registration**: Added kinds 1630-1633 to renderer maps in `index.tsx`

### Visual Enhancements
- Status badges with color coding:
  - 🟢 Open (1630) - Green
  - 🟣 Resolved/Merged (1631) - Purple
  - 🔴 Closed (1632) - Red
  - ⚪ Draft (1633) - Gray
- Status icons from lucide-react (CircleDot, CheckCircle2, XCircle, FileEdit)
- Embedded referenced events in status detail view
- Status history section in issue detail view

## Implementation Details
- Status events are fetched using `useTimeline()` hook with aggregator relays
- Repository events are fetched to validate status authors and get maintainers
- Status validation ensures only authorized users (event author, repo owner, maintainers) can set status
- All timestamp formatting now respects user's browser locale settings
- Maintains backward compatibility with existing renderers