### PR TITLE
feat: make NWC connections more robust and wallet state reactive

### DIFF
--- a/src/components/ConnectWalletDialog.tsx
+++ b/src/components/ConnectWalletDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useGrimoire } from "@/core/state";
-import { createWalletFromURI } from "@/services/nwc";
+import { createWalletFromURI, balance$ } from "@/services/nwc";
 
 interface ConnectWalletDialogProps {
   open: boolean;
@@ -66,6 +66,8 @@ export default function ConnectWalletDialog({
       try {
         const balanceResult = await wallet.getBalance();
         balance = balanceResult.balance;
+        // Update the observable immediately so WalletViewer shows correct balance
+        balance$.next(balance);
       } catch (err) {
         console.warn("[NWC] Failed to get balance:", err);
         // Balance is optional, continue anyway

--- a/src/components/ConnectWalletDialog.tsx
+++ b/src/components/ConnectWalletDialog.tsx
@@ -83,6 +83,7 @@ export default function ConnectWalletDialog({
         balance,
         info: {
           alias: info.alias,
+          network: info.network,
           methods: info.methods,
           notifications: info.notifications,
         },
@@ -96,6 +97,7 @@ export default function ConnectWalletDialog({
       // Update info
       updateNWCInfo({
         alias: info.alias,
+        network: info.network,
         methods: info.methods,
         notifications: info.notifications,
       });

--- a/src/components/WalletConnectionStatus.tsx
+++ b/src/components/WalletConnectionStatus.tsx
@@ -1,0 +1,65 @@
+/**
+ * WalletConnectionStatus Component
+ *
+ * Displays a visual indicator for wallet connection status.
+ * Shows different colors and animations based on status:
+ * - connected: green
+ * - connecting: yellow (pulsing)
+ * - error: red
+ * - disconnected: gray
+ */
+
+import type { NWCConnectionStatus } from "@/services/nwc";
+
+interface WalletConnectionStatusProps {
+  status: NWCConnectionStatus;
+  /** Size of the indicator */
+  size?: "sm" | "md";
+  /** Whether to show the status label */
+  showLabel?: boolean;
+  /** Additional class names */
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: "size-1.5",
+  md: "size-2",
+};
+
+/**
+ * Get the color class for a connection status
+ */
+export function getConnectionStatusColor(status: NWCConnectionStatus): string {
+  switch (status) {
+    case "connected":
+      return "bg-green-500";
+    case "connecting":
+      return "bg-yellow-500 animate-pulse";
+    case "error":
+      return "bg-red-500";
+    default:
+      return "bg-gray-500";
+  }
+}
+
+export function WalletConnectionStatus({
+  status,
+  size = "sm",
+  showLabel = false,
+  className = "",
+}: WalletConnectionStatusProps) {
+  const colorClass = getConnectionStatusColor(status);
+
+  if (!showLabel) {
+    return (
+      <span className={`${sizeClasses[size]} ${colorClass} ${className}`} />
+    );
+  }
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`}>
+      <span className={`${sizeClasses[size]} ${colorClass}`} />
+      <span className="text-sm font-medium capitalize">{status}</span>
+    </div>
+  );
+}

--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -452,6 +452,9 @@ export default function WalletViewer() {
   const [showRawTransaction, setShowRawTransaction] = useState(false);
   const [copiedRawTx, setCopiedRawTx] = useState(false);
 
+  // Copy NWC connection string state
+  const [copiedNwc, setCopiedNwc] = useState(false);
+
   // Reset state when connection changes
   useEffect(() => {
     // Detect connection state changes
@@ -602,6 +605,24 @@ export default function WalletViewer() {
     } finally {
       setLoading(false);
     }
+  }
+
+  function copyNwcString() {
+    if (!state.nwcConnection) return;
+
+    const { service, relays, secret, lud16 } = state.nwcConnection;
+    const params = new URLSearchParams();
+    relays.forEach((relay) => params.append("relay", relay));
+    params.append("secret", secret);
+    if (lud16) params.append("lud16", lud16);
+
+    const nwcString = `nostr+walletconnect://${service}?${params.toString()}`;
+
+    navigator.clipboard.writeText(nwcString).then(() => {
+      setCopiedNwc(true);
+      toast.success("Connection string copied");
+      setTimeout(() => setCopiedNwc(false), 2000);
+    });
   }
 
   async function handleConfirmSend() {
@@ -1090,6 +1111,23 @@ export default function WalletViewer() {
               </DropdownMenuContent>
             </DropdownMenu>
           )}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={copyNwcString}
+                className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Copy connection string"
+              >
+                {copiedNwc ? (
+                  <Check className="size-3 text-green-500" />
+                ) : (
+                  <Copy className="size-3" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Copy Connection String</TooltipContent>
+          </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/components/WalletViewer.tsx
+++ b/src/components/WalletViewer.tsx
@@ -62,6 +62,7 @@ import { KindRenderer } from "./nostr/kinds";
 import { RichText } from "./nostr/RichText";
 import { UserName } from "./nostr/UserName";
 import { CodeCopyButton } from "./CodeCopyButton";
+import { WalletConnectionStatus } from "./WalletConnectionStatus";
 import type { Transaction } from "@/types/wallet";
 
 interface InvoiceDetails {
@@ -873,17 +874,7 @@ export default function WalletViewer() {
           </span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <div
-                className={`size-1.5 rounded-full ${
-                  connectionStatus === "connected"
-                    ? "bg-green-500"
-                    : connectionStatus === "connecting"
-                      ? "bg-yellow-500 animate-pulse"
-                      : connectionStatus === "error"
-                        ? "bg-red-500"
-                        : "bg-gray-500"
-                }`}
-              />
+              <WalletConnectionStatus status={connectionStatus} size="sm" />
             </TooltipTrigger>
             <TooltipContent>
               {connectionStatus === "connected" && "Connected"}

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -228,8 +228,7 @@ export default function UserMenu() {
 
             <div className="space-y-4">
               {/* Balance */}
-              {(balance !== undefined ||
-                nwcConnection.balance !== undefined) && (
+              {balance !== undefined && (
                 <div className="flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">
                     Balance:
@@ -243,7 +242,7 @@ export default function UserMenu() {
                       <span>
                         {state.walletBalancesBlurred
                           ? "✦✦✦✦✦✦"
-                          : formatBalance(balance ?? nwcConnection.balance)}
+                          : formatBalance(balance)}
                       </span>
                       {state.walletBalancesBlurred ? (
                         <EyeOff className="size-3 text-muted-foreground" />
@@ -402,14 +401,13 @@ export default function UserMenu() {
             >
               <div className="flex items-center gap-2">
                 <Wallet className="size-4 text-muted-foreground" />
-                {balance !== undefined ||
-                nwcConnection.balance !== undefined ? (
+                {balance !== undefined && (
                   <span className="text-sm">
                     {state.walletBalancesBlurred
                       ? "✦✦✦✦"
-                      : formatBalance(balance ?? nwcConnection.balance)}
+                      : formatBalance(balance)}
                   </span>
-                ) : null}
+                )}
               </div>
               <div className="flex items-center gap-1.5">
                 <span

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -10,6 +10,7 @@ import {
   LogOut,
   Settings,
 } from "lucide-react";
+import { WalletConnectionStatus } from "@/components/WalletConnectionStatus";
 import accounts from "@/services/accounts";
 import { useProfile } from "@/hooks/useProfile";
 import { use$ } from "applesauce-react/hooks";
@@ -239,22 +240,11 @@ export default function UserMenu() {
               {/* Connection Status */}
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">Status:</span>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`size-2 rounded-full ${
-                      connectionStatus === "connected"
-                        ? "bg-green-500"
-                        : connectionStatus === "connecting"
-                          ? "bg-yellow-500 animate-pulse"
-                          : connectionStatus === "error"
-                            ? "bg-red-500"
-                            : "bg-gray-500"
-                    }`}
-                  />
-                  <span className="text-sm font-medium capitalize">
-                    {connectionStatus}
-                  </span>
-                </div>
+                <WalletConnectionStatus
+                  status={connectionStatus}
+                  size="md"
+                  showLabel
+                />
               </div>
 
               {/* Lightning Address */}
@@ -378,17 +368,7 @@ export default function UserMenu() {
                   </span>
                 )}
               </div>
-              <span
-                className={`size-1.5 rounded-full ${
-                  connectionStatus === "connected"
-                    ? "bg-green-500"
-                    : connectionStatus === "connecting"
-                      ? "bg-yellow-500 animate-pulse"
-                      : connectionStatus === "error"
-                        ? "bg-red-500"
-                        : "bg-gray-500"
-                }`}
-              />
+              <WalletConnectionStatus status={connectionStatus} size="sm" />
             </DropdownMenuItem>
           ) : (
             <DropdownMenuItem

--- a/src/components/nostr/user-menu.tsx
+++ b/src/components/nostr/user-menu.tsx
@@ -118,18 +118,12 @@ export default function UserMenu() {
     return sats.toString();
   }
 
-  // Get wallet service profile for display name, using wallet relays as hints
-  const walletServiceProfile = useProfile(
-    nwcConnection?.service,
-    nwcConnection?.relays,
-  );
-
-  // Use wallet hook for real-time balance and methods
+  // Use wallet hook for real-time balance and connection status
   const {
     disconnect: disconnectWallet,
     refreshBalance,
     balance,
-    wallet,
+    connectionStatus,
   } = useWallet();
 
   function openProfile() {
@@ -183,26 +177,6 @@ export default function UserMenu() {
     } catch (_error) {
       toast.error("Failed to refresh balance");
     }
-  }
-
-  function getWalletName(): string {
-    if (!nwcConnection) return "";
-    // Use service pubkey profile name, fallback to alias, then pubkey slice
-    return (
-      getDisplayName(nwcConnection.service, walletServiceProfile) ||
-      nwcConnection.info?.alias ||
-      nwcConnection.service.slice(0, 8)
-    );
-  }
-
-  function openWalletServiceProfile() {
-    if (!nwcConnection?.service) return;
-    addWindow(
-      "profile",
-      { pubkey: nwcConnection.service },
-      `Profile ${nwcConnection.service.slice(0, 8)}...`,
-    );
-    setShowWalletInfo(false);
   }
 
   return (
@@ -262,28 +236,23 @@ export default function UserMenu() {
                 </div>
               )}
 
-              {/* Wallet Name */}
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Wallet:</span>
-                <button
-                  onClick={openWalletServiceProfile}
-                  className="text-sm font-medium hover:underline cursor-crosshair text-primary"
-                >
-                  {getWalletName()}
-                </button>
-              </div>
-
               {/* Connection Status */}
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">Status:</span>
                 <div className="flex items-center gap-2">
                   <span
                     className={`size-2 rounded-full ${
-                      wallet ? "bg-green-500" : "bg-red-500"
+                      connectionStatus === "connected"
+                        ? "bg-green-500"
+                        : connectionStatus === "connecting"
+                          ? "bg-yellow-500 animate-pulse"
+                          : connectionStatus === "error"
+                            ? "bg-red-500"
+                            : "bg-gray-500"
                     }`}
                   />
-                  <span className="text-sm font-medium">
-                    {wallet ? "Connected" : "Disconnected"}
+                  <span className="text-sm font-medium capitalize">
+                    {connectionStatus}
                   </span>
                 </div>
               </div>
@@ -409,16 +378,17 @@ export default function UserMenu() {
                   </span>
                 )}
               </div>
-              <div className="flex items-center gap-1.5">
-                <span
-                  className={`size-1.5 rounded-full ${
-                    wallet ? "bg-green-500" : "bg-red-500"
-                  }`}
-                />
-                <span className="text-xs text-muted-foreground">
-                  {getWalletName()}
-                </span>
-              </div>
+              <span
+                className={`size-1.5 rounded-full ${
+                  connectionStatus === "connected"
+                    ? "bg-green-500"
+                    : connectionStatus === "connecting"
+                      ? "bg-yellow-500 animate-pulse"
+                      : connectionStatus === "error"
+                        ? "bg-red-500"
+                        : "bg-gray-500"
+                }`}
+              />
             </DropdownMenuItem>
           ) : (
             <DropdownMenuItem

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -35,6 +35,10 @@ import {
   balance$,
   connectionStatus$,
   lastError$,
+  transactionsState$,
+  loadTransactions as loadTransactionsService,
+  loadMoreTransactions as loadMoreTransactionsService,
+  retryLoadTransactions as retryLoadTransactionsService,
 } from "@/services/nwc";
 
 export function useWallet() {
@@ -47,6 +51,7 @@ export function useWallet() {
   const balance = use$(balance$);
   const connectionStatus = use$(connectionStatus$);
   const lastError = use$(lastError$);
+  const transactionsState = use$(transactionsState$);
 
   // Wallet support from library's support$ observable (cached)
   const support = use$(() => wallet?.support$, [wallet]);
@@ -145,6 +150,18 @@ export function useWallet() {
     return await refreshBalanceService();
   }
 
+  async function loadTransactions() {
+    await loadTransactionsService();
+  }
+
+  async function loadMoreTransactions() {
+    await loadMoreTransactionsService();
+  }
+
+  async function retryLoadTransactions() {
+    await retryLoadTransactionsService();
+  }
+
   return {
     // State (all derived from observables)
     wallet,
@@ -154,6 +171,7 @@ export function useWallet() {
     lastError,
     support,
     walletMethods,
+    transactionsState,
 
     // Operations
     payInvoice,
@@ -166,5 +184,8 @@ export function useWallet() {
     payKeysend,
     disconnect,
     reconnect,
+    loadTransactions,
+    loadMoreTransactions,
+    retryLoadTransactions,
   };
 }

--- a/src/services/nwc.ts
+++ b/src/services/nwc.ts
@@ -149,6 +149,7 @@ export function createWalletFromURI(connectionString: string): WalletConnect {
   wallet$.next(wallet);
 
   subscribeToNotifications(wallet);
+  refreshBalance(); // Fetch initial balance
 
   return wallet;
 }

--- a/src/services/nwc.ts
+++ b/src/services/nwc.ts
@@ -9,18 +9,48 @@
  * - Subscribes to NIP-47 notifications (kind 23197) for balance updates
  * - Fully reactive using RxJS observables (no polling!)
  * - Components use use$() to reactively subscribe to balance changes
+ * - Connection health tracking with automatic recovery
+ * - Uses library's support$ observable for cached wallet capabilities
  */
 
 import { WalletConnect } from "applesauce-wallet-connect";
 import type { NWCConnection } from "@/types/app";
 import pool from "./relay-pool";
-import { BehaviorSubject, Subscription } from "rxjs";
+import { BehaviorSubject, Subscription, firstValueFrom, timeout } from "rxjs";
 
 // Set the pool for wallet connect to use
 WalletConnect.pool = pool;
 
 let walletInstance: WalletConnect | null = null;
 let notificationSubscription: Subscription | null = null;
+let supportSubscription: Subscription | null = null;
+
+/**
+ * Connection status for the NWC wallet
+ * - disconnected: No wallet connected
+ * - connecting: Wallet is being restored/validated
+ * - connected: Wallet is connected and responding
+ * - error: Connection failed or lost
+ */
+export type NWCConnectionStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "error";
+
+/**
+ * Observable for connection status
+ * Components can subscribe to this for real-time connection state using use$()
+ */
+export const connectionStatus$ = new BehaviorSubject<NWCConnectionStatus>(
+  "disconnected",
+);
+
+/**
+ * Observable for the last connection error
+ * Components can use this to display error messages
+ */
+export const lastError$ = new BehaviorSubject<Error | null>(null);
 
 /**
  * Observable for wallet balance updates
@@ -40,43 +70,104 @@ function hexToBytes(hex: string): Uint8Array {
 }
 
 /**
- * Subscribe to wallet notifications (NIP-47 kind 23197)
+ * Subscribe to wallet notifications with automatic retry on error
  * This enables real-time balance updates when transactions occur
  */
-function subscribeToNotifications(wallet: WalletConnect) {
+function subscribeToNotificationsWithRetry(wallet: WalletConnect) {
   // Clean up existing subscription
   if (notificationSubscription) {
     notificationSubscription.unsubscribe();
+    notificationSubscription = null;
   }
 
-  console.log("[NWC] Subscribing to wallet notifications");
+  let retryCount = 0;
+  const maxRetries = 5;
+  const baseDelay = 2000; // 2 seconds
 
-  // Subscribe to the wallet's notifications$ observable
-  // This receives events like payment_received, payment_sent, etc.
-  notificationSubscription = wallet.notifications$.subscribe({
-    next: (notification) => {
-      console.log("[NWC] Notification received:", notification);
+  function subscribe() {
+    console.log(
+      `[NWC] Subscribing to wallet notifications (attempt ${retryCount + 1})`,
+    );
 
-      // When we get a notification, refresh the balance
-      // The notification types include: payment_received, payment_sent, etc.
-      wallet
-        .getBalance()
-        .then((result) => {
-          const newBalance = result.balance;
-          if (balance$.value !== newBalance) {
-            balance$.next(newBalance);
-            console.log("[NWC] Balance updated from notification:", newBalance);
-          }
-        })
-        .catch((error) => {
-          console.error(
-            "[NWC] Failed to fetch balance after notification:",
-            error,
+    notificationSubscription = wallet.notifications$.subscribe({
+      next: (notification) => {
+        console.log("[NWC] Notification received:", notification);
+        retryCount = 0; // Reset retry count on success
+
+        // Mark as connected if we were in error state
+        if (connectionStatus$.value === "error") {
+          connectionStatus$.next("connected");
+          lastError$.next(null);
+        }
+
+        // When we get a notification, refresh the balance
+        refreshBalance();
+      },
+      error: (error) => {
+        console.error("[NWC] Notification subscription error:", error);
+
+        if (retryCount < maxRetries) {
+          const delay = baseDelay * Math.pow(2, retryCount);
+          retryCount++;
+          console.log(`[NWC] Retrying notification subscription in ${delay}ms`);
+          connectionStatus$.next("connecting");
+          setTimeout(subscribe, delay);
+        } else {
+          console.error("[NWC] Max notification retries reached");
+          connectionStatus$.next("error");
+          lastError$.next(
+            error instanceof Error
+              ? error
+              : new Error("Notification subscription failed"),
           );
-        });
+        }
+      },
+      complete: () => {
+        console.log("[NWC] Notification subscription completed");
+        // If subscription completes unexpectedly, try to reconnect
+        if (walletInstance && retryCount < maxRetries) {
+          const delay = baseDelay * Math.pow(2, retryCount);
+          retryCount++;
+          console.log(
+            `[NWC] Subscription completed, reconnecting in ${delay}ms`,
+          );
+          setTimeout(subscribe, delay);
+        }
+      },
+    });
+  }
+
+  subscribe();
+}
+
+/**
+ * Subscribe to the wallet's support$ observable for cached capabilities
+ * This keeps connection alive and validates the wallet is responding
+ */
+function subscribeToSupport(wallet: WalletConnect) {
+  // Clean up existing subscription
+  if (supportSubscription) {
+    supportSubscription.unsubscribe();
+    supportSubscription = null;
+  }
+
+  supportSubscription = wallet.support$.subscribe({
+    next: (support) => {
+      if (support) {
+        console.log("[NWC] Wallet support info received:", support);
+        // Mark as connected when we receive support info
+        if (
+          connectionStatus$.value === "connecting" ||
+          connectionStatus$.value === "error"
+        ) {
+          connectionStatus$.next("connected");
+          lastError$.next(null);
+        }
+      }
     },
     error: (error) => {
-      console.error("[NWC] Notification subscription error:", error);
+      console.error("[NWC] Support subscription error:", error);
+      // Don't set error state here as notifications subscription handles recovery
     },
   });
 }
@@ -86,28 +177,73 @@ function subscribeToNotifications(wallet: WalletConnect) {
  * Automatically subscribes to notifications for balance updates
  */
 export function createWalletFromURI(connectionString: string): WalletConnect {
+  connectionStatus$.next("connecting");
+  lastError$.next(null);
+
   walletInstance = WalletConnect.fromConnectURI(connectionString);
-  subscribeToNotifications(walletInstance);
+  subscribeToSupport(walletInstance);
+  subscribeToNotificationsWithRetry(walletInstance);
+
   return walletInstance;
 }
 
 /**
  * Restores a wallet from saved connection data
  * Used on app startup to reconnect to a previously connected wallet
+ * Validates the connection using the support$ observable
  */
-export function restoreWallet(connection: NWCConnection): WalletConnect {
+export async function restoreWallet(
+  connection: NWCConnection,
+): Promise<WalletConnect> {
+  connectionStatus$.next("connecting");
+  lastError$.next(null);
+
   walletInstance = new WalletConnect({
     service: connection.service,
     relays: connection.relays,
     secret: hexToBytes(connection.secret),
   });
 
-  // Set initial balance from cache
+  // Set initial balance from cache while we validate
   if (connection.balance !== undefined) {
     balance$.next(connection.balance);
   }
 
-  subscribeToNotifications(walletInstance);
+  // Subscribe to support$ for cached wallet capabilities
+  subscribeToSupport(walletInstance);
+
+  // Validate connection by waiting for support info with timeout
+  try {
+    console.log("[NWC] Validating wallet connection...");
+    await firstValueFrom(
+      walletInstance.support$.pipe(
+        timeout({
+          first: 10000, // 10 second timeout for first value
+          with: () => {
+            throw new Error("Connection validation timeout");
+          },
+        }),
+      ),
+    );
+    console.log("[NWC] Wallet connection validated");
+    connectionStatus$.next("connected");
+  } catch (error) {
+    console.error("[NWC] Wallet validation failed:", error);
+    connectionStatus$.next("error");
+    lastError$.next(
+      error instanceof Error
+        ? error
+        : new Error("Connection validation failed"),
+    );
+    // Continue anyway - notifications subscription will retry
+  }
+
+  // Subscribe to notifications with retry logic
+  subscribeToNotificationsWithRetry(walletInstance);
+
+  // Refresh balance from wallet (not just cache)
+  refreshBalance();
+
   return walletInstance;
 }
 
@@ -126,25 +262,80 @@ export function clearWallet(): void {
     notificationSubscription.unsubscribe();
     notificationSubscription = null;
   }
+  if (supportSubscription) {
+    supportSubscription.unsubscribe();
+    supportSubscription = null;
+  }
   walletInstance = null;
   balance$.next(undefined);
+  connectionStatus$.next("disconnected");
+  lastError$.next(null);
 }
 
 /**
  * Manually refresh the balance from the wallet
  * Useful for initial load or manual refresh button
+ * Includes retry logic for reliability
  */
 export async function refreshBalance(): Promise<number | undefined> {
   if (!walletInstance) return undefined;
 
-  try {
-    const result = await walletInstance.getBalance();
-    const newBalance = result.balance;
+  const maxRetries = 3;
+  const baseDelay = 1000;
 
-    balance$.next(newBalance);
-    return newBalance;
-  } catch (error) {
-    console.error("[NWC] Failed to refresh balance:", error);
-    return undefined;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const result = await walletInstance.getBalance();
+      const newBalance = result.balance;
+
+      balance$.next(newBalance);
+
+      // Mark as connected on successful balance fetch
+      if (connectionStatus$.value === "error") {
+        connectionStatus$.next("connected");
+        lastError$.next(null);
+      }
+
+      return newBalance;
+    } catch (error) {
+      console.error(
+        `[NWC] Failed to refresh balance (attempt ${attempt + 1}):`,
+        error,
+      );
+
+      if (attempt < maxRetries - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelay * Math.pow(2, attempt)),
+        );
+      } else {
+        // Only set error state on final failure if not already connected
+        if (connectionStatus$.value !== "connected") {
+          connectionStatus$.next("error");
+          lastError$.next(
+            error instanceof Error ? error : new Error("Failed to get balance"),
+          );
+        }
+      }
+    }
   }
+
+  return undefined;
+}
+
+/**
+ * Attempt to reconnect the wallet
+ * Call this when the user wants to manually retry after an error
+ */
+export async function reconnect(): Promise<void> {
+  if (!walletInstance) return;
+
+  connectionStatus$.next("connecting");
+  lastError$.next(null);
+
+  // Re-subscribe to support and notifications
+  subscribeToSupport(walletInstance);
+  subscribeToNotificationsWithRetry(walletInstance);
+
+  // Try to refresh balance
+  await refreshBalance();
 }

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -100,6 +100,7 @@ export interface NWCConnection {
   /** Optional wallet info */
   info?: {
     alias?: string;
+    network?: string;
     methods?: string[];
     notifications?: string[];
   };

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,51 @@
+/**
+ * Wallet-related type definitions for NWC (NIP-47)
+ */
+
+/**
+ * A Lightning/Bitcoin transaction from NWC list_transactions
+ */
+export interface Transaction {
+  type: "incoming" | "outgoing";
+  invoice?: string;
+  description?: string;
+  description_hash?: string;
+  preimage?: string;
+  payment_hash?: string;
+  amount: number;
+  fees_paid?: number;
+  created_at: number;
+  expires_at?: number;
+  settled_at?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * State for the transactions observable
+ */
+export interface TransactionsState {
+  /** The list of transactions */
+  items: Transaction[];
+  /** Whether we're loading the initial batch */
+  loading: boolean;
+  /** Whether we're loading more (pagination) */
+  loadingMore: boolean;
+  /** Whether there are more transactions to load */
+  hasMore: boolean;
+  /** Error from last load attempt */
+  error: Error | null;
+  /** Whether initial load has been triggered */
+  initialized: boolean;
+}
+
+/**
+ * Initial state for transactions
+ */
+export const INITIAL_TRANSACTIONS_STATE: TransactionsState = {
+  items: [],
+  loading: false,
+  loadingMore: false,
+  hasMore: true,
+  error: null,
+  initialized: false,
+};


### PR DESCRIPTION
## Summary
Refactored wallet connection handling to use the library's built-in `support$` observable for cached wallet capabilities instead of manual `getInfo()` calls, and added comprehensive connection status tracking with automatic recovery mechanisms.

## Key Changes

### Connection Status & Error Tracking
- Added `connectionStatus$` observable tracking states: `disconnected`, `connecting`, `connected`, `error`
- Added `lastError$` observable to expose connection errors to UI components
- Implemented automatic retry logic with exponential backoff for notification subscriptions
- Added manual `reconnect()` function for user-initiated recovery after errors

### Wallet Support Caching
- Replaced manual `getInfo()` calls with subscription to wallet's `support$` observable
- Removed local `walletInfo` state from `WalletViewer` component
- Updated all capability checks to use `support?.methods` instead of `walletInfo.methods`
- Support info is now cached by the library and automatically kept in sync

### Enhanced Connection Validation
- Made `restoreWallet()` async to validate connection using `support$` observable with 10-second timeout
- Added subscription to `support$` observable to keep connection alive and validate wallet responsiveness
- Improved error handling with proper state transitions during connection lifecycle

### UI Improvements
- Enhanced connection status indicator with color coding and tooltip
- Added "Retry" button when connection is in error state
- Display connection status (connected/connecting/error/disconnected) with visual feedback
- Network info now sourced from cached `state.nwcConnection?.info?.network`

### Code Cleanup
- Removed `WalletInfo` interface from `WalletViewer` (moved to service layer)
- Removed `walletInfoLoadedRef` tracking (no longer needed with observable pattern)
- Simplified component state management by relying on observables
- Updated `useWallet()` hook to expose `connectionStatus`, `lastError`, and `support`

## Implementation Details
- Connection recovery uses exponential backoff (2s, 4s, 8s, 16s, 32s) with max 5 retries
- Balance refresh includes retry logic (3 attempts with exponential backoff)
- All observables are fully reactive - components using `use$()` hook automatically update on changes
- Network info is now persisted in `NWCConnection.info.network` for display purposes

https://claude.ai/code/session_01CnJgjFMvZHZWs2ujAiWAiQ