### PR TITLE
fix(time-format): avoid displaying "0m ago"; show weeks instead

### DIFF
--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -84,7 +84,7 @@ export function formatTimestamp(
     if (minutes < 60) return `${minutes}m ago`;
     if (hours < 24) return `${hours}h ago`;
     if (days < 7) return `${days}d ago`;
-    if (weeks < 4) return `${weeks}w ago`;
+    if (weeks < 4 || months == 0) return `${weeks}w ago`;
     if (months < 12) return `${months}mo ago`;
     return `${years}y ago`;
   }


### PR DESCRIPTION
before:
<img width="450" height="153" alt="imagen" src="https://github.com/user-attachments/assets/125d8506-bfe9-4cc7-815a-f473cb4ca773" />
now:
<img width="451" height="150" alt="imagen" src="https://github.com/user-attachments/assets/2a892fd8-c044-4cfe-89d2-5f18f848e350" />
