### PR TITLE
Add blobUrl and mediaType props to WindowRenderer

### DIFF
--- a/src/components/WindowRenderer.tsx
+++ b/src/components/WindowRenderer.tsx
@@ -230,6 +230,8 @@ export function WindowRenderer({ window, onClose }: WindowRendererProps) {
             sourceUrl={window.props.sourceUrl}
             targetServer={window.props.targetServer}
             sha256={window.props.sha256}
+            blobUrl={window.props.blobUrl}
+            mediaType={window.props.mediaType}
           />
         );
         break;


### PR DESCRIPTION
## Summary
Extended the WindowRenderer component to pass `blobUrl` and `mediaType` props to the FileDownloadRenderer, enabling better handling of blob-based file downloads with explicit media type information.

## Changes
- Added `blobUrl` prop forwarding from window props to FileDownloadRenderer
- Added `mediaType` prop forwarding from window props to FileDownloadRenderer

## Details
These new props allow the FileDownloadRenderer to work with blob URLs and properly identify file types through explicit media type specification, improving support for dynamically generated or in-memory file downloads.

https://claude.ai/code/session_018edX9kUcEudJzwuFCGh1xf