### PR TITLE
feat(relay): add wss://relay.zapstore.dev for zapstore app kinds

### DIFF
--- a/src/components/nostr/kinds/ZapstoreAppDetailRenderer.tsx
+++ b/src/components/nostr/kinds/ZapstoreAppDetailRenderer.tsx
@@ -169,11 +169,15 @@ export function ZapstoreAppDetailRenderer({
   const identifier = getAppIdentifier(event);
 
   // Build relay list for fetching releases:
-  // 1. Seen relays (where we received this app event)
-  // 2. Publisher's outbox relays (NIP-65)
-  // 3. Aggregator relays (fallback)
+  // 1. Zapstore relay (primary source for app events)
+  // 2. Seen relays (where we received this app event)
+  // 3. Publisher's outbox relays (NIP-65)
+  // 4. Aggregator relays (fallback)
   const relays = useMemo(() => {
     const relaySet = new Set<string>();
+
+    // Add zapstore relay (primary source for app metadata)
+    relaySet.add("wss://relay.zapstore.dev/");
 
     // Add seen relays from the app event
     const seenRelays = getSeenRelays(event);

--- a/src/components/nostr/kinds/ZapstoreAppRenderer.tsx
+++ b/src/components/nostr/kinds/ZapstoreAppRenderer.tsx
@@ -32,11 +32,15 @@ export function ZapstoreAppRenderer({ event }: BaseEventProps) {
   const platforms = detectPlatforms(event);
 
   // Build relay list for fetching releases:
-  // 1. Seen relays (where we received this app event)
-  // 2. Publisher's outbox relays (NIP-65)
-  // 3. Aggregator relays (fallback)
+  // 1. Zapstore relay (primary source for app events)
+  // 2. Seen relays (where we received this app event)
+  // 3. Publisher's outbox relays (NIP-65)
+  // 4. Aggregator relays (fallback)
   const relays = useMemo(() => {
     const relaySet = new Set<string>();
+
+    // Add zapstore relay (primary source for app metadata)
+    relaySet.add("wss://relay.zapstore.dev/");
 
     // Add seen relays from the app event
     const seenRelays = getSeenRelays(event);

--- a/src/components/nostr/kinds/ZapstoreAppSetDetailRenderer.tsx
+++ b/src/components/nostr/kinds/ZapstoreAppSetDetailRenderer.tsx
@@ -10,8 +10,11 @@ import {
 } from "@/lib/zapstore-helpers";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { useGrimoire } from "@/core/state";
+import { useMemo } from "react";
 import { UserName } from "../UserName";
 import { Package } from "lucide-react";
+
+const ZAPSTORE_RELAY = "wss://relay.zapstore.dev/";
 import { PlatformIcon } from "./zapstore/PlatformIcon";
 
 interface ZapstoreAppSetDetailRendererProps {
@@ -23,11 +26,20 @@ interface ZapstoreAppSetDetailRendererProps {
  */
 function AppCard({
   address,
+  relayHint,
 }: {
   address: { kind: number; pubkey: string; identifier: string };
+  relayHint?: string;
 }) {
   const { addWindow } = useGrimoire();
-  const appEvent = useNostrEvent(address);
+  const pointer = useMemo(
+    () => ({
+      ...address,
+      relays: [ZAPSTORE_RELAY, ...(relayHint ? [relayHint] : [])],
+    }),
+    [address, relayHint],
+  );
+  const appEvent = useNostrEvent(pointer);
 
   if (!appEvent) {
     return (
@@ -139,7 +151,11 @@ export function ZapstoreAppSetDetailRenderer({
         ) : (
           <div className="flex flex-col gap-3">
             {apps.map((ref, idx) => (
-              <AppCard key={idx} address={ref.address} />
+              <AppCard
+                key={idx}
+                address={ref.address}
+                relayHint={ref.relayHint}
+              />
             ))}
           </div>
         )}

--- a/src/components/nostr/kinds/ZapstoreAppSetRenderer.tsx
+++ b/src/components/nostr/kinds/ZapstoreAppSetRenderer.tsx
@@ -10,15 +10,27 @@ import {
 } from "@/lib/zapstore-helpers";
 import { useNostrEvent } from "@/hooks/useNostrEvent";
 import { useGrimoire } from "@/core/state";
+import { useMemo } from "react";
 import { Package } from "lucide-react";
+
+const ZAPSTORE_RELAY = "wss://relay.zapstore.dev/";
 
 function AppItem({
   address,
+  relayHint,
 }: {
   address: { kind: number; pubkey: string; identifier: string };
+  relayHint?: string;
 }) {
   const { addWindow } = useGrimoire();
-  const appEvent = useNostrEvent(address);
+  const pointer = useMemo(
+    () => ({
+      ...address,
+      relays: [ZAPSTORE_RELAY, ...(relayHint ? [relayHint] : [])],
+    }),
+    [address, relayHint],
+  );
+  const appEvent = useNostrEvent(pointer);
   const appName = appEvent
     ? getAppName(appEvent)
     : address?.identifier || "Unknown App";
@@ -65,7 +77,11 @@ export function ZapstoreAppSetRenderer({ event }: BaseEventProps) {
         {apps.length > 0 && (
           <div className="flex flex-col gap-0.5">
             {apps.map((ref, idx) => (
-              <AppItem key={idx} address={ref.address} />
+              <AppItem
+                key={idx}
+                address={ref.address}
+                relayHint={ref.relayHint}
+              />
             ))}
           </div>
         )}


### PR DESCRIPTION
Include the Zapstore relay when loading kind 32267 (app metadata)
events, since they're primarily hosted on relay.zapstore.dev for now.

Changes:
- Wrap addressLoader in loaders.ts to inject zapstore relay for
  kind 32267 pointers — covers all code paths (zaps, generic viewers,
  any a-tag referencing an app)
- Add zapstore relay to ZapstoreAppRenderer/DetailRenderer relay lists
  (for fetching releases related to an app)
- Add zapstore relay to ZapstoreAppSetRenderer/DetailRenderer when
  resolving app references from app collections (kind 30267)

https://claude.ai/code/session_016CY1NFzK3AzhvB4e9Vc4Qq