### PR TITLE
Update suggestion list colors to use popover-foreground tokens

### DIFF
--- a/src/components/editor/EmojiSuggestionList.tsx
+++ b/src/components/editor/EmojiSuggestionList.tsx
@@ -93,7 +93,7 @@ export const EmojiSuggestionList = forwardRef<
 
   if (items.length === 0) {
     return (
-      <div className="border border-border/50 bg-popover p-4 text-sm text-muted-foreground shadow-md">
+      <div className="border border-border/50 bg-popover p-4 text-sm text-popover-foreground/60 shadow-md">
         No emoji found
       </div>
     );
@@ -103,7 +103,7 @@ export const EmojiSuggestionList = forwardRef<
     <div
       ref={listRef}
       role="listbox"
-      className="max-h-[240px] w-[296px] overflow-y-auto border border-border/50 bg-popover p-2 shadow-md"
+      className="max-h-[240px] w-[296px] overflow-y-auto border border-border/50 bg-popover p-2 text-popover-foreground shadow-md"
     >
       <div className="grid grid-cols-8 gap-0.5">
         {items.map((item, index) => (
@@ -141,7 +141,7 @@ export const EmojiSuggestionList = forwardRef<
       </div>
       {/* Show selected emoji shortcode */}
       {items[selectedIndex] && (
-        <div className="mt-2 border-t border-border/50 pt-2 text-center text-xs text-muted-foreground">
+        <div className="mt-2 border-t border-border/50 pt-2 text-center text-xs text-popover-foreground/60">
           :{items[selectedIndex].shortcode}:
         </div>
       )}

--- a/src/components/editor/ProfileSuggestionList.tsx
+++ b/src/components/editor/ProfileSuggestionList.tsx
@@ -71,7 +71,7 @@ export const ProfileSuggestionList = forwardRef<
 
   if (items.length === 0) {
     return (
-      <div className="border border-border/50 bg-popover p-4 text-sm text-muted-foreground shadow-md">
+      <div className="border border-border/50 bg-popover p-4 text-sm text-popover-foreground/60 shadow-md">
         No profiles found
       </div>
     );
@@ -81,7 +81,7 @@ export const ProfileSuggestionList = forwardRef<
     <div
       ref={listRef}
       role="listbox"
-      className="max-h-[300px] w-[320px] overflow-y-auto border border-border/50 bg-popover shadow-md"
+      className="max-h-[300px] w-[320px] overflow-y-auto border border-border/50 bg-popover text-popover-foreground shadow-md"
     >
       {items.map((item, index) => (
         <button
@@ -99,7 +99,7 @@ export const ProfileSuggestionList = forwardRef<
               <UserName pubkey={item.pubkey} />
             </div>
             {item.nip05 && (
-              <div className="truncate text-xs text-muted-foreground">
+              <div className="truncate text-xs text-popover-foreground/60">
                 {item.nip05}
               </div>
             )}

--- a/src/components/editor/SlashCommandSuggestionList.tsx
+++ b/src/components/editor/SlashCommandSuggestionList.tsx
@@ -71,7 +71,7 @@ export const SlashCommandSuggestionList = forwardRef<
 
   if (items.length === 0) {
     return (
-      <div className="border border-border/50 bg-popover p-4 text-sm text-muted-foreground shadow-md">
+      <div className="border border-border/50 bg-popover p-4 text-sm text-popover-foreground/60 shadow-md">
         No commands available
       </div>
     );
@@ -81,7 +81,7 @@ export const SlashCommandSuggestionList = forwardRef<
     <div
       ref={listRef}
       role="listbox"
-      className="max-h-[300px] w-[320px] overflow-y-auto border border-border/50 bg-popover shadow-md"
+      className="max-h-[300px] w-[320px] overflow-y-auto border border-border/50 bg-popover text-popover-foreground shadow-md"
     >
       {items.map((item, index) => (
         <button
@@ -94,12 +94,12 @@ export const SlashCommandSuggestionList = forwardRef<
             index === selectedIndex ? "bg-muted/60" : "hover:bg-muted/60"
           }`}
         >
-          <Terminal className="size-4 flex-shrink-0 text-muted-foreground" />
+          <Terminal className="size-4 flex-shrink-0 text-popover-foreground/60" />
           <div className="min-w-0 flex-1">
             <div className="truncate text-sm font-medium font-mono">
               /{item.name}
             </div>
-            <div className="truncate text-xs text-muted-foreground">
+            <div className="truncate text-xs text-popover-foreground/60">
               {item.description}
             </div>
           </div>


### PR DESCRIPTION
## Summary
Updated color tokens in suggestion list components (emoji, profile, and slash command) to use `popover-foreground` instead of `muted-foreground` for better semantic consistency with the popover design system.

## Changes
- **EmojiSuggestionList**: Updated empty state and selected emoji shortcode text to use `text-popover-foreground/60`, and added `text-popover-foreground` to the main list container
- **ProfileSuggestionList**: Updated empty state and NIP05 display text to use `text-popover-foreground/60`, and added `text-popover-foreground` to the main list container
- **SlashCommandSuggestionList**: Updated empty state, command description, and terminal icon to use `text-popover-foreground/60`, and added `text-popover-foreground` to the main list container

## Details
These changes ensure that all suggestion list components use color tokens that are semantically tied to the popover component they're displayed in, rather than generic muted foreground colors. This improves theme consistency and makes it easier to maintain a cohesive color scheme across the editor's suggestion UI.

https://claude.ai/code/session_0145zLfku7idq3WEqGzvTdvu