### PR TITLE
feat(nip34): extract useRepositoryRelays hook, add patch series nav and PR Updates renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tiptap/core": "^3.15.3",
+        "@tiptap/extension-link": "^3.19.0",
         "@tiptap/extension-mention": "^3.15.3",
         "@tiptap/extension-placeholder": "^3.15.3",
         "@tiptap/pm": "^3.15.3",
@@ -5283,16 +5284,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.18.0.tgz",
-      "integrity": "sha512-Gczd4GbK1DNgy/QUPElMVozoa0GW9mW8E31VIi7Q4a9PHHz8PcrxPmuWwtJ2q0PF8MWpOSLuBXoQTWaXZRPRnQ==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.19.0.tgz",
+      "integrity": "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.18.0"
+        "@tiptap/pm": "^3.19.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -5488,9 +5489,9 @@
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.18.0.tgz",
-      "integrity": "sha512-1J28C4+fKAMQi7q/UsTjAmgmKTnzjExXY98hEBneiVzFDxqF69n7+Vb7nVTNAIhmmJkZMA0DEcMhSiQC/1/u4A==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.19.0.tgz",
+      "integrity": "sha512-HEGDJnnCPfr7KWu7Dsq+eRRe/mBCsv6DuI+7fhOCLDJjjKzNgrX2abbo/zG3D/4lCVFaVb+qawgJubgqXR/Smw==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.2"
@@ -5500,8 +5501,8 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.18.0",
-        "@tiptap/pm": "^3.18.0"
+        "@tiptap/core": "^3.19.0",
+        "@tiptap/pm": "^3.19.0"
       }
     },
     "node_modules/@tiptap/extension-list": {
@@ -5652,9 +5653,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.18.0.tgz",
-      "integrity": "sha512-8RoI5gW0xBVCsuxahpK8vx7onAw6k2/uR3hbGBBnH+HocDMaAZKot3nTyY546ij8ospIC1mnQ7k4BhVUZesZDQ==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.19.0.tgz",
+      "integrity": "sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tiptap/core": "^3.15.3",
+    "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-mention": "^3.15.3",
     "@tiptap/extension-placeholder": "^3.15.3",
     "@tiptap/pm": "^3.15.3",

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -1,0 +1,528 @@
+import {
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+import { useEditor, EditorContent, ReactRenderer } from "@tiptap/react";
+import { Extension } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Mention from "@tiptap/extension-mention";
+import Placeholder from "@tiptap/extension-placeholder";
+import Link from "@tiptap/extension-link";
+import type { SuggestionOptions } from "@tiptap/suggestion";
+import tippy from "tippy.js";
+import type { Instance as TippyInstance } from "tippy.js";
+import "tippy.js/dist/tippy.css";
+import {
+  ProfileSuggestionList,
+  type ProfileSuggestionListHandle,
+} from "./ProfileSuggestionList";
+import {
+  EmojiSuggestionList,
+  type EmojiSuggestionListHandle,
+} from "./EmojiSuggestionList";
+import type { ProfileSearchResult } from "@/services/profile-search";
+import type { EmojiSearchResult } from "@/services/emoji-search";
+import { nip19 } from "nostr-tools";
+import { NostrPasteHandler } from "./extensions/nostr-paste-handler";
+import { FilePasteHandler } from "./extensions/file-paste-handler";
+import { BlobAttachmentRichNode } from "./extensions/blob-attachment-rich";
+import { NostrEventPreviewRichNode } from "./extensions/nostr-event-preview-rich";
+import type { BlobAttachment, SerializedContent } from "./MentionEditor";
+import { MarkdownToolbar } from "./MarkdownToolbar";
+import { MarkdownContent } from "@/components/nostr/MarkdownContent";
+import { serializeEditorToMarkdown } from "@/lib/markdown-serializer";
+
+export interface MarkdownEditorProps {
+  placeholder?: string;
+  onSubmit?: (markdown: string, serialized: SerializedContent) => void;
+  onChange?: () => void;
+  searchProfiles: (query: string) => Promise<ProfileSearchResult[]>;
+  searchEmojis?: (query: string) => Promise<EmojiSearchResult[]>;
+  onFilePaste?: (files: File[]) => void;
+  autoFocus?: boolean;
+  className?: string;
+  /** Minimum editor height in pixels */
+  minHeight?: number;
+  /** Maximum editor height in pixels */
+  maxHeight?: number;
+}
+
+export interface MarkdownEditorHandle {
+  focus: () => void;
+  clear: () => void;
+  /** Get the content serialized as a markdown string */
+  getMarkdown: () => string;
+  /** Get full serialized content with emoji tags, blob attachments, etc. */
+  getSerializedContent: () => SerializedContent;
+  isEmpty: () => boolean;
+  submit: () => void;
+  /** Insert text at the current cursor position */
+  insertText: (text: string) => void;
+  /** Insert a blob attachment with rich preview */
+  insertBlob: (blob: BlobAttachment) => void;
+  /** Get editor state as JSON (for persistence/drafts) */
+  getJSON: () => any;
+  /** Restore editor content from JSON */
+  setContent: (json: any) => void;
+}
+
+// Create emoji extension by extending Mention with a different name and custom node view
+const EmojiMention = Mention.extend({
+  name: "emoji",
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      url: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-url"),
+        renderHTML: (attributes) => {
+          if (!attributes.url) return {};
+          return { "data-url": attributes.url };
+        },
+      },
+      source: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-source"),
+        renderHTML: (attributes) => {
+          if (!attributes.source) return {};
+          return { "data-source": attributes.source };
+        },
+      },
+    };
+  },
+
+  renderText({ node }) {
+    if (node.attrs.source === "unicode") {
+      return node.attrs.url || "";
+    }
+    return `:${node.attrs.id}:`;
+  },
+
+  addNodeView() {
+    return ({ node }) => {
+      const { url, source, id } = node.attrs;
+      const isUnicode = source === "unicode";
+
+      const dom = document.createElement("span");
+      dom.className = "emoji-node";
+      dom.setAttribute("data-emoji", id || "");
+
+      if (isUnicode && url) {
+        const span = document.createElement("span");
+        span.className = "emoji-unicode";
+        span.textContent = url;
+        span.title = `:${id}:`;
+        dom.appendChild(span);
+      } else if (url) {
+        const img = document.createElement("img");
+        img.src = url;
+        img.alt = `:${id}:`;
+        img.title = `:${id}:`;
+        img.className = "emoji-image";
+        img.draggable = false;
+        img.onerror = () => {
+          dom.textContent = `:${id}:`;
+        };
+        dom.appendChild(img);
+      } else {
+        dom.textContent = `:${id}:`;
+      }
+
+      return { dom };
+    };
+  },
+});
+
+export const MarkdownEditor = forwardRef<
+  MarkdownEditorHandle,
+  MarkdownEditorProps
+>(
+  (
+    {
+      placeholder = "Write markdown...",
+      onSubmit,
+      onChange,
+      searchProfiles,
+      searchEmojis,
+      onFilePaste,
+      autoFocus = false,
+      className = "",
+      minHeight = 200,
+      maxHeight = 600,
+    },
+    ref,
+  ) => {
+    const [preview, setPreview] = useState(false);
+    const [previewContent, setPreviewContent] = useState("");
+    const handleSubmitRef = useRef<(editor: any) => void>(() => {});
+
+    // Create mention suggestion configuration
+    const mentionSuggestion: Omit<SuggestionOptions, "editor"> = useMemo(
+      () => ({
+        char: "@",
+        allowSpaces: false,
+        items: async ({ query }) => {
+          return await searchProfiles(query);
+        },
+        render: () => {
+          let component: ReactRenderer<ProfileSuggestionListHandle>;
+          let popup: TippyInstance[];
+
+          return {
+            onStart: (props) => {
+              component = new ReactRenderer(ProfileSuggestionList, {
+                props: { items: [], command: props.command },
+                editor: props.editor,
+              });
+
+              if (!props.clientRect) return;
+
+              popup = tippy("body", {
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+                appendTo: () => document.body,
+                content: component.element,
+                showOnCreate: true,
+                interactive: true,
+                trigger: "manual",
+                placement: "bottom-start",
+                theme: "mention",
+              });
+            },
+
+            onUpdate(props) {
+              component.updateProps({
+                items: props.items,
+                command: props.command,
+              });
+              if (!props.clientRect) return;
+              popup[0].setProps({
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+              });
+            },
+
+            onKeyDown(props) {
+              if (props.event.key === "Escape") {
+                popup[0].hide();
+                return true;
+              }
+              return component.ref?.onKeyDown(props.event) || false;
+            },
+
+            onExit() {
+              popup[0].destroy();
+              component.destroy();
+            },
+          };
+        },
+      }),
+      [searchProfiles],
+    );
+
+    // Create emoji suggestion configuration
+    const emojiSuggestion: Omit<SuggestionOptions, "editor"> | undefined =
+      useMemo(() => {
+        if (!searchEmojis) return undefined;
+
+        return {
+          char: ":",
+          allowSpaces: false,
+          items: async ({ query }) => {
+            return await searchEmojis(query);
+          },
+          render: () => {
+            let component: ReactRenderer<EmojiSuggestionListHandle>;
+            let popup: TippyInstance[];
+
+            return {
+              onStart: (props) => {
+                component = new ReactRenderer(EmojiSuggestionList, {
+                  props: { items: [], command: props.command },
+                  editor: props.editor,
+                });
+
+                if (!props.clientRect) return;
+
+                popup = tippy("body", {
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                  appendTo: () => document.body,
+                  content: component.element,
+                  showOnCreate: true,
+                  interactive: true,
+                  trigger: "manual",
+                  placement: "bottom-start",
+                  theme: "mention",
+                });
+              },
+
+              onUpdate(props) {
+                component.updateProps({
+                  items: props.items,
+                  command: props.command,
+                });
+                if (!props.clientRect) return;
+                popup[0].setProps({
+                  getReferenceClientRect: props.clientRect as () => DOMRect,
+                });
+              },
+
+              onKeyDown(props) {
+                if (props.event.key === "Escape") {
+                  popup[0].hide();
+                  return true;
+                }
+                return component.ref?.onKeyDown(props.event) || false;
+              },
+
+              onExit() {
+                popup[0].destroy();
+                component.destroy();
+              },
+            };
+          },
+        };
+      }, [searchEmojis]);
+
+    // Handle submit
+    const handleSubmit = useCallback(
+      (editorInstance: any) => {
+        if (editorInstance.isEmpty) return;
+
+        const serialized = serializeEditorToMarkdown(editorInstance);
+
+        if (onSubmit) {
+          onSubmit(serialized.text, serialized);
+        }
+      },
+      [onSubmit],
+    );
+
+    handleSubmitRef.current = handleSubmit;
+
+    // Build extensions
+    const extensions = useMemo(() => {
+      const SubmitShortcut = Extension.create({
+        name: "submitShortcut",
+        addKeyboardShortcuts() {
+          return {
+            "Mod-Enter": ({ editor }) => {
+              handleSubmitRef.current(editor);
+              return true;
+            },
+          };
+        },
+      });
+
+      const exts = [
+        SubmitShortcut,
+        StarterKit.configure({
+          hardBreak: { keepMarks: false },
+        }),
+        Link.configure({
+          openOnClick: false,
+          HTMLAttributes: {
+            class: "text-accent underline decoration-dotted cursor-pointer",
+          },
+        }),
+        Mention.extend({
+          renderText({ node }) {
+            try {
+              return `nostr:${nip19.npubEncode(node.attrs.id)}`;
+            } catch {
+              return `@${node.attrs.label}`;
+            }
+          },
+        }).configure({
+          HTMLAttributes: { class: "mention" },
+          suggestion: {
+            ...mentionSuggestion,
+            command: ({ editor, range, props }: any) => {
+              editor
+                .chain()
+                .focus()
+                .insertContentAt(range, [
+                  {
+                    type: "mention",
+                    attrs: {
+                      id: props.pubkey,
+                      label: props.displayName,
+                    },
+                  },
+                  { type: "text", text: " " },
+                ])
+                .run();
+            },
+          },
+          renderLabel({ node }) {
+            return `@${node.attrs.label}`;
+          },
+        }),
+        Placeholder.configure({ placeholder }),
+        BlobAttachmentRichNode,
+        NostrEventPreviewRichNode,
+        NostrPasteHandler,
+        FilePasteHandler.configure({ onFilePaste }),
+      ];
+
+      if (emojiSuggestion) {
+        exts.push(
+          EmojiMention.configure({
+            HTMLAttributes: { class: "emoji" },
+            suggestion: {
+              ...emojiSuggestion,
+              command: ({ editor, range, props }: any) => {
+                editor
+                  .chain()
+                  .focus()
+                  .insertContentAt(range, [
+                    {
+                      type: "emoji",
+                      attrs: {
+                        id: props.shortcode,
+                        label: props.shortcode,
+                        url: props.url,
+                        source: props.source,
+                      },
+                    },
+                    { type: "text", text: " " },
+                  ])
+                  .run();
+              },
+            },
+          }),
+        );
+      }
+
+      return exts;
+    }, [mentionSuggestion, emojiSuggestion, onFilePaste, placeholder]);
+
+    const editor = useEditor({
+      extensions,
+      editorProps: {
+        attributes: {
+          class: "prose prose-sm max-w-none focus:outline-none",
+          style: `min-height: ${minHeight}px; max-height: ${maxHeight}px; overflow-y: auto; padding: 1rem;`,
+        },
+      },
+      autofocus: autoFocus,
+      onUpdate: () => {
+        onChange?.();
+      },
+    });
+
+    const isEditorReady = useCallback(() => {
+      return editor && editor.view && editor.view.dom;
+    }, [editor]);
+
+    // Toggle preview mode
+    const togglePreview = useCallback(() => {
+      setPreview((prev) => {
+        if (!prev && isEditorReady() && editor) {
+          // Entering preview: capture current markdown
+          const serialized = serializeEditorToMarkdown(editor);
+          setPreviewContent(serialized.text);
+        }
+        return !prev;
+      });
+    }, [editor, isEditorReady]);
+
+    // Expose editor methods
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => {
+          if (isEditorReady()) {
+            editor?.commands.focus();
+          }
+        },
+        clear: () => {
+          if (isEditorReady()) {
+            editor?.commands.clearContent();
+          }
+        },
+        getMarkdown: () => {
+          if (!isEditorReady() || !editor) return "";
+          return serializeEditorToMarkdown(editor).text;
+        },
+        getSerializedContent: () => {
+          if (!isEditorReady() || !editor)
+            return {
+              text: "",
+              emojiTags: [],
+              blobAttachments: [],
+              addressRefs: [],
+            };
+          return serializeEditorToMarkdown(editor);
+        },
+        isEmpty: () => {
+          if (!isEditorReady()) return true;
+          return editor?.isEmpty ?? true;
+        },
+        submit: () => {
+          if (isEditorReady() && editor) {
+            handleSubmit(editor);
+          }
+        },
+        insertText: (text: string) => {
+          if (isEditorReady()) {
+            editor?.commands.insertContent(text);
+          }
+        },
+        insertBlob: (blob: BlobAttachment) => {
+          if (isEditorReady()) {
+            editor?.commands.insertContent({
+              type: "blobAttachment",
+              attrs: blob,
+            });
+          }
+        },
+        getJSON: () => {
+          if (!isEditorReady()) return null;
+          return editor?.getJSON() || null;
+        },
+        setContent: (json: any) => {
+          if (isEditorReady() && json) {
+            editor?.commands.setContent(json);
+          }
+        },
+      }),
+      [editor, handleSubmit, isEditorReady],
+    );
+
+    if (!editor) {
+      return null;
+    }
+
+    return (
+      <div
+        className={`markdown-editor flex flex-col border border-border rounded overflow-hidden ${className}`}
+      >
+        <MarkdownToolbar
+          editor={editor}
+          preview={preview}
+          onTogglePreview={togglePreview}
+        />
+
+        {preview ? (
+          <div className="p-4 overflow-y-auto" style={{ minHeight, maxHeight }}>
+            {previewContent ? (
+              <MarkdownContent content={previewContent} />
+            ) : (
+              <p className="text-sm text-muted-foreground italic">
+                Nothing to preview
+              </p>
+            )}
+          </div>
+        ) : (
+          <EditorContent editor={editor} />
+        )}
+      </div>
+    );
+  },
+);
+
+MarkdownEditor.displayName = "MarkdownEditor";

--- a/src/components/editor/MarkdownEditor.tsx
+++ b/src/components/editor/MarkdownEditor.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import { useEditor, EditorContent, ReactRenderer } from "@tiptap/react";
-import { Extension } from "@tiptap/core";
+import { Extension, type Editor, type JSONContent } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Mention from "@tiptap/extension-mention";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -65,9 +65,9 @@ export interface MarkdownEditorHandle {
   /** Insert a blob attachment with rich preview */
   insertBlob: (blob: BlobAttachment) => void;
   /** Get editor state as JSON (for persistence/drafts) */
-  getJSON: () => any;
+  getJSON: () => JSONContent | null;
   /** Restore editor content from JSON */
-  setContent: (json: any) => void;
+  setContent: (json: JSONContent) => void;
 }
 
 // Create emoji extension by extending Mention with a different name and custom node view
@@ -159,7 +159,7 @@ export const MarkdownEditor = forwardRef<
   ) => {
     const [preview, setPreview] = useState(false);
     const [previewContent, setPreviewContent] = useState("");
-    const handleSubmitRef = useRef<(editor: any) => void>(() => {});
+    const handleSubmitRef = useRef<(editor: Editor) => void>(() => {});
 
     // Create mention suggestion configuration
     const mentionSuggestion: Omit<SuggestionOptions, "editor"> = useMemo(
@@ -289,7 +289,7 @@ export const MarkdownEditor = forwardRef<
 
     // Handle submit
     const handleSubmit = useCallback(
-      (editorInstance: any) => {
+      (editorInstance: Editor) => {
         if (editorInstance.isEmpty) return;
 
         const serialized = serializeEditorToMarkdown(editorInstance);
@@ -340,17 +340,16 @@ export const MarkdownEditor = forwardRef<
           HTMLAttributes: { class: "mention" },
           suggestion: {
             ...mentionSuggestion,
-            command: ({ editor, range, props }: any) => {
-              editor
-                .chain()
+            command: ({ editor: ed, range: r, props: mentionAttrs }) => {
+              // items() returns ProfileSearchResult[]; the selected item is
+              // passed as props at runtime despite being typed as MentionNodeAttrs
+              const p = mentionAttrs as unknown as ProfileSearchResult;
+              ed.chain()
                 .focus()
-                .insertContentAt(range, [
+                .insertContentAt(r, [
                   {
                     type: "mention",
-                    attrs: {
-                      id: props.pubkey,
-                      label: props.displayName,
-                    },
+                    attrs: { id: p.pubkey, label: p.displayName },
                   },
                   { type: "text", text: " " },
                 ])
@@ -374,18 +373,20 @@ export const MarkdownEditor = forwardRef<
             HTMLAttributes: { class: "emoji" },
             suggestion: {
               ...emojiSuggestion,
-              command: ({ editor, range, props }: any) => {
-                editor
-                  .chain()
+              command: ({ editor: ed, range: r, props: mentionAttrs }) => {
+                // items() returns EmojiSearchResult[]; the selected item is
+                // passed as props at runtime despite being typed as MentionNodeAttrs
+                const p = mentionAttrs as unknown as EmojiSearchResult;
+                ed.chain()
                   .focus()
-                  .insertContentAt(range, [
+                  .insertContentAt(r, [
                     {
                       type: "emoji",
                       attrs: {
-                        id: props.shortcode,
-                        label: props.shortcode,
-                        url: props.url,
-                        source: props.source,
+                        id: p.shortcode,
+                        label: p.shortcode,
+                        url: p.url,
+                        source: p.source,
                       },
                     },
                     { type: "text", text: " " },
@@ -484,7 +485,7 @@ export const MarkdownEditor = forwardRef<
           if (!isEditorReady()) return null;
           return editor?.getJSON() || null;
         },
-        setContent: (json: any) => {
+        setContent: (json: JSONContent) => {
           if (isEditorReady() && json) {
             editor?.commands.setContent(json);
           }

--- a/src/components/editor/MarkdownToolbar.tsx
+++ b/src/components/editor/MarkdownToolbar.tsx
@@ -1,0 +1,323 @@
+import { useCallback, useState } from "react";
+import type { Editor } from "@tiptap/core";
+import {
+  Bold,
+  Italic,
+  Strikethrough,
+  Code,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Quote,
+  CodeSquare,
+  Link,
+  Unlink,
+  Minus,
+  Eye,
+  Pencil,
+} from "lucide-react";
+
+interface MarkdownToolbarProps {
+  editor: Editor | null;
+  preview: boolean;
+  onTogglePreview: () => void;
+}
+
+interface ToolbarButtonProps {
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+  title: string;
+  children: React.ReactNode;
+}
+
+function ToolbarButton({
+  onClick,
+  active = false,
+  disabled = false,
+  title,
+  children,
+}: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => {
+        // Prevent stealing focus from editor
+        e.preventDefault();
+        onClick();
+      }}
+      disabled={disabled}
+      title={title}
+      className={`p-1.5 rounded transition-colors ${
+        active
+          ? "bg-primary/20 text-primary"
+          : disabled
+            ? "text-muted-foreground/40 cursor-not-allowed"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ToolbarSeparator() {
+  return <div className="w-px h-5 bg-border mx-0.5" />;
+}
+
+/**
+ * Formatting toolbar for the MarkdownEditor.
+ * Provides buttons for common markdown formatting, link insertion,
+ * and a preview toggle.
+ */
+export function MarkdownToolbar({
+  editor,
+  preview,
+  onTogglePreview,
+}: MarkdownToolbarProps) {
+  const [linkInput, setLinkInput] = useState<{
+    open: boolean;
+    url: string;
+  }>({ open: false, url: "" });
+
+  const isActive = useCallback(
+    (name: string, attrs?: Record<string, any>) => {
+      if (!editor) return false;
+      return editor.isActive(name, attrs);
+    },
+    [editor],
+  );
+
+  const run = useCallback(
+    (command: (chain: any) => any) => {
+      if (!editor) return;
+      command(editor.chain().focus());
+    },
+    [editor],
+  );
+
+  const handleLinkSubmit = useCallback(() => {
+    if (!editor || !linkInput.url) {
+      setLinkInput({ open: false, url: "" });
+      return;
+    }
+
+    // Ensure URL has a protocol
+    let url = linkInput.url.trim();
+    if (url && !/^https?:\/\//.test(url)) {
+      url = `https://${url}`;
+    }
+
+    editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
+    setLinkInput({ open: false, url: "" });
+  }, [editor, linkInput.url]);
+
+  const handleUnlink = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().unsetLink().run();
+    setLinkInput({ open: false, url: "" });
+  }, [editor]);
+
+  const disabled = !editor || preview;
+  const iconSize = "size-4";
+
+  return (
+    <div className="flex flex-col border-b border-border">
+      <div className="flex items-center gap-0.5 px-2 py-1 flex-wrap">
+        {/* Inline marks */}
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleBold().run())}
+          active={isActive("bold")}
+          disabled={disabled}
+          title="Bold (Ctrl+B)"
+        >
+          <Bold className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleItalic().run())}
+          active={isActive("italic")}
+          disabled={disabled}
+          title="Italic (Ctrl+I)"
+        >
+          <Italic className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleStrike().run())}
+          active={isActive("strike")}
+          disabled={disabled}
+          title="Strikethrough"
+        >
+          <Strikethrough className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleCode().run())}
+          active={isActive("code")}
+          disabled={disabled}
+          title="Inline code"
+        >
+          <Code className={iconSize} />
+        </ToolbarButton>
+
+        <ToolbarSeparator />
+
+        {/* Headings */}
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleHeading({ level: 1 }).run())}
+          active={isActive("heading", { level: 1 })}
+          disabled={disabled}
+          title="Heading 1"
+        >
+          <Heading1 className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleHeading({ level: 2 }).run())}
+          active={isActive("heading", { level: 2 })}
+          disabled={disabled}
+          title="Heading 2"
+        >
+          <Heading2 className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleHeading({ level: 3 }).run())}
+          active={isActive("heading", { level: 3 })}
+          disabled={disabled}
+          title="Heading 3"
+        >
+          <Heading3 className={iconSize} />
+        </ToolbarButton>
+
+        <ToolbarSeparator />
+
+        {/* Block elements */}
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleBulletList().run())}
+          active={isActive("bulletList")}
+          disabled={disabled}
+          title="Bullet list"
+        >
+          <List className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleOrderedList().run())}
+          active={isActive("orderedList")}
+          disabled={disabled}
+          title="Ordered list"
+        >
+          <ListOrdered className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleBlockquote().run())}
+          active={isActive("blockquote")}
+          disabled={disabled}
+          title="Blockquote"
+        >
+          <Quote className={iconSize} />
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => run((c) => c.toggleCodeBlock().run())}
+          active={isActive("codeBlock")}
+          disabled={disabled}
+          title="Code block"
+        >
+          <CodeSquare className={iconSize} />
+        </ToolbarButton>
+
+        <ToolbarSeparator />
+
+        {/* Link */}
+        {isActive("link") ? (
+          <ToolbarButton
+            onClick={handleUnlink}
+            active
+            disabled={disabled}
+            title="Remove link"
+          >
+            <Unlink className={iconSize} />
+          </ToolbarButton>
+        ) : (
+          <ToolbarButton
+            onClick={() => {
+              if (disabled) return;
+              // Get existing link href if cursor is on a link
+              const attrs = editor?.getAttributes("link");
+              setLinkInput({
+                open: true,
+                url: attrs?.href || "",
+              });
+            }}
+            disabled={disabled}
+            title="Insert link"
+          >
+            <Link className={iconSize} />
+          </ToolbarButton>
+        )}
+
+        {/* Horizontal rule */}
+        <ToolbarButton
+          onClick={() => run((c) => c.setHorizontalRule().run())}
+          disabled={disabled}
+          title="Horizontal rule"
+        >
+          <Minus className={iconSize} />
+        </ToolbarButton>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Preview toggle */}
+        <ToolbarButton
+          onClick={onTogglePreview}
+          active={preview}
+          title={preview ? "Edit" : "Preview"}
+        >
+          {preview ? (
+            <Pencil className={iconSize} />
+          ) : (
+            <Eye className={iconSize} />
+          )}
+        </ToolbarButton>
+      </div>
+
+      {/* Link input row */}
+      {linkInput.open && (
+        <div className="flex items-center gap-2 px-2 py-1.5 border-t border-border bg-muted/30">
+          <Link className="size-3.5 text-muted-foreground flex-shrink-0" />
+          <input
+            type="url"
+            value={linkInput.url}
+            onChange={(e) =>
+              setLinkInput((s) => ({ ...s, url: e.target.value }))
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleLinkSubmit();
+              } else if (e.key === "Escape") {
+                setLinkInput({ open: false, url: "" });
+              }
+            }}
+            placeholder="https://example.com"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/50"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={handleLinkSubmit}
+            className="text-xs px-2 py-0.5 bg-primary/20 text-primary rounded hover:bg-primary/30"
+          >
+            Apply
+          </button>
+          <button
+            type="button"
+            onClick={() => setLinkInput({ open: false, url: "" })}
+            className="text-xs px-2 py-0.5 text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/MarkdownToolbar.tsx
+++ b/src/components/editor/MarkdownToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { Editor } from "@tiptap/core";
+import type { Editor, ChainedCommands } from "@tiptap/core";
 import {
   Bold,
   Italic,
@@ -83,7 +83,7 @@ export function MarkdownToolbar({
   }>({ open: false, url: "" });
 
   const isActive = useCallback(
-    (name: string, attrs?: Record<string, any>) => {
+    (name: string, attrs?: Record<string, number | string | boolean>) => {
       if (!editor) return false;
       return editor.isActive(name, attrs);
     },
@@ -91,7 +91,7 @@ export function MarkdownToolbar({
   );
 
   const run = useCallback(
-    (command: (chain: any) => any) => {
+    (command: (chain: ChainedCommands) => void) => {
       if (!editor) return;
       command(editor.chain().focus());
     },

--- a/src/components/nostr/kinds/IssueDetailRenderer.tsx
+++ b/src/components/nostr/kinds/IssueDetailRenderer.tsx
@@ -7,20 +7,16 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
-  getRepositoryRelays,
   getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
-import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
-import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
 import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
-import { useNostrEvent } from "@/hooks/useNostrEvent";
+import { useRepositoryRelays } from "@/hooks/useRepositoryRelays";
 import { formatTimestamp } from "@/hooks/useLocale";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
 
 /**
  * Detail renderer for Kind 1621 - Issue (NIP-34)
@@ -31,55 +27,10 @@ export function IssueDetailRenderer({ event }: { event: NostrEvent }) {
   const labels = getIssueLabels(event);
   const repoAddress = getIssueRepositoryAddress(event);
 
-  // Parse repository address for fetching repo event
-  const parsedRepo = useMemo(
-    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
-    [repoAddress],
-  );
-
-  // Fetch repository event to get maintainers list
-  const repoPointer = useMemo(() => {
-    if (!parsedRepo) return undefined;
-    return {
-      kind: parsedRepo.kind,
-      pubkey: parsedRepo.pubkey,
-      identifier: parsedRepo.identifier,
-    };
-  }, [parsedRepo]);
-
-  const repositoryEvent = useNostrEvent(repoPointer);
-
-  // Fetch repo author's relay list for fallback
-  const repoAuthorRelayListPointer = useMemo(() => {
-    if (!parsedRepo?.pubkey) return undefined;
-    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
-  }, [parsedRepo?.pubkey]);
-
-  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
-
-  // Build relay list with fallbacks:
-  // 1. Repository configured relays
-  // 2. Repo author's outbox (write) relays
-  // 3. AGGREGATOR_RELAYS as final fallback
-  const statusRelays = useMemo(() => {
-    // Try repository relays first
-    if (repositoryEvent) {
-      const repoRelays = getRepositoryRelays(repositoryEvent);
-      if (repoRelays.length > 0) return repoRelays;
-    }
-
-    // Try repo author's outbox relays
-    if (repoAuthorRelayList) {
-      const authorOutbox = getOutboxes(repoAuthorRelayList);
-      if (authorOutbox.length > 0) return authorOutbox;
-    }
-
-    // Fallback to aggregator relays
-    return AGGREGATOR_RELAYS;
-  }, [repositoryEvent, repoAuthorRelayList]);
+  const { relays: statusRelays, repositoryEvent } =
+    useRepositoryRelays(repoAddress);
 
   // Fetch status events that reference this issue
-  // Status events use e tag with root marker to reference the issue
   const statusFilter = useMemo(
     () => ({
       kinds: [1630, 1631, 1632, 1633],

--- a/src/components/nostr/kinds/IssueRenderer.tsx
+++ b/src/components/nostr/kinds/IssueRenderer.tsx
@@ -8,18 +8,14 @@ import {
   getIssueTitle,
   getIssueLabels,
   getIssueRepositoryAddress,
-  getRepositoryRelays,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
-import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
-import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
 import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
-import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
+import { useRepositoryRelays } from "@/hooks/useRepositoryRelays";
 
 /**
  * Renderer for Kind 1621 - Issue
@@ -30,52 +26,8 @@ export function IssueRenderer({ event }: BaseEventProps) {
   const labels = getIssueLabels(event);
   const repoAddress = getIssueRepositoryAddress(event);
 
-  // Parse repository address for fetching repo event
-  const parsedRepo = useMemo(
-    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
-    [repoAddress],
-  );
-
-  // Fetch repository event to get maintainers list
-  const repoPointer = useMemo(() => {
-    if (!parsedRepo) return undefined;
-    return {
-      kind: parsedRepo.kind,
-      pubkey: parsedRepo.pubkey,
-      identifier: parsedRepo.identifier,
-    };
-  }, [parsedRepo]);
-
-  const repositoryEvent = useNostrEvent(repoPointer);
-
-  // Fetch repo author's relay list for fallback
-  const repoAuthorRelayListPointer = useMemo(() => {
-    if (!parsedRepo?.pubkey) return undefined;
-    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
-  }, [parsedRepo?.pubkey]);
-
-  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
-
-  // Build relay list with fallbacks:
-  // 1. Repository configured relays
-  // 2. Repo author's outbox (write) relays
-  // 3. AGGREGATOR_RELAYS as final fallback
-  const statusRelays = useMemo(() => {
-    // Try repository relays first
-    if (repositoryEvent) {
-      const repoRelays = getRepositoryRelays(repositoryEvent);
-      if (repoRelays.length > 0) return repoRelays;
-    }
-
-    // Try repo author's outbox relays
-    if (repoAuthorRelayList) {
-      const authorOutbox = getOutboxes(repoAuthorRelayList);
-      if (authorOutbox.length > 0) return authorOutbox;
-    }
-
-    // Fallback to aggregator relays
-    return AGGREGATOR_RELAYS;
-  }, [repositoryEvent, repoAuthorRelayList]);
+  const { relays: statusRelays, repositoryEvent } =
+    useRepositoryRelays(repoAddress);
 
   // Fetch status events that reference this issue
   const statusFilter = useMemo(

--- a/src/components/nostr/kinds/PRUpdateDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PRUpdateDetailRenderer.tsx
@@ -1,0 +1,153 @@
+import { GitPullRequestArrow, GitBranch, Copy, CopyCheck } from "lucide-react";
+import { UserName } from "../UserName";
+import { MarkdownContent } from "../MarkdownContent";
+import { EmbeddedEvent } from "../EmbeddedEvent";
+import { RepositoryLink } from "../RepositoryLink";
+import { useCopy } from "@/hooks/useCopy";
+import { formatTimestamp } from "@/hooks/useLocale";
+import { useGrimoire } from "@/core/state";
+import type { NostrEvent } from "@/types/nostr";
+import type { EventPointer } from "nostr-tools/nip19";
+import {
+  getPRUpdatePREventId,
+  getPRUpdatePRRelayHint,
+  getPRUpdateCommits,
+  getPRUpdateBranchName,
+  getPRUpdateRepositoryAddress,
+} from "@/lib/nip34-helpers";
+
+/**
+ * Detail renderer for Kind 1619 - Pull Request Updates (NIP-34)
+ * Full view showing the update details and referenced PR
+ */
+export function PRUpdateDetailRenderer({ event }: { event: NostrEvent }) {
+  const { copy, copied } = useCopy();
+  const { addWindow } = useGrimoire();
+
+  const prEventId = getPRUpdatePREventId(event);
+  const relayHint = getPRUpdatePRRelayHint(event);
+  const commits = getPRUpdateCommits(event);
+  const branchName = getPRUpdateBranchName(event);
+  const repoAddress = getPRUpdateRepositoryAddress(event);
+
+  // Build event pointer for the referenced PR
+  const prPointer: EventPointer | undefined = prEventId
+    ? { id: prEventId, relays: relayHint ? [relayHint] : undefined }
+    : undefined;
+
+  const createdDate = formatTimestamp(event.created_at, "long");
+
+  return (
+    <div className="flex flex-col gap-4 p-4 max-w-3xl mx-auto">
+      {/* Header */}
+      <header className="flex flex-col gap-3 pb-4 border-b border-border">
+        <h1 className="text-2xl font-bold flex items-center gap-2">
+          <GitPullRequestArrow className="size-6" />
+          Pull Request Update
+        </h1>
+
+        {/* Repository Link */}
+        {repoAddress && (
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Repository:</span>
+            <RepositoryLink
+              repoAddress={repoAddress}
+              iconSize="size-4"
+              className="font-mono"
+            />
+          </div>
+        )}
+
+        {/* Metadata */}
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <span>By</span>
+            <UserName pubkey={event.pubkey} className="font-semibold" />
+          </div>
+          <span>•</span>
+          <time>{createdDate}</time>
+        </div>
+      </header>
+
+      {/* Branch and Commits */}
+      {(branchName || commits.length > 0) && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xl font-semibold flex items-center gap-2">
+            <GitBranch className="size-5" />
+            Update Details
+          </h2>
+
+          {branchName && (
+            <div className="flex items-center gap-2 p-2 bg-muted/30">
+              <span className="text-sm text-muted-foreground">Branch:</span>
+              <code className="flex-1 text-sm font-mono truncate">
+                {branchName}
+              </code>
+            </div>
+          )}
+
+          {commits.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <h3 className="text-sm font-semibold text-muted-foreground">
+                Commits ({commits.length})
+              </h3>
+              <ul className="flex flex-col gap-1">
+                {commits.map((hash, idx) => (
+                  <li
+                    key={idx}
+                    className="flex items-center gap-2 p-2 bg-muted/30"
+                  >
+                    <code className="flex-1 text-sm font-mono truncate">
+                      {hash}
+                    </code>
+                    <button
+                      onClick={() => copy(hash)}
+                      className="flex-shrink-0 p-1 hover:bg-muted"
+                      aria-label="Copy commit hash"
+                    >
+                      {copied ? (
+                        <CopyCheck className="size-3 text-muted-foreground" />
+                      ) : (
+                        <Copy className="size-3 text-muted-foreground" />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Description */}
+      {event.content ? (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold">Description</h2>
+          <MarkdownContent content={event.content} />
+        </section>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">
+          (No description provided)
+        </p>
+      )}
+
+      {/* Referenced PR */}
+      {prPointer && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-lg font-semibold">Pull Request</h2>
+          <EmbeddedEvent
+            eventPointer={prPointer}
+            onOpen={(id) => {
+              addWindow(
+                "open",
+                { id: id as string },
+                `PR ${(id as string).slice(0, 8)}...`,
+              );
+            }}
+            className="border border-muted rounded overflow-hidden"
+          />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/nostr/kinds/PRUpdateRenderer.tsx
+++ b/src/components/nostr/kinds/PRUpdateRenderer.tsx
@@ -1,0 +1,101 @@
+import { GitPullRequestArrow } from "lucide-react";
+import {
+  BaseEventContainer,
+  type BaseEventProps,
+  ClickableEventTitle,
+} from "./BaseEventRenderer";
+import {
+  getPRUpdatePREventId,
+  getPRUpdatePRRelayHint,
+  getPRUpdateCommitTip,
+  getPRUpdateBranchName,
+  getPRUpdateRepositoryAddress,
+} from "@/lib/nip34-helpers";
+import { RepositoryLink } from "../RepositoryLink";
+import { EmbeddedEvent } from "../EmbeddedEvent";
+import { useGrimoire } from "@/core/state";
+import type { EventPointer } from "nostr-tools/nip19";
+
+/**
+ * Renderer for Kind 1619 - Pull Request Updates (NIP-34)
+ * Displays a compact card showing the PR update with a reference
+ * to the original PR event
+ */
+export function PRUpdateRenderer({ event }: BaseEventProps) {
+  const { addWindow } = useGrimoire();
+
+  const prEventId = getPRUpdatePREventId(event);
+  const relayHint = getPRUpdatePRRelayHint(event);
+  const commitTip = getPRUpdateCommitTip(event);
+  const branchName = getPRUpdateBranchName(event);
+  const repoAddress = getPRUpdateRepositoryAddress(event);
+
+  const shortCommit = commitTip ? commitTip.slice(0, 7) : undefined;
+
+  // Build event pointer for the referenced PR
+  const prPointer: EventPointer | undefined = prEventId
+    ? { id: prEventId, relays: relayHint ? [relayHint] : undefined }
+    : undefined;
+
+  return (
+    <BaseEventContainer event={event}>
+      <div className="flex flex-col gap-2">
+        {/* Title */}
+        <ClickableEventTitle
+          event={event}
+          className="font-semibold text-foreground"
+        >
+          <span className="flex items-center gap-1.5">
+            <GitPullRequestArrow className="size-3.5 flex-shrink-0" />
+            PR Update
+            {branchName && (
+              <code className="text-xs font-mono text-muted-foreground">
+                {branchName}
+              </code>
+            )}
+          </span>
+        </ClickableEventTitle>
+
+        {/* Metadata line */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          {repoAddress && (
+            <>
+              <span className="text-muted-foreground">in</span>
+              <RepositoryLink repoAddress={repoAddress} />
+            </>
+          )}
+          {shortCommit && (
+            <>
+              <span className="text-muted-foreground">•</span>
+              <code className="text-muted-foreground font-mono text-xs">
+                {shortCommit}
+              </code>
+            </>
+          )}
+        </div>
+
+        {/* Description preview */}
+        {event.content && (
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {event.content}
+          </p>
+        )}
+
+        {/* Embedded PR reference */}
+        {prPointer && (
+          <EmbeddedEvent
+            eventPointer={prPointer}
+            onOpen={(id) => {
+              addWindow(
+                "open",
+                { id: id as string },
+                `PR ${(id as string).slice(0, 8)}...`,
+              );
+            }}
+            className="border border-muted rounded overflow-hidden"
+          />
+        )}
+      </div>
+    </BaseEventContainer>
+  );
+}

--- a/src/components/nostr/kinds/PatchRenderer.tsx
+++ b/src/components/nostr/kinds/PatchRenderer.tsx
@@ -8,17 +8,13 @@ import {
   getPatchSubject,
   getPatchCommitId,
   getPatchRepositoryAddress,
-  getRepositoryRelays,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
-import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
-import { getOutboxes } from "applesauce-core/helpers";
 import { RepositoryLink } from "../RepositoryLink";
 import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
-import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
+import { useRepositoryRelays } from "@/hooks/useRepositoryRelays";
 
 /**
  * Renderer for Kind 1617 - Patch
@@ -32,52 +28,8 @@ export function PatchRenderer({ event }: BaseEventProps) {
   // Shorten commit ID for display
   const shortCommitId = commitId ? commitId.slice(0, 7) : undefined;
 
-  // Parse repository address for fetching repo event
-  const parsedRepo = useMemo(
-    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
-    [repoAddress],
-  );
-
-  // Fetch repository event to get maintainers list
-  const repoPointer = useMemo(() => {
-    if (!parsedRepo) return undefined;
-    return {
-      kind: parsedRepo.kind,
-      pubkey: parsedRepo.pubkey,
-      identifier: parsedRepo.identifier,
-    };
-  }, [parsedRepo]);
-
-  const repositoryEvent = useNostrEvent(repoPointer);
-
-  // Fetch repo author's relay list for fallback
-  const repoAuthorRelayListPointer = useMemo(() => {
-    if (!parsedRepo?.pubkey) return undefined;
-    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
-  }, [parsedRepo?.pubkey]);
-
-  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
-
-  // Build relay list with fallbacks:
-  // 1. Repository configured relays
-  // 2. Repo author's outbox (write) relays
-  // 3. AGGREGATOR_RELAYS as final fallback
-  const statusRelays = useMemo(() => {
-    // Try repository relays first
-    if (repositoryEvent) {
-      const repoRelays = getRepositoryRelays(repositoryEvent);
-      if (repoRelays.length > 0) return repoRelays;
-    }
-
-    // Try repo author's outbox relays
-    if (repoAuthorRelayList) {
-      const authorOutbox = getOutboxes(repoAuthorRelayList);
-      if (authorOutbox.length > 0) return authorOutbox;
-    }
-
-    // Fallback to aggregator relays
-    return AGGREGATOR_RELAYS;
-  }, [repositoryEvent, repoAuthorRelayList]);
+  const { relays: statusRelays, repositoryEvent } =
+    useRepositoryRelays(repoAddress);
 
   // Fetch status events that reference this patch
   const statusFilter = useMemo(

--- a/src/components/nostr/kinds/PatchSeriesNav.tsx
+++ b/src/components/nostr/kinds/PatchSeriesNav.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from "react";
+import { Layers, ChevronRight } from "lucide-react";
+import { getNip10References } from "applesauce-common/helpers/threading";
+import { useTimeline } from "@/hooks/useTimeline";
+import { useGrimoire } from "@/core/state";
+import { getPatchSubject, isPatchRoot } from "@/lib/nip34-helpers";
+import { formatTimestamp } from "@/hooks/useLocale";
+import type { NostrEvent } from "@/types/nostr";
+
+interface PatchSeriesNavProps {
+  event: NostrEvent;
+  relays: string[];
+}
+
+/**
+ * Patch series navigation component for the PatchDetailRenderer.
+ *
+ * NIP-34 patches form a series via NIP-10 threading:
+ * - The first patch is tagged ["t", "root"]
+ * - Subsequent patches include ["e", rootPatchId, relay, "root"]
+ *
+ * This component finds the root patch, then queries all patches
+ * that reference the same root to build a navigable series list.
+ */
+export function PatchSeriesNav({ event, relays }: PatchSeriesNavProps) {
+  const { addWindow } = useGrimoire();
+  const isRoot = isPatchRoot(event);
+
+  // Parse NIP-10 references to find the root patch
+  const refs = getNip10References(event);
+  const rootPointer = refs.root?.e;
+  const rootEventId = rootPointer?.id;
+
+  // The effective root ID: if this IS the root patch, use its own ID;
+  // otherwise use the referenced root
+  const seriesRootId = isRoot ? event.id : rootEventId;
+
+  // Query all kind 1617 patches that reference the same root
+  const seriesFilter = useMemo(() => {
+    if (!seriesRootId) return null;
+    return {
+      kinds: [1617],
+      "#e": [seriesRootId],
+    };
+  }, [seriesRootId]);
+
+  const { events: relatedPatches } = useTimeline(
+    seriesRootId ? `patch-series-${seriesRootId}` : "patch-series-noop",
+    seriesFilter ?? { kinds: [1617], "#e": ["noop"] },
+    seriesFilter ? relays : [],
+    { limit: 50 },
+  );
+
+  // Build sorted series: root first, then related patches by created_at
+  const series = useMemo(() => {
+    if (!seriesRootId) return [];
+
+    // Collect all patches in the series
+    const patches: NostrEvent[] = [];
+
+    // If this is the root, include it; relatedPatches are the children
+    if (isRoot) {
+      patches.push(event);
+      patches.push(...relatedPatches.filter((p) => p.id !== event.id));
+    } else {
+      // Include related patches (which reference the root)
+      patches.push(...relatedPatches.filter((p) => p.id !== event.id));
+    }
+
+    // Sort by created_at ascending (oldest first = series order)
+    patches.sort((a, b) => a.created_at - b.created_at);
+
+    return patches;
+  }, [seriesRootId, isRoot, event, relatedPatches]);
+
+  // Don't show if there are no related patches
+  if (series.length === 0) return null;
+
+  const handlePatchClick = (patchEvent: NostrEvent) => {
+    addWindow(
+      "open",
+      { id: patchEvent.id },
+      getPatchSubject(patchEvent) || "Patch",
+    );
+  };
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-sm font-semibold text-muted-foreground flex items-center gap-1.5">
+        <Layers className="size-3.5" />
+        Patch Series ({series.length + (isRoot ? 0 : 1)})
+      </h2>
+
+      <div className="flex flex-col border border-border rounded overflow-hidden">
+        {/* Root patch indicator (if we're not the root and have a rootEventId) */}
+        {!isRoot && rootEventId && (
+          <button
+            onClick={() => addWindow("open", { id: rootEventId }, "Root Patch")}
+            className="flex items-center gap-2 px-3 py-2 text-xs bg-accent/10 text-accent hover:bg-accent/20 transition-colors text-left"
+          >
+            <ChevronRight className="size-3 flex-shrink-0" />
+            <span className="font-semibold">Root Patch</span>
+          </button>
+        )}
+
+        {/* Series patches */}
+        {series.map((patch, idx) => {
+          const isCurrent = patch.id === event.id;
+          const subject = getPatchSubject(patch) || `Patch ${idx + 1}`;
+
+          return (
+            <button
+              key={patch.id}
+              onClick={() => !isCurrent && handlePatchClick(patch)}
+              disabled={isCurrent}
+              className={`flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors border-t border-border first:border-t-0 ${
+                isCurrent
+                  ? "bg-primary/10 text-primary font-semibold cursor-default"
+                  : "hover:bg-muted/50 text-foreground cursor-crosshair"
+              }`}
+            >
+              <span className="text-muted-foreground flex-shrink-0 w-5 text-right">
+                {idx + 1}.
+              </span>
+              <span className="truncate flex-1">{subject}</span>
+              <span className="text-muted-foreground flex-shrink-0">
+                {formatTimestamp(patch.created_at, "relative")}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
+++ b/src/components/nostr/kinds/PullRequestDetailRenderer.tsx
@@ -13,19 +13,15 @@ import {
   getPullRequestCloneUrls,
   getPullRequestMergeBase,
   getPullRequestRepositoryAddress,
-  getRepositoryRelays,
   getStatusType,
   getValidStatusAuthors,
   findCurrentStatus,
 } from "@/lib/nip34-helpers";
-import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
-import { getOutboxes } from "applesauce-core/helpers";
 import { Label } from "@/components/ui/label";
 import { RepositoryLink } from "../RepositoryLink";
 import { StatusIndicator } from "../StatusIndicator";
 import { useTimeline } from "@/hooks/useTimeline";
-import { useNostrEvent } from "@/hooks/useNostrEvent";
-import { AGGREGATOR_RELAYS } from "@/services/loaders";
+import { useRepositoryRelays } from "@/hooks/useRepositoryRelays";
 
 /**
  * Detail renderer for Kind 1618 - Pull Request
@@ -42,44 +38,8 @@ export function PullRequestDetailRenderer({ event }: { event: NostrEvent }) {
   const mergeBase = getPullRequestMergeBase(event);
   const repoAddress = getPullRequestRepositoryAddress(event);
 
-  // Parse repository address for fetching repo event
-  const parsedRepo = useMemo(
-    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
-    [repoAddress],
-  );
-
-  // Fetch repository event to get maintainers list
-  const repoPointer = useMemo(() => {
-    if (!parsedRepo) return undefined;
-    return {
-      kind: parsedRepo.kind,
-      pubkey: parsedRepo.pubkey,
-      identifier: parsedRepo.identifier,
-    };
-  }, [parsedRepo]);
-
-  const repositoryEvent = useNostrEvent(repoPointer);
-
-  // Fetch repo author's relay list for fallback
-  const repoAuthorRelayListPointer = useMemo(() => {
-    if (!parsedRepo?.pubkey) return undefined;
-    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
-  }, [parsedRepo?.pubkey]);
-
-  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
-
-  // Build relay list with fallbacks
-  const statusRelays = useMemo(() => {
-    if (repositoryEvent) {
-      const repoRelays = getRepositoryRelays(repositoryEvent);
-      if (repoRelays.length > 0) return repoRelays;
-    }
-    if (repoAuthorRelayList) {
-      const authorOutbox = getOutboxes(repoAuthorRelayList);
-      if (authorOutbox.length > 0) return authorOutbox;
-    }
-    return AGGREGATOR_RELAYS;
-  }, [repositoryEvent, repoAuthorRelayList]);
+  const { relays: statusRelays, repositoryEvent } =
+    useRepositoryRelays(repoAddress);
 
   // Fetch status events
   const statusFilter = useMemo(

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -23,6 +23,8 @@ import { PatchRenderer } from "./PatchRenderer";
 import { PatchDetailRenderer } from "./PatchDetailRenderer";
 import { PullRequestRenderer } from "./PullRequestRenderer";
 import { PullRequestDetailRenderer } from "./PullRequestDetailRenderer";
+import { PRUpdateRenderer } from "./PRUpdateRenderer";
+import { PRUpdateDetailRenderer } from "./PRUpdateDetailRenderer";
 import { Kind9735Renderer } from "./ZapReceiptRenderer";
 import { Kind9802Renderer } from "./HighlightRenderer";
 import { Kind9802DetailRenderer } from "./HighlightDetailRenderer";
@@ -189,6 +191,7 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
   1337: Kind1337Renderer, // Code Snippet (NIP-C0)
   1617: PatchRenderer, // Patch (NIP-34)
   1618: PullRequestRenderer, // Pull Request (NIP-34)
+  1619: PRUpdateRenderer, // PR Updates (NIP-34)
   1621: IssueRenderer, // Issue (NIP-34)
   1630: IssueStatusRenderer, // Open Status (NIP-34)
   1631: IssueStatusRenderer, // Applied/Merged/Resolved Status (NIP-34)
@@ -303,6 +306,7 @@ const detailRenderers: Record<
   1337: Kind1337DetailRenderer, // Code Snippet Detail (NIP-C0)
   1617: PatchDetailRenderer, // Patch Detail (NIP-34)
   1618: PullRequestDetailRenderer, // Pull Request Detail (NIP-34)
+  1619: PRUpdateDetailRenderer, // PR Updates Detail (NIP-34)
   1621: IssueDetailRenderer, // Issue Detail (NIP-34)
   1630: IssueStatusDetailRenderer, // Open Status Detail (NIP-34)
   1631: IssueStatusDetailRenderer, // Applied/Merged/Resolved Status Detail (NIP-34)

--- a/src/hooks/useRepositoryRelays.ts
+++ b/src/hooks/useRepositoryRelays.ts
@@ -1,0 +1,58 @@
+import { useMemo } from "react";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { getOutboxes } from "applesauce-core/helpers";
+import { useNostrEvent } from "./useNostrEvent";
+import { getRepositoryRelays } from "@/lib/nip34-helpers";
+import { AGGREGATOR_RELAYS } from "@/services/loaders";
+
+/**
+ * Hook to resolve relay URLs for a NIP-34 repository address.
+ *
+ * Implements the standard relay fallback chain:
+ * 1. Repository-configured relays (from the repo event's `relays` tag)
+ * 2. Repository author's outbox (write) relays (from kind 10002)
+ * 3. AGGREGATOR_RELAYS as final fallback
+ *
+ * Also returns the fetched repository event, useful for getting
+ * maintainers list and other repo metadata.
+ *
+ * @param repoAddress - Repository address in "kind:pubkey:identifier" format
+ */
+export function useRepositoryRelays(repoAddress: string | undefined) {
+  const parsedRepo = useMemo(
+    () => (repoAddress ? parseReplaceableAddress(repoAddress) : null),
+    [repoAddress],
+  );
+
+  const repoPointer = useMemo(() => {
+    if (!parsedRepo) return undefined;
+    return {
+      kind: parsedRepo.kind,
+      pubkey: parsedRepo.pubkey,
+      identifier: parsedRepo.identifier,
+    };
+  }, [parsedRepo]);
+
+  const repositoryEvent = useNostrEvent(repoPointer);
+
+  const repoAuthorRelayListPointer = useMemo(() => {
+    if (!parsedRepo?.pubkey) return undefined;
+    return { kind: 10002, pubkey: parsedRepo.pubkey, identifier: "" };
+  }, [parsedRepo?.pubkey]);
+
+  const repoAuthorRelayList = useNostrEvent(repoAuthorRelayListPointer);
+
+  const relays = useMemo(() => {
+    if (repositoryEvent) {
+      const repoRelays = getRepositoryRelays(repositoryEvent);
+      if (repoRelays.length > 0) return repoRelays;
+    }
+    if (repoAuthorRelayList) {
+      const authorOutbox = getOutboxes(repoAuthorRelayList);
+      if (authorOutbox.length > 0) return authorOutbox;
+    }
+    return AGGREGATOR_RELAYS;
+  }, [repositoryEvent, repoAuthorRelayList]);
+
+  return { relays, repositoryEvent };
+}

--- a/src/lib/markdown-serializer.ts
+++ b/src/lib/markdown-serializer.ts
@@ -1,0 +1,304 @@
+import { nip19 } from "nostr-tools";
+import type {
+  EmojiTag,
+  BlobAttachment,
+  SerializedContent,
+} from "@/components/editor/MentionEditor";
+
+/**
+ * Serialize a Tiptap/ProseMirror document to markdown.
+ *
+ * Handles standard markdown formatting (headings, bold, italic, code, lists,
+ * blockquotes, links, horizontal rules) plus Nostr-specific nodes (mentions,
+ * custom emojis, blob attachments, event previews).
+ *
+ * Returns both the markdown string and extracted metadata (emoji tags, blob
+ * attachments, address refs) needed for building Nostr events.
+ */
+export function serializeEditorToMarkdown(editor: any): SerializedContent {
+  const emojiTags: EmojiTag[] = [];
+  const blobAttachments: BlobAttachment[] = [];
+  const addressRefs: Array<{
+    kind: number;
+    pubkey: string;
+    identifier: string;
+  }> = [];
+  const seenEmojis = new Set<string>();
+  const seenBlobs = new Set<string>();
+  const seenAddrs = new Set<string>();
+
+  const ctx = {
+    emojiTags,
+    blobAttachments,
+    addressRefs,
+    seenEmojis,
+    seenBlobs,
+    seenAddrs,
+  };
+
+  const doc = editor.state.doc;
+  const text = serializeBlocks(doc, ctx, "");
+
+  return { text, emojiTags, blobAttachments, addressRefs };
+}
+
+interface SerializerContext {
+  emojiTags: EmojiTag[];
+  blobAttachments: BlobAttachment[];
+  addressRefs: Array<{ kind: number; pubkey: string; identifier: string }>;
+  seenEmojis: Set<string>;
+  seenBlobs: Set<string>;
+  seenAddrs: Set<string>;
+}
+
+/**
+ * Serialize all block-level children of a node, joined by double newlines.
+ */
+function serializeBlocks(
+  node: any,
+  ctx: SerializerContext,
+  indent: string,
+): string {
+  const blocks: string[] = [];
+
+  node.forEach((child: any) => {
+    const result = serializeBlock(child, ctx, indent);
+    if (result !== null) {
+      blocks.push(result);
+    }
+  });
+
+  return blocks.join("\n\n");
+}
+
+/**
+ * Serialize a single block-level node to markdown.
+ */
+function serializeBlock(
+  node: any,
+  ctx: SerializerContext,
+  indent: string,
+): string | null {
+  switch (node.type.name) {
+    case "paragraph":
+      return indent + serializeInline(node, ctx);
+
+    case "heading": {
+      const level = node.attrs.level || 1;
+      const prefix = "#".repeat(Math.min(level, 6));
+      return `${indent}${prefix} ${serializeInline(node, ctx)}`;
+    }
+
+    case "codeBlock": {
+      const lang = node.attrs.language || "";
+      const code = node.textContent;
+      return `${indent}\`\`\`${lang}\n${code}\n${indent}\`\`\``;
+    }
+
+    case "blockquote": {
+      const inner = serializeBlocks(node, ctx, "");
+      return inner
+        .split("\n")
+        .map((line) => `${indent}> ${line}`)
+        .join("\n");
+    }
+
+    case "bulletList": {
+      const items: string[] = [];
+      node.forEach((item: any) => {
+        const content = serializeListItemContent(item, ctx, indent + "  ");
+        items.push(`${indent}- ${content}`);
+      });
+      return items.join("\n");
+    }
+
+    case "orderedList": {
+      const items: string[] = [];
+      const start = node.attrs.start || 1;
+      node.forEach((item: any, _offset: number, idx: number) => {
+        const num = start + idx;
+        const content = serializeListItemContent(item, ctx, indent + "   ");
+        items.push(`${indent}${num}. ${content}`);
+      });
+      return items.join("\n");
+    }
+
+    case "horizontalRule":
+      return `${indent}---`;
+
+    case "blobAttachment": {
+      const { url, sha256, mimeType, size, server } = node.attrs;
+      if (!ctx.seenBlobs.has(sha256)) {
+        ctx.seenBlobs.add(sha256);
+        ctx.blobAttachments.push({ url, sha256, mimeType, size, server });
+      }
+      // Images become markdown images, others just the URL
+      if (mimeType?.startsWith("image/")) {
+        return `${indent}![](${url})`;
+      }
+      return `${indent}${url}`;
+    }
+
+    case "nostrEventPreview": {
+      const { type, data } = node.attrs;
+      // Collect address refs for manual a-tags
+      if (type === "naddr" && data) {
+        const key = `${data.kind}:${data.pubkey}:${data.identifier || ""}`;
+        if (!ctx.seenAddrs.has(key)) {
+          ctx.seenAddrs.add(key);
+          ctx.addressRefs.push({
+            kind: data.kind,
+            pubkey: data.pubkey,
+            identifier: data.identifier || "",
+          });
+        }
+      }
+      return `${indent}${renderNostrEventPreviewText(type, data)}`;
+    }
+
+    default:
+      // For unknown block nodes, try to get text content
+      if (node.textContent) {
+        return indent + node.textContent;
+      }
+      return null;
+  }
+}
+
+/**
+ * Serialize a list item's children. The first paragraph is inlined,
+ * subsequent blocks get their own lines with indentation.
+ */
+function serializeListItemContent(
+  item: any,
+  ctx: SerializerContext,
+  continuationIndent: string,
+): string {
+  const parts: string[] = [];
+  let first = true;
+
+  item.forEach((child: any) => {
+    if (first) {
+      // First child is inlined (no leading indent)
+      parts.push(serializeBlock(child, ctx, "") || "");
+      first = false;
+    } else {
+      // Subsequent children get continuation indent
+      parts.push(serializeBlock(child, ctx, continuationIndent) || "");
+    }
+  });
+
+  return parts.join("\n");
+}
+
+/**
+ * Serialize inline content of a block node (text with marks + inline nodes).
+ */
+function serializeInline(node: any, ctx: SerializerContext): string {
+  let result = "";
+
+  node.forEach((child: any) => {
+    if (child.isText) {
+      let text = child.text || "";
+      // Apply marks — order matters: link wraps bold wraps italic etc.
+      const marks = [...child.marks].sort(markPriority);
+      for (const mark of marks) {
+        text = applyMark(mark, text);
+      }
+      result += text;
+    } else {
+      result += serializeInlineNode(child, ctx);
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Sort marks so nesting is correct: innermost marks first.
+ * code < strike < italic < bold < link
+ */
+function markPriority(a: any, b: any): number {
+  const order: Record<string, number> = {
+    code: 0,
+    strike: 1,
+    italic: 2,
+    bold: 3,
+    link: 4,
+  };
+  return (order[a.type.name] ?? 5) - (order[b.type.name] ?? 5);
+}
+
+/**
+ * Wrap text with the markdown syntax for a mark.
+ */
+function applyMark(mark: any, text: string): string {
+  switch (mark.type.name) {
+    case "bold":
+      return `**${text}**`;
+    case "italic":
+      return `*${text}*`;
+    case "code":
+      return `\`${text}\``;
+    case "strike":
+      return `~~${text}~~`;
+    case "link":
+      return `[${text}](${mark.attrs.href || ""})`;
+    default:
+      return text;
+  }
+}
+
+/**
+ * Serialize a non-text inline node (mention, emoji, hardBreak).
+ */
+function serializeInlineNode(node: any, ctx: SerializerContext): string {
+  switch (node.type.name) {
+    case "mention": {
+      try {
+        return `nostr:${nip19.npubEncode(node.attrs.id)}`;
+      } catch {
+        return `@${node.attrs.label || "unknown"}`;
+      }
+    }
+
+    case "emoji": {
+      const { id, url, source } = node.attrs;
+      if (source === "unicode") {
+        return url || "";
+      }
+      // Custom emoji — collect tag
+      if (!ctx.seenEmojis.has(id)) {
+        ctx.seenEmojis.add(id);
+        ctx.emojiTags.push({ shortcode: id, url });
+      }
+      return `:${id}:`;
+    }
+
+    case "hardBreak":
+      return "\n";
+
+    default:
+      return node.textContent || "";
+  }
+}
+
+/**
+ * Render a nostr event preview node back to its bech32 URI.
+ */
+function renderNostrEventPreviewText(type: string, data: any): string {
+  try {
+    switch (type) {
+      case "note":
+        return `nostr:${nip19.noteEncode(data)}`;
+      case "nevent":
+        return `nostr:${nip19.neventEncode(data)}`;
+      case "naddr":
+        return `nostr:${nip19.naddrEncode(data)}`;
+      default:
+        return "";
+    }
+  } catch {
+    return "";
+  }
+}

--- a/src/lib/markdown-serializer.ts
+++ b/src/lib/markdown-serializer.ts
@@ -1,4 +1,10 @@
+import type { Editor } from "@tiptap/core";
+import type {
+  Node as ProseMirrorNode,
+  Mark as ProseMirrorMark,
+} from "@tiptap/pm/model";
 import { nip19 } from "nostr-tools";
+import type { EventPointer, AddressPointer } from "nostr-tools/nip19";
 import type {
   EmojiTag,
   BlobAttachment,
@@ -15,7 +21,7 @@ import type {
  * Returns both the markdown string and extracted metadata (emoji tags, blob
  * attachments, address refs) needed for building Nostr events.
  */
-export function serializeEditorToMarkdown(editor: any): SerializedContent {
+export function serializeEditorToMarkdown(editor: Editor): SerializedContent {
   const emojiTags: EmojiTag[] = [];
   const blobAttachments: BlobAttachment[] = [];
   const addressRefs: Array<{
@@ -27,7 +33,7 @@ export function serializeEditorToMarkdown(editor: any): SerializedContent {
   const seenBlobs = new Set<string>();
   const seenAddrs = new Set<string>();
 
-  const ctx = {
+  const ctx: SerializerContext = {
     emojiTags,
     blobAttachments,
     addressRefs,
@@ -55,13 +61,13 @@ interface SerializerContext {
  * Serialize all block-level children of a node, joined by double newlines.
  */
 function serializeBlocks(
-  node: any,
+  node: ProseMirrorNode,
   ctx: SerializerContext,
   indent: string,
 ): string {
   const blocks: string[] = [];
 
-  node.forEach((child: any) => {
+  node.forEach((child) => {
     const result = serializeBlock(child, ctx, indent);
     if (result !== null) {
       blocks.push(result);
@@ -75,7 +81,7 @@ function serializeBlocks(
  * Serialize a single block-level node to markdown.
  */
 function serializeBlock(
-  node: any,
+  node: ProseMirrorNode,
   ctx: SerializerContext,
   indent: string,
 ): string | null {
@@ -84,13 +90,13 @@ function serializeBlock(
       return indent + serializeInline(node, ctx);
 
     case "heading": {
-      const level = node.attrs.level || 1;
+      const level = (node.attrs.level as number) || 1;
       const prefix = "#".repeat(Math.min(level, 6));
       return `${indent}${prefix} ${serializeInline(node, ctx)}`;
     }
 
     case "codeBlock": {
-      const lang = node.attrs.language || "";
+      const lang = (node.attrs.language as string) || "";
       const code = node.textContent;
       return `${indent}\`\`\`${lang}\n${code}\n${indent}\`\`\``;
     }
@@ -105,7 +111,7 @@ function serializeBlock(
 
     case "bulletList": {
       const items: string[] = [];
-      node.forEach((item: any) => {
+      node.forEach((item) => {
         const content = serializeListItemContent(item, ctx, indent + "  ");
         items.push(`${indent}- ${content}`);
       });
@@ -114,8 +120,8 @@ function serializeBlock(
 
     case "orderedList": {
       const items: string[] = [];
-      const start = node.attrs.start || 1;
-      node.forEach((item: any, _offset: number, idx: number) => {
+      const start = (node.attrs.start as number) || 1;
+      node.forEach((item, _offset, idx) => {
         const num = start + idx;
         const content = serializeListItemContent(item, ctx, indent + "   ");
         items.push(`${indent}${num}. ${content}`);
@@ -127,7 +133,11 @@ function serializeBlock(
       return `${indent}---`;
 
     case "blobAttachment": {
-      const { url, sha256, mimeType, size, server } = node.attrs;
+      const url = node.attrs.url as string;
+      const sha256 = node.attrs.sha256 as string;
+      const mimeType = node.attrs.mimeType as string | undefined;
+      const size = node.attrs.size as number | undefined;
+      const server = node.attrs.server as string | undefined;
       if (!ctx.seenBlobs.has(sha256)) {
         ctx.seenBlobs.add(sha256);
         ctx.blobAttachments.push({ url, sha256, mimeType, size, server });
@@ -140,20 +150,25 @@ function serializeBlock(
     }
 
     case "nostrEventPreview": {
-      const { type, data } = node.attrs;
+      const previewType = node.attrs.type as string;
+      const previewData = node.attrs.data as
+        | string
+        | EventPointer
+        | AddressPointer;
       // Collect address refs for manual a-tags
-      if (type === "naddr" && data) {
-        const key = `${data.kind}:${data.pubkey}:${data.identifier || ""}`;
+      if (previewType === "naddr" && previewData) {
+        const addr = previewData as AddressPointer;
+        const key = `${addr.kind}:${addr.pubkey}:${addr.identifier || ""}`;
         if (!ctx.seenAddrs.has(key)) {
           ctx.seenAddrs.add(key);
           ctx.addressRefs.push({
-            kind: data.kind,
-            pubkey: data.pubkey,
-            identifier: data.identifier || "",
+            kind: addr.kind,
+            pubkey: addr.pubkey,
+            identifier: addr.identifier || "",
           });
         }
       }
-      return `${indent}${renderNostrEventPreviewText(type, data)}`;
+      return `${indent}${renderNostrEventPreviewText(previewType, previewData)}`;
     }
 
     default:
@@ -170,14 +185,14 @@ function serializeBlock(
  * subsequent blocks get their own lines with indentation.
  */
 function serializeListItemContent(
-  item: any,
+  item: ProseMirrorNode,
   ctx: SerializerContext,
   continuationIndent: string,
 ): string {
   const parts: string[] = [];
   let first = true;
 
-  item.forEach((child: any) => {
+  item.forEach((child) => {
     if (first) {
       // First child is inlined (no leading indent)
       parts.push(serializeBlock(child, ctx, "") || "");
@@ -194,10 +209,13 @@ function serializeListItemContent(
 /**
  * Serialize inline content of a block node (text with marks + inline nodes).
  */
-function serializeInline(node: any, ctx: SerializerContext): string {
+function serializeInline(
+  node: ProseMirrorNode,
+  ctx: SerializerContext,
+): string {
   let result = "";
 
-  node.forEach((child: any) => {
+  node.forEach((child) => {
     if (child.isText) {
       let text = child.text || "";
       // Apply marks — order matters: link wraps bold wraps italic etc.
@@ -218,7 +236,7 @@ function serializeInline(node: any, ctx: SerializerContext): string {
  * Sort marks so nesting is correct: innermost marks first.
  * code < strike < italic < bold < link
  */
-function markPriority(a: any, b: any): number {
+function markPriority(a: ProseMirrorMark, b: ProseMirrorMark): number {
   const order: Record<string, number> = {
     code: 0,
     strike: 1,
@@ -232,7 +250,7 @@ function markPriority(a: any, b: any): number {
 /**
  * Wrap text with the markdown syntax for a mark.
  */
-function applyMark(mark: any, text: string): string {
+function applyMark(mark: ProseMirrorMark, text: string): string {
   switch (mark.type.name) {
     case "bold":
       return `**${text}**`;
@@ -243,7 +261,7 @@ function applyMark(mark: any, text: string): string {
     case "strike":
       return `~~${text}~~`;
     case "link":
-      return `[${text}](${mark.attrs.href || ""})`;
+      return `[${text}](${(mark.attrs.href as string) || ""})`;
     default:
       return text;
   }
@@ -252,18 +270,23 @@ function applyMark(mark: any, text: string): string {
 /**
  * Serialize a non-text inline node (mention, emoji, hardBreak).
  */
-function serializeInlineNode(node: any, ctx: SerializerContext): string {
+function serializeInlineNode(
+  node: ProseMirrorNode,
+  ctx: SerializerContext,
+): string {
   switch (node.type.name) {
     case "mention": {
       try {
-        return `nostr:${nip19.npubEncode(node.attrs.id)}`;
+        return `nostr:${nip19.npubEncode(node.attrs.id as string)}`;
       } catch {
-        return `@${node.attrs.label || "unknown"}`;
+        return `@${(node.attrs.label as string) || "unknown"}`;
       }
     }
 
     case "emoji": {
-      const { id, url, source } = node.attrs;
+      const id = node.attrs.id as string;
+      const url = node.attrs.url as string;
+      const source = node.attrs.source as string;
       if (source === "unicode") {
         return url || "";
       }
@@ -286,15 +309,18 @@ function serializeInlineNode(node: any, ctx: SerializerContext): string {
 /**
  * Render a nostr event preview node back to its bech32 URI.
  */
-function renderNostrEventPreviewText(type: string, data: any): string {
+function renderNostrEventPreviewText(
+  type: string,
+  data: string | EventPointer | AddressPointer,
+): string {
   try {
     switch (type) {
       case "note":
-        return `nostr:${nip19.noteEncode(data)}`;
+        return `nostr:${nip19.noteEncode(data as string)}`;
       case "nevent":
-        return `nostr:${nip19.neventEncode(data)}`;
+        return `nostr:${nip19.neventEncode(data as EventPointer)}`;
       case "naddr":
-        return `nostr:${nip19.naddrEncode(data)}`;
+        return `nostr:${nip19.naddrEncode(data as AddressPointer)}`;
       default:
         return "";
     }

--- a/src/lib/nip34-helpers.ts
+++ b/src/lib/nip34-helpers.ts
@@ -329,6 +329,73 @@ export function getPullRequestRepositoryAddress(
 }
 
 // ============================================================================
+// Pull Request Update Event Helpers (Kind 1619)
+// ============================================================================
+
+const PRUpdateCommitsSymbol = Symbol("prUpdateCommits");
+
+/**
+ * Get the referenced PR event ID from a PR Update event
+ * @param event PR Update event (kind 1619)
+ * @returns PR event ID or undefined
+ */
+export function getPRUpdatePREventId(event: NostrEvent): string | undefined {
+  const eTag = event.tags.find((t) => t[0] === "e");
+  return eTag?.[1];
+}
+
+/**
+ * Get the relay hint for the referenced PR
+ * @param event PR Update event (kind 1619)
+ * @returns Relay URL or undefined
+ */
+export function getPRUpdatePRRelayHint(event: NostrEvent): string | undefined {
+  const eTag = event.tags.find((t) => t[0] === "e");
+  return eTag?.[2] || undefined;
+}
+
+/**
+ * Get the repository address from a PR Update event
+ * @param event PR Update event (kind 1619)
+ * @returns Repository address (a tag) or undefined
+ */
+export function getPRUpdateRepositoryAddress(
+  event: NostrEvent,
+): string | undefined {
+  return getTagValue(event, "a");
+}
+
+/**
+ * Get the new commit tip from a PR Update event
+ * @param event PR Update event (kind 1619)
+ * @returns Commit hash or undefined
+ */
+export function getPRUpdateCommitTip(event: NostrEvent): string | undefined {
+  return getTagValue(event, "c");
+}
+
+/**
+ * Get all commit hashes from a PR Update event
+ * PR updates may include multiple commit tags for the new commits
+ * @param event PR Update event (kind 1619)
+ * @returns Array of commit hashes
+ */
+export function getPRUpdateCommits(event: NostrEvent): string[] {
+  return getOrComputeCachedValue(event, PRUpdateCommitsSymbol, () =>
+    event.tags.filter((t) => t[0] === "c" && t[1]).map((t) => t[1]),
+  );
+}
+
+/**
+ * Get the branch name from a PR Update event
+ * @param event PR Update event (kind 1619)
+ * @returns Branch name or undefined
+ */
+export function getPRUpdateBranchName(event: NostrEvent): string | undefined {
+  return getTagValue(event, "branch-name");
+}
+
+// ============================================================================
 // Repository State Event Helpers (Kind 30618)
 // ============================================================================
 


### PR DESCRIPTION
- Extract duplicated relay resolution logic (repo relays → outbox → aggregators)
  into a reusable useRepositoryRelays hook, removing ~200 lines across 6 renderers
- Add PatchSeriesNav component to PatchDetailRenderer for navigating patch series
  via NIP-10 threading (root patches and their children)
- Add Kind 1619 PR Updates renderer (feed + detail) with commit list, branch info,
  and embedded PR reference
- Add PR Update helper functions to nip34-helpers.ts

https://claude.ai/code/session_01TUzfLDbarxHDYQRA2fyYTr