### PR TITLE
fix: sync NIP-5C me parameter with active account on login/logout

### DIFF
--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -57,6 +57,19 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
 
   const isActive = runtimeState === "loading" || runtimeState === "running";
 
+  // Sync "me" param with active account pubkey
+  useEffect(() => {
+    const hasMeParam = params.some(
+      (p) => p.name === "me" && p.type === "public_key",
+    );
+    if (!hasMeParam || isActive) return;
+
+    setParamValues((prev) => ({
+      ...prev,
+      me: pubkey || "",
+    }));
+  }, [pubkey, params, isActive]);
+
   // Sorted, deduplicated display events (newest first)
   const displayedEvents = useMemo(
     () =>

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -61,17 +61,19 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
 
   const isActive = runtimeState === "loading" || runtimeState === "running";
 
-  // Sync "me" param with active account pubkey
+  // Sync the "me" param on login/logout only. Syncing on every render pass
+  // would clobber a pubkey the user typed in by hand — including on run/stop,
+  // since that flips isActive.
+  const syncedPubkeyRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const hasMeParam = params.some(
       (p) => p.name === "me" && p.type === "public_key",
     );
     if (!hasMeParam || isActive) return;
+    if (syncedPubkeyRef.current === pubkey) return;
 
-    setParamValues((prev) => ({
-      ...prev,
-      me: pubkey || "",
-    }));
+    syncedPubkeyRef.current = pubkey;
+    setParamValues((prev) => ({ ...prev, me: pubkey || "" }));
   }, [pubkey, params, isActive]);
 
   // Sorted, deduplicated display events (newest first)

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -61,6 +61,19 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
 
   const isActive = runtimeState === "loading" || runtimeState === "running";
 
+  // Sync "me" param with active account pubkey
+  useEffect(() => {
+    const hasMeParam = params.some(
+      (p) => p.name === "me" && p.type === "public_key",
+    );
+    if (!hasMeParam || isActive) return;
+
+    setParamValues((prev) => ({
+      ...prev,
+      me: pubkey || "",
+    }));
+  }, [pubkey, params, isActive]);
+
   // Sorted, deduplicated display events (newest first)
   const displayedEvents = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- Keep the `me` parameter in NIP-5C scroll forms in sync with the active account pubkey
- Clears the field on logout, updates on account switch
- Skips updates while a scroll is actively running to avoid mid-execution confusion

## Issue
Closes #265

## Verification
- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Code review passed (1 round)

Generated with [Claude Code](https://claude.ai/code) via `/bug-sweep`