### PR TITLE
feat(kind-1111): show root scope and parent context per NIP-22

### DIFF
--- a/src/components/nostr/kinds/Kind1111Renderer.tsx
+++ b/src/components/nostr/kinds/Kind1111Renderer.tsx
@@ -91,7 +91,7 @@ function ScopeRow({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className={`${base} text-accent hover:underline hover:decoration-dotted`}
+        className={`${base} text-muted-foreground underline decoration-dotted hover:text-foreground transition-colors`}
       >
         {children}
       </a>

--- a/src/components/nostr/kinds/Kind1111Renderer.tsx
+++ b/src/components/nostr/kinds/Kind1111Renderer.tsx
@@ -119,7 +119,11 @@ function NostrEventContent({ nostrEvent }: { nostrEvent: NostrEvent }) {
   const title = getEventDisplayTitle(nostrEvent, false);
   return (
     <>
-      <KindBadge kind={nostrEvent.kind} variant="compact" />
+      <KindBadge
+        kind={nostrEvent.kind}
+        variant="compact"
+        iconClassname="size-3"
+      />
       <UserName
         pubkey={nostrEvent.pubkey}
         className="text-accent font-semibold flex-shrink-0"
@@ -147,8 +151,14 @@ function RootScopeDisplay({
 
   // External identifier (I-tag) — render as a link
   if (root.scope.type === "external") {
-    const label = getExternalIdentifierLabel(root.scope.value, root.kind);
-    const href = root.scope.hint || undefined;
+    const { value, hint } = root.scope;
+    const label = getExternalIdentifierLabel(value, root.kind);
+    // Use hint if available, otherwise use value directly when it's a URL
+    const href =
+      hint ||
+      (value.startsWith("http://") || value.startsWith("https://")
+        ? value
+        : undefined);
     return (
       <ScopeRow href={href}>
         <ExternalLink className="size-3 flex-shrink-0" />
@@ -164,7 +174,11 @@ function RootScopeDisplay({
     return (
       <InlineReplySkeleton
         icon={
-          <KindBadge kind={parseInt(root.kind, 10) || 0} variant="compact" />
+          <KindBadge
+            kind={parseInt(root.kind, 10) || 0}
+            variant="compact"
+            iconClassname="size-3"
+          />
         }
       />
     );

--- a/src/lib/nip22-helpers.ts
+++ b/src/lib/nip22-helpers.ts
@@ -1,0 +1,244 @@
+import { getOrComputeCachedValue } from "applesauce-core/helpers";
+import {
+  getEventPointerFromETag,
+  getAddressPointerFromATag,
+  getProfilePointerFromPTag,
+} from "applesauce-core/helpers/pointers";
+import type { NostrEvent } from "nostr-tools";
+import type {
+  EventPointer,
+  AddressPointer,
+  ProfilePointer,
+} from "nostr-tools/nip19";
+import type { LucideIcon } from "lucide-react";
+import {
+  Globe,
+  Podcast,
+  BookOpen,
+  FileText,
+  MapPin,
+  Hash,
+  Coins,
+  Film,
+  Flag,
+  ExternalLink,
+} from "lucide-react";
+
+// --- Types ---
+
+export type CommentExternalPointer = {
+  type: "external";
+  value: string;
+  hint?: string;
+};
+
+export type CommentScope =
+  | ({ type: "event" } & EventPointer)
+  | ({ type: "address" } & AddressPointer)
+  | CommentExternalPointer;
+
+export type CommentRootScope = {
+  scope: CommentScope;
+  kind: string; // K tag value — a number string or external type like "web"
+  author?: ProfilePointer;
+};
+
+export type CommentParent = {
+  scope: CommentScope;
+  kind: string; // k tag value
+  author?: ProfilePointer;
+};
+
+// --- Cache symbols ---
+
+const RootScopeSymbol = Symbol("nip22RootScope");
+const ParentSymbol = Symbol("nip22Parent");
+const IsTopLevelSymbol = Symbol("nip22IsTopLevel");
+
+// --- Parsing helpers ---
+
+function findTag(event: NostrEvent, tagName: string): string[] | undefined {
+  return event.tags.find((t: string[]) => t[0] === tagName);
+}
+
+/**
+ * Parse scope from E/e, A/a, I/i tags using applesauce helpers.
+ * The helpers work on the tag array structure regardless of tag name casing.
+ */
+function parseScopeFromTags(
+  event: NostrEvent,
+  eTagName: string,
+  aTagName: string,
+  iTagName: string,
+): CommentScope | null {
+  // Check E/e tag — use applesauce helper for structured parsing
+  const eTagData = findTag(event, eTagName);
+  if (eTagData) {
+    const pointer = getEventPointerFromETag(eTagData);
+    if (pointer) {
+      return { type: "event", ...pointer };
+    }
+  }
+
+  // Check A/a tag — use applesauce helper for coordinate parsing
+  const aTagData = findTag(event, aTagName);
+  if (aTagData) {
+    const pointer = getAddressPointerFromATag(aTagData);
+    if (pointer) {
+      return { type: "address", ...pointer };
+    }
+  }
+
+  // Check I/i tag — external identifiers (no applesauce helper for this)
+  const iTagData = findTag(event, iTagName);
+  if (iTagData && iTagData[1]) {
+    return {
+      type: "external",
+      value: iTagData[1],
+      hint: iTagData[2] || undefined,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Parse an author tag (P/p) using applesauce helper.
+ */
+function parseAuthorTag(
+  event: NostrEvent,
+  tagName: string,
+): ProfilePointer | undefined {
+  const tag = findTag(event, tagName);
+  if (!tag) return undefined;
+  return getProfilePointerFromPTag(tag) ?? undefined;
+}
+
+// --- Public API ---
+
+/**
+ * Get the root scope of a NIP-22 comment (uppercase E/A/I + K + P tags).
+ * This tells you what the comment thread is *about* (a blog post, file, URL, podcast, etc.).
+ */
+export function getCommentRootScope(
+  event: NostrEvent,
+): CommentRootScope | null {
+  return getOrComputeCachedValue(event, RootScopeSymbol, () => {
+    const scope = parseScopeFromTags(event, "E", "A", "I");
+    if (!scope) return null;
+
+    const kTag = findTag(event, "K");
+    if (!kTag || !kTag[1]) return null; // K is mandatory
+
+    const author = parseAuthorTag(event, "P");
+
+    return {
+      scope,
+      kind: kTag[1],
+      author,
+    };
+  });
+}
+
+/**
+ * Get the parent item of a NIP-22 comment (lowercase e/a/i + k + p tags).
+ * This tells you what this comment is directly replying to.
+ */
+export function getCommentParent(event: NostrEvent): CommentParent | null {
+  return getOrComputeCachedValue(event, ParentSymbol, () => {
+    const scope = parseScopeFromTags(event, "e", "a", "i");
+    if (!scope) return null;
+
+    const kTag = findTag(event, "k");
+    if (!kTag || !kTag[1]) return null; // k is mandatory
+
+    const author = parseAuthorTag(event, "p");
+
+    return {
+      scope,
+      kind: kTag[1],
+      author,
+    };
+  });
+}
+
+/**
+ * Returns true when the comment is a top-level comment on the root item
+ * (not a reply to another comment). Determined by checking if the parent
+ * kind is not "1111".
+ */
+export function isTopLevelComment(event: NostrEvent): boolean {
+  return getOrComputeCachedValue(event, IsTopLevelSymbol, () => {
+    const parent = getCommentParent(event);
+    if (!parent) return true;
+    return parent.kind !== "1111";
+  });
+}
+
+/**
+ * Map a NIP-73 external identifier type (K/k value) to an appropriate icon.
+ */
+export function getExternalIdentifierIcon(kValue: string): LucideIcon {
+  if (kValue === "web") return Globe;
+  if (kValue.startsWith("podcast")) return Podcast;
+  if (kValue === "isbn") return BookOpen;
+  if (kValue === "doi") return FileText;
+  if (kValue === "geo") return MapPin;
+  if (kValue === "iso3166") return Flag;
+  if (kValue === "#") return Hash;
+  if (kValue === "isan") return Film;
+  // Blockchain types: "bitcoin:tx", "ethereum:1:address", etc.
+  if (kValue.includes(":tx") || kValue.includes(":address")) return Coins;
+  return ExternalLink;
+}
+
+/**
+ * Get a human-friendly label for an external identifier value.
+ */
+export function getExternalIdentifierLabel(
+  iValue: string,
+  kValue?: string,
+): string {
+  // URLs - show truncated
+  if (
+    kValue === "web" ||
+    iValue.startsWith("http://") ||
+    iValue.startsWith("https://")
+  ) {
+    try {
+      const url = new URL(iValue);
+      const path = url.pathname === "/" ? "" : url.pathname;
+      return `${url.hostname}${path}`;
+    } catch {
+      return iValue;
+    }
+  }
+
+  // Podcast types
+  if (iValue.startsWith("podcast:item:guid:")) return "Podcast Episode";
+  if (iValue.startsWith("podcast:publisher:guid:")) return "Podcast Publisher";
+  if (iValue.startsWith("podcast:guid:")) return "Podcast Feed";
+
+  // ISBN
+  if (iValue.startsWith("isbn:")) return `ISBN ${iValue.slice(5)}`;
+
+  // DOI
+  if (iValue.startsWith("doi:")) return `DOI ${iValue.slice(4)}`;
+
+  // Geohash
+  if (kValue === "geo") return `Location ${iValue}`;
+
+  // Country codes
+  if (kValue === "iso3166") return iValue.toUpperCase();
+
+  // Hashtag
+  if (iValue.startsWith("#")) return iValue;
+
+  // Blockchain
+  if (iValue.includes(":tx:"))
+    return `Transaction ${iValue.split(":tx:")[1]?.slice(0, 12)}...`;
+  if (iValue.includes(":address:"))
+    return `Address ${iValue.split(":address:")[1]?.slice(0, 12)}...`;
+
+  return iValue;
+}


### PR DESCRIPTION
The Kind 1111 renderer previously only showed the immediate parent reply,
missing the root scope that defines what a comment thread is about. Now
shows both the root item (blog post, file, URL, podcast, etc.) and the
parent reply (when replying to another comment), giving full threading
context.

- Add NIP-22 helper library using applesauce pointer helpers
  (getEventPointerFromETag, getAddressPointerFromATag,
  getProfilePointerFromPTag) for tag parsing
- Support external identifiers (I-tags) with NIP-73 type-specific icons
- Unified ScopeRow component for consistent inline display
- Only show parent reply line for nested comments (not top-level)

https://claude.ai/code/session_01Dxedi6VWdZG8nFpba211oR