### PR TITLE
feat(kind-11): add dedicated ThreadRenderer with optional title

### DIFF
--- a/src/components/nostr/kinds/ThreadRenderer.tsx
+++ b/src/components/nostr/kinds/ThreadRenderer.tsx
@@ -1,0 +1,32 @@
+import { RichText } from "../RichText";
+import {
+  BaseEventContainer,
+  type BaseEventProps,
+  ClickableEventTitle,
+} from "./BaseEventRenderer";
+import { getTagValue } from "applesauce-core/helpers";
+
+/**
+ * Renderer for Kind 11 - Thread (NIP-7D)
+ * Thread root events with an optional title tag.
+ * Shows the title as a clickable heading when present, followed by the content.
+ */
+export function ThreadRenderer({ event, depth = 0 }: BaseEventProps) {
+  const title = getTagValue(event, "title");
+
+  return (
+    <BaseEventContainer event={event}>
+      <div className="flex flex-col gap-1">
+        {title && (
+          <ClickableEventTitle
+            event={event}
+            className="font-semibold text-foreground"
+          >
+            {title}
+          </ClickableEventTitle>
+        )}
+        <RichText event={event} className="text-sm" depth={depth} />
+      </div>
+    </BaseEventContainer>
+  );
+}

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -160,6 +160,7 @@ import { PollRenderer } from "./PollRenderer";
 import { PollDetailRenderer } from "./PollDetailRenderer";
 import { PollResponseRenderer } from "./PollResponseRenderer";
 import { ReportRenderer, ReportDetailRenderer } from "./ReportRenderer";
+import { ThreadRenderer } from "./ThreadRenderer";
 
 /**
  * Registry of kind-specific renderers
@@ -173,7 +174,7 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
   7: Kind7Renderer, // Reaction
   8: BadgeAwardRenderer, // Badge Award (NIP-58)
   9: Kind9Renderer, // Chat Message (NIP-29)
-  11: Kind1Renderer, // Public Thread Reply (NIP-10)
+  11: ThreadRenderer, // Thread (NIP-7D)
   16: RepostRenderer, // Generic Repost
   17: Kind7Renderer, // Reaction (NIP-25)
   20: Kind20Renderer, // Picture (NIP-68)


### PR DESCRIPTION
Kind 11 events are thread roots (NIP-7D) with an optional title tag.
Previously they reused the Kind1Renderer (short text note). Now they
get a dedicated ThreadRenderer that shows the title as a clickable
heading (via ClickableEventTitle) when present, followed by the
content rendered with RichText.

https://claude.ai/code/session_01SQLhrJfeQHceRAS1MjYHrN