### PR TITLE
Move client tag addition from encodeSpell to publish-spell

### DIFF
--- a/src/lib/spell-conversion.test.ts
+++ b/src/lib/spell-conversion.test.ts
@@ -12,7 +12,8 @@ describe("Spell Conversion", () => {
       });
 
       expect(result.tags).toContainEqual(["cmd", "REQ"]);
-      expect(result.tags).toContainEqual(GRIMOIRE_CLIENT_TAG);
+      // Note: Client tag is NOT added by encodeSpell - it's added by publish-spell.ts
+      // based on user settings to avoid duplicate tags
       expect(result.tags).toContainEqual(["k", "1"]);
       expect(result.tags).toContainEqual(["k", "3"]);
       expect(result.tags).toContainEqual(["k", "7"]);

--- a/src/lib/spell-conversion.ts
+++ b/src/lib/spell-conversion.ts
@@ -6,7 +6,6 @@ import type {
   SpellEvent,
 } from "@/types/spell";
 import type { NostrFilter } from "@/types/nostr";
-import { GRIMOIRE_CLIENT_TAG } from "@/constants/app";
 
 /**
  * Simple tokenization that doesn't expand shell variables
@@ -115,10 +114,8 @@ export function encodeSpell(options: CreateSpellOptions): EncodedSpell {
   }
 
   // Start with required tags
-  const tags: [string, string, ...string[]][] = [
-    ["cmd", cmdType],
-    GRIMOIRE_CLIENT_TAG,
-  ];
+  // Note: Client tag is added by publish-spell.ts based on user settings
+  const tags: [string, string, ...string[]][] = [["cmd", cmdType]];
 
   // Add name tag if provided
   if (name && name.trim().length > 0) {


### PR DESCRIPTION
## Summary
Refactored the spell encoding logic to remove client tag addition from `encodeSpell()` function and defer it to the `publish-spell.ts` module. This change allows client tag assignment to be based on user settings, preventing duplicate tags.

## Changes
- Removed `GRIMOIRE_CLIENT_TAG` import and addition from `spell-conversion.ts`
- Removed client tag from the initial tags array in `encodeSpell()` function
- Updated test expectations to reflect that client tag is no longer added by `encodeSpell()`
- Added clarifying comments explaining that client tag is now added by `publish-spell.ts` based on user settings

## Implementation Details
The client tag was previously hardcoded in the spell encoding step, which could lead to duplicate tags if the publishing logic also added it. By moving this responsibility to `publish-spell.ts`, the tag can now be conditionally added based on user configuration, ensuring cleaner event data and avoiding tag duplication.