### PR TITLE
fix: replace numeric timestamp input with date picker in NIP-5C scrolls

### DIFF
--- a/src/components/scroll/ScrollParamForm.tsx
+++ b/src/components/scroll/ScrollParamForm.tsx
@@ -2,7 +2,75 @@ import { Settings } from "lucide-react";
 import { PARAM_CONFIG } from "@/components/nostr/kinds/ScrollRenderer";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { formatTimestamp } from "@/hooks/useLocale";
 import type { ScrollParam } from "@/lib/nip5c-helpers";
+
+const TIMESTAMP_PRESETS = [
+  { label: "1h ago", offset: 3600 },
+  { label: "1d ago", offset: 86400 },
+  { label: "1w ago", offset: 604800 },
+  { label: "1mo ago", offset: 2592000 },
+] as const;
+
+function unixToDatetimeLocal(unixSeconds: number): string {
+  const date = new Date(unixSeconds * 1000);
+  // toISOString gives UTC; adjust to local time for datetime-local input
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+}
+
+function TimestampInput({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}) {
+  const numericValue = value ? parseInt(value, 10) : null;
+  const datetimeValue =
+    numericValue && !isNaN(numericValue)
+      ? unixToDatetimeLocal(numericValue)
+      : "";
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex gap-1">
+        {TIMESTAMP_PRESETS.map(({ label, offset }) => (
+          <button
+            key={label}
+            type="button"
+            disabled={disabled}
+            onClick={() =>
+              onChange(String(Math.floor(Date.now() / 1000) - offset))
+            }
+            className="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <Input
+        type="datetime-local"
+        value={datetimeValue}
+        onChange={(e) => {
+          const parsed = new Date(e.target.value).getTime();
+          if (!isNaN(parsed)) {
+            onChange(String(Math.floor(parsed / 1000)));
+          }
+        }}
+        disabled={disabled}
+        className="h-8 text-xs"
+      />
+      {numericValue && !isNaN(numericValue) && (
+        <span className="text-xs text-muted-foreground">
+          {formatTimestamp(numericValue, "datetime")}
+        </span>
+      )}
+    </div>
+  );
+}
 
 interface ScrollParamFormProps {
   params: ScrollParam[];
@@ -90,6 +158,12 @@ export function ScrollParamForm({
                     className="flex-1 h-8 text-xs"
                   />
                 </div>
+              ) : param.type === "timestamp" ? (
+                <TimestampInput
+                  value={values[param.name] || ""}
+                  onChange={(v) => setValue(param.name, v)}
+                  disabled={disabled}
+                />
               ) : (
                 <Input
                   type={inputType}

--- a/src/components/scroll/ScrollParamForm.tsx
+++ b/src/components/scroll/ScrollParamForm.tsx
@@ -19,6 +19,13 @@ function unixToDatetimeLocal(unixSeconds: number): string {
   return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
+/** Parse a stored param value, rejecting anything that isn't a whole number. */
+function parseUnixSeconds(value: string): number | null {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
 function TimestampInput({
   value,
   onChange,
@@ -28,11 +35,9 @@ function TimestampInput({
   onChange: (value: string) => void;
   disabled?: boolean;
 }) {
-  const numericValue = value ? parseInt(value, 10) : null;
+  const numericValue = parseUnixSeconds(value);
   const datetimeValue =
-    numericValue && !isNaN(numericValue)
-      ? unixToDatetimeLocal(numericValue)
-      : "";
+    numericValue === null ? "" : unixToDatetimeLocal(numericValue);
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -55,6 +60,12 @@ function TimestampInput({
         type="datetime-local"
         value={datetimeValue}
         onChange={(e) => {
+          // An empty input means "no timestamp" — propagate it, otherwise the
+          // field can be set but never cleared.
+          if (e.target.value === "") {
+            onChange("");
+            return;
+          }
           const parsed = new Date(e.target.value).getTime();
           if (!isNaN(parsed)) {
             onChange(String(Math.floor(parsed / 1000)));
@@ -63,7 +74,7 @@ function TimestampInput({
         disabled={disabled}
         className="h-8 text-xs"
       />
-      {numericValue && !isNaN(numericValue) && (
+      {numericValue !== null && (
         <span className="text-xs text-muted-foreground">
           {formatTimestamp(numericValue, "datetime")}
         </span>


### PR DESCRIPTION
## Summary
- Replace `<input type="number">` for timestamp parameters with a proper date/time picker
- Add relative presets ("1h ago", "1d ago", "1w ago", "1mo ago") as quick-select chips
- Show locale-aware human-readable date preview below the input via `formatTimestamp`

## Issue
Closes #263

## Verification
- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Code review passed (1 round)

Generated with [Claude Code](https://claude.ai/code) via `/bug-sweep`