### PR TITLE
Add "live" subscription state for post-EOSE streaming events

### DIFF
--- a/src/components/ReqViewer.tsx
+++ b/src/components/ReqViewer.tsx
@@ -1234,12 +1234,17 @@ export default function ReqViewer({
                               </div>
                             )}
 
-                            {/* EOSE status */}
+                            {/* Subscription status icon */}
                             {reqState && (
                               <>
-                                {reqState.subscriptionState === "eose" ? (
+                                {reqState.subscriptionState === "live" ? (
+                                  // Live: EOSE received + actively streaming
+                                  <Radio className="size-3 text-green-500 animate-pulse" />
+                                ) : reqState.subscriptionState === "eose" ? (
+                                  // EOSE received, idle
                                   <Check className="size-3 text-green-600/70" />
                                 ) : (
+                                  // Receiving historical or waiting
                                   (reqState.subscriptionState === "receiving" ||
                                     reqState.subscriptionState ===
                                       "waiting") && (

--- a/src/lib/req-state-machine.test.ts
+++ b/src/lib/req-state-machine.test.ts
@@ -538,6 +538,7 @@ describe("getStatusText", () => {
     connectedCount: 3,
     receivingCount: 2,
     eoseCount: 1,
+    liveCount: 0,
     errorCount: 0,
     disconnectedCount: 0,
     hasReceivedEvents: true,
@@ -568,6 +569,7 @@ describe("getStatusTooltip", () => {
     connectedCount: 3,
     receivingCount: 2,
     eoseCount: 1,
+    liveCount: 0,
     errorCount: 0,
     disconnectedCount: 0,
     hasReceivedEvents: true,
@@ -625,7 +627,18 @@ describe("shouldAnimate", () => {
 });
 
 describe("getRelayStateBadge", () => {
-  it("should return receiving badge", () => {
+  it("should return live badge (EOSE received + streaming)", () => {
+    const badge = getRelayStateBadge({
+      url: "wss://relay.com",
+      connectionState: "connected",
+      subscriptionState: "live",
+      eventCount: 15,
+    });
+    expect(badge?.text).toBe("LIVE");
+    expect(badge?.color).toBe("text-success");
+  });
+
+  it("should return receiving badge (before EOSE)", () => {
     const badge = getRelayStateBadge({
       url: "wss://relay.com",
       connectionState: "connected",
@@ -633,7 +646,8 @@ describe("getRelayStateBadge", () => {
       eventCount: 5,
     });
     expect(badge?.text).toBe("RECEIVING");
-    expect(badge?.color).toBe("text-success");
+    // Warning color because it's still loading (pre-EOSE)
+    expect(badge?.color).toBe("text-warning");
   });
 
   it("should return eose badge", () => {

--- a/src/types/req-state.ts
+++ b/src/types/req-state.ts
@@ -18,11 +18,23 @@ export type RelayConnectionState =
 
 /**
  * Subscription state specific to this REQ
+ *
+ * State machine:
+ *   waiting → receiving → eose → live
+ *                  ↘      ↗
+ *                   error
+ *
+ * - waiting: Connected, subscription sent, no events yet
+ * - receiving: Getting historical events (before EOSE)
+ * - eose: EOSE received, no live events yet
+ * - live: EOSE received AND receiving live events (streaming mode)
+ * - error: Subscription error occurred
  */
 export type RelaySubscriptionState =
   | "waiting" // Connected but no events yet
-  | "receiving" // Events being received
-  | "eose" // EOSE received (real or timeout)
+  | "receiving" // Getting historical events (before EOSE)
+  | "eose" // EOSE received, idle (no live events yet)
+  | "live" // EOSE received AND receiving live events
   | "error"; // Subscription error
 
 /**
@@ -75,7 +87,8 @@ export interface ReqOverallState {
   totalRelays: number;
   connectedCount: number;
   receivingCount: number;
-  eoseCount: number;
+  eoseCount: number; // Relays in "eose" state (EOSE received, idle)
+  liveCount: number; // Relays in "live" state (EOSE received + streaming)
   errorCount: number;
   disconnectedCount: number;
 


### PR DESCRIPTION
## Summary
This PR introduces a new "live" subscription state to distinguish between relays that have received EOSE but are idle versus those actively streaming live events after EOSE. This provides better visibility into relay behavior and improves the user experience with more accurate status indicators.

## Key Changes

- **New subscription state**: Added "live" state to the subscription state machine
  - `waiting` → `receiving` → `eose` → `live` (with error as a terminal state)
  - "live" means EOSE was received AND the relay is actively streaming new events
  - "eose" now specifically means EOSE received but idle (no live events yet)

- **Updated state tracking**: Modified `useReqTimelineEnhanced` to detect when events arrive after EOSE and transition to "live" state
  - Checks if `eoseAt` exists to determine if an incoming event is historical or live
  - Sets appropriate subscription state based on whether EOSE has been received

- **Enhanced UI indicators**:
  - Live relays show a pulsing green radio icon (animated)
  - EOSE (idle) relays show a static green checkmark
  - Receiving (pre-EOSE) relays show a warning color indicator
  - Badge text updated: "LIVE" for streaming, "RECEIVING" for historical, "EOSE" for idle

- **Updated state machine logic**:
  - `deriveOverallState` now tracks `liveCount` separately from `eoseCount`
  - Both "live" and "eose" states are considered terminal for initial load completion
  - `getRelayStateBadge` prioritizes display order: live → receiving → eose

- **Type definitions**: Updated `RelaySubscriptionState` type with comprehensive documentation of the state machine and each state's meaning

## Implementation Details

The key insight is that after EOSE is received, subsequent events represent live/real-time data from the relay. By tracking `eoseAt`, we can distinguish between:
- Historical events (arriving before EOSE)
- Live events (arriving after EOSE)

This allows for more granular monitoring of relay behavior and better user feedback about what data is being received.

https://claude.ai/code/session_01DVTWqKNY4UHVSDDxckjkAh