### PR TITLE
Refactor assertion subject rendering to use QuotedEvent component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13318,6 +13318,7 @@
     },
     "packages/relay-auth-manager": {
       "version": "0.1.0",
+      "license": "MIT",
       "peerDependencies": {
         "rxjs": "^7.0.0"
       }

--- a/src/components/nostr/kinds/TrustedAssertionDetailRenderer.tsx
+++ b/src/components/nostr/kinds/TrustedAssertionDetailRenderer.tsx
@@ -1,5 +1,6 @@
 import { NostrEvent } from "@/types/nostr";
 import { UserName } from "../UserName";
+import { QuotedEvent } from "../QuotedEvent";
 import { ExternalIdentifierBlock } from "../ExternalIdentifierDisplay";
 import {
   getAssertionSubject,
@@ -11,12 +12,13 @@ import {
   ASSERTION_KIND_LABELS,
   ASSERTION_TAG_LABELS,
 } from "@/lib/nip85-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import {
   getExternalIdentifierIcon,
   getExternalTypeLabel,
 } from "@/lib/nip73-helpers";
 import { formatTimestamp } from "@/hooks/useLocale";
-import { ShieldCheck, User, FileText, Hash } from "lucide-react";
+import { ShieldCheck, User, Hash } from "lucide-react";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 
@@ -119,32 +121,14 @@ function SubjectHeader({
     );
   }
 
-  // Kind 30384: addressable event (kind:pubkey:d-tag)
+  // Kind 30384: addressable event — quote the referenced event
   if (event.kind === 30384) {
-    const parts = subject.split(":");
-    if (parts.length >= 3) {
-      return (
-        <div className="flex items-center gap-2 p-3 rounded-md bg-muted/50">
-          <FileText className="size-4 text-muted-foreground" />
-          <span className="font-mono text-sm">
-            Kind {parts[0]} by{" "}
-            <UserName pubkey={parts[1]} className="text-sm inline" />
-            {parts[2] && (
-              <span className="text-muted-foreground"> / {parts[2]}</span>
-            )}
-          </span>
-        </div>
-      );
-    }
+    const pointer = parseReplaceableAddress(subject);
+    if (pointer) return <QuotedEvent addressPointer={pointer} depth={1} />;
   }
 
-  // Kind 30383: event ID
-  return (
-    <div className="flex items-center gap-2 p-3 rounded-md bg-muted/50">
-      <FileText className="size-4 text-muted-foreground" />
-      <span className="font-mono text-sm break-all">{subject}</span>
-    </div>
-  );
+  // Kind 30383: event ID — quote the referenced event
+  return <QuotedEvent eventPointer={{ id: subject }} depth={1} />;
 }
 
 /**

--- a/src/components/nostr/kinds/TrustedAssertionRenderer.tsx
+++ b/src/components/nostr/kinds/TrustedAssertionRenderer.tsx
@@ -5,6 +5,7 @@ import {
 } from "./BaseEventRenderer";
 import { Label } from "@/components/ui/label";
 import { UserName } from "../UserName";
+import { QuotedEvent } from "../QuotedEvent";
 import { ExternalIdentifierInline } from "../ExternalIdentifierDisplay";
 import {
   getAssertionSubject,
@@ -16,6 +17,7 @@ import {
   ASSERTION_KIND_LABELS,
   ASSERTION_TAG_LABELS,
 } from "@/lib/nip85-helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
 
@@ -47,7 +49,7 @@ function RankBar({ rank }: { rank: number }) {
 }
 
 /**
- * Subject as the visual anchor — rendered as ClickableEventTitle
+ * Subject as the visual anchor — rendered as ClickableEventTitle or QuotedEvent
  */
 function SubjectTitle({
   event,
@@ -83,31 +85,14 @@ function SubjectTitle({
     );
   }
 
+  // Kind 30384: addressable event — quote inline
   if (event.kind === 30384) {
-    const parts = subject.split(":");
-    const display =
-      parts.length >= 3
-        ? `${parts[0]}:${parts[1].slice(0, 8)}...:${parts[2] || "*"}`
-        : subject;
-    return (
-      <ClickableEventTitle
-        event={event}
-        className="text-sm font-semibold font-mono text-foreground"
-      >
-        {display}
-      </ClickableEventTitle>
-    );
+    const pointer = parseReplaceableAddress(subject);
+    if (pointer) return <QuotedEvent addressPointer={pointer} depth={2} />;
   }
 
-  // Event ID (30383)
-  return (
-    <ClickableEventTitle
-      event={event}
-      className="text-sm font-semibold font-mono text-foreground"
-    >
-      {subject.slice(0, 16)}...
-    </ClickableEventTitle>
-  );
+  // Kind 30383: event ID — quote inline
+  return <QuotedEvent eventPointer={{ id: subject }} depth={2} />;
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored the rendering of assertion subjects in trusted assertion components to use the `QuotedEvent` component instead of custom inline rendering logic. This improves consistency and maintainability across the codebase.

## Key Changes
- **TrustedAssertionDetailRenderer.tsx**: 
  - Replaced custom kind 30384 (addressable event) parsing with `parseReplaceableAddress()` helper and `QuotedEvent` component
  - Replaced custom kind 30383 (event ID) rendering with `QuotedEvent` component
  - Removed unused `FileText` icon import
  - Added imports for `QuotedEvent` component and `parseReplaceableAddress` helper

- **TrustedAssertionRenderer.tsx**:
  - Replaced custom kind 30384 subject title rendering with `QuotedEvent` component
  - Replaced custom kind 30383 subject title rendering with `QuotedEvent` component
  - Updated comment to reflect new rendering approach
  - Added imports for `QuotedEvent` component and `parseReplaceableAddress` helper

## Implementation Details
- Both components now delegate event/address pointer rendering to the `QuotedEvent` component with appropriate depth levels (1 for detail view, 2 for inline view)
- Uses `parseReplaceableAddress()` to safely parse addressable event pointers before rendering
- Removes approximately 50 lines of duplicated custom rendering logic
- Maintains the same visual hierarchy and functionality while improving code reusability

https://claude.ai/code/session_01L4Kwg3Ad4C2S1cvkvwACH1