### PR TITLE
fix: auto-stop NIP-5C scroll program after 3s of inactivity

### DIFF
--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -50,6 +50,7 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const [activeSubs, setActiveSubs] = useState<SubscriptionInfo[]>([]);
   const [eventCount, setEventCount] = useState(0);
   const controllerRef = useRef<ScrollRuntimeController | null>(null);
+  const hasHadSubsRef = useRef(false);
 
   // Encoding options
   const [endianness, setEndianness] = useState<"LE" | "BE">("BE");
@@ -76,6 +77,30 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
     };
   }, []);
 
+  // Auto-stop after 3 seconds of inactivity (no open subscriptions)
+  useEffect(() => {
+    // Track if we've ever had subscriptions
+    if (activeSubs.some((s) => !s.closed)) {
+      hasHadSubsRef.current = true;
+    }
+
+    // Only auto-stop if: running, has had subs before, and no open subs now
+    const openSubs = activeSubs.filter((s) => !s.closed).length;
+    if (runtimeState !== "running" || !hasHadSubsRef.current || openSubs > 0) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      controllerRef.current?.stop();
+      setLogEntries((prev) => [
+        ...prev,
+        "Auto-stopped: no active subscriptions for 3 seconds",
+      ]);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [activeSubs, runtimeState]);
+
   const handleRun = useCallback(async () => {
     controllerRef.current?.stop();
 
@@ -85,6 +110,7 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
     setActiveSubs([]);
     setEventCount(0);
     setRuntimeState("loading");
+    hasHadSubsRef.current = false;
 
     // Resolve param values — fetch all event params before running
     const resolved = new Map<string, ParamValue>();

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -23,6 +23,9 @@ interface ScrollExecutorProps {
   wasmBase64: string;
 }
 
+/** Stop a running scroll this long after its last subscription closes. */
+const INACTIVITY_STOP_MS = 3000;
+
 export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const { pubkey } = useAccount();
   const { relays: relayStates } = useRelayState();
@@ -77,26 +80,30 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
     };
   }, []);
 
-  // Auto-stop after 3 seconds of inactivity (no open subscriptions)
+  // Auto-stop once every subscription has closed and nothing else happens.
+  // Gated on having had a subscription at all, so a program isn't killed during
+  // startup before it opens its first REQ.
   useEffect(() => {
-    // Track if we've ever had subscriptions
     if (activeSubs.some((s) => !s.closed)) {
       hasHadSubsRef.current = true;
     }
 
-    // Only auto-stop if: running, has had subs before, and no open subs now
-    const openSubs = activeSubs.filter((s) => !s.closed).length;
-    if (runtimeState !== "running" || !hasHadSubsRef.current || openSubs > 0) {
+    const hasOpenSubs = activeSubs.some((s) => !s.closed);
+    if (runtimeState !== "running" || !hasHadSubsRef.current || hasOpenSubs) {
       return;
     }
 
+    // Capture the controller for this run: if the user starts another run
+    // before the timer fires, this must not stop the new one.
+    const controller = controllerRef.current;
+
     const timer = setTimeout(() => {
-      controllerRef.current?.stop();
+      controller?.stop();
       setLogEntries((prev) => [
         ...prev,
-        "Auto-stopped: no active subscriptions for 3 seconds",
+        `Auto-stopped: no active subscriptions for ${INACTIVITY_STOP_MS / 1000}s`,
       ]);
-    }, 3000);
+    }, INACTIVITY_STOP_MS);
 
     return () => clearTimeout(timer);
   }, [activeSubs, runtimeState]);


### PR DESCRIPTION
## Summary
- Auto-stop WASM scroll programs when all relay subscriptions close and no new ones appear within 3 seconds
- Track subscription history with `hasHadSubsRef` to avoid premature stops before first subscription
- Log "Auto-stopped: no active subscriptions for 3 seconds" message to scroll output

## Issue
Closes #264

## Verification
- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Code review passed (1 round)

Generated with [Claude Code](https://claude.ai/code) via `/bug-sweep`