### PR TITLE
fix: persist NIP-5C scroll settings and parameters across reloads

### DIFF
--- a/src/components/nostr/kinds/ScrollRenderer.tsx
+++ b/src/components/nostr/kinds/ScrollRenderer.tsx
@@ -148,7 +148,11 @@ export function ScrollDetailRenderer({ event }: { event: NostrEvent }) {
         )}
       </div>
 
-      <ScrollExecutor params={params} wasmBase64={event.content} />
+      <ScrollExecutor
+        params={params}
+        wasmBase64={event.content}
+        eventId={event.id}
+      />
     </div>
   );
 }

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -21,9 +21,48 @@ interface ScrollExecutorProps {
   params: ScrollParam[];
   /** Base64-encoded WASM binary */
   wasmBase64: string;
+  /** Event ID used as localStorage key for persisting settings */
+  eventId?: string;
 }
 
-export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
+const SCROLL_STORAGE_PREFIX = "scroll_settings_";
+
+function loadScrollSettings(eventId: string): {
+  paramValues?: Record<string, string>;
+  endianness?: "LE" | "BE";
+  presenceBytes?: boolean;
+} {
+  try {
+    const stored = localStorage.getItem(SCROLL_STORAGE_PREFIX + eventId);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveScrollSettings(
+  eventId: string,
+  settings: {
+    paramValues: Record<string, string>;
+    endianness: "LE" | "BE";
+    presenceBytes: boolean;
+  },
+) {
+  try {
+    localStorage.setItem(
+      SCROLL_STORAGE_PREFIX + eventId,
+      JSON.stringify(settings),
+    );
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+export function ScrollExecutor({
+  params,
+  wasmBase64,
+  eventId,
+}: ScrollExecutorProps) {
   const { pubkey } = useAccount();
   const { relays: relayStates } = useRelayState();
 
@@ -31,17 +70,28 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
     .filter(([, state]) => state.connectionState === "connected")
     .map(([url]) => url);
 
-  // Pre-fill "me" params with logged-in pubkey
+  // Load persisted settings
+  const stored = eventId ? loadScrollSettings(eventId) : {};
+
+  // Pre-fill "me" params with logged-in pubkey, then overlay persisted values
   const defaultValues: Record<string, string> = {};
   for (const p of params) {
     if (p.name === "me" && p.type === "public_key" && pubkey) {
       defaultValues[p.name] = pubkey;
     }
   }
+  // Filter stored values to only include current params (remove stale keys)
+  const validParamNames = new Set(params.map((p) => p.name));
+  const filteredStored = Object.fromEntries(
+    Object.entries(stored.paramValues || {}).filter(([k]) =>
+      validParamNames.has(k),
+    ),
+  );
+  const initialValues = { ...defaultValues, ...filteredStored };
 
   const [runtimeState, setRuntimeState] = useState<ScrollRuntimeState>("idle");
   const [paramValues, setParamValues] =
-    useState<Record<string, string>>(defaultValues);
+    useState<Record<string, string>>(initialValues);
   const [displayedEventsMap, setDisplayedEventsMap] = useState<
     Map<string, NostrEvent>
   >(new Map());
@@ -50,10 +100,15 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const [activeSubs, setActiveSubs] = useState<SubscriptionInfo[]>([]);
   const [eventCount, setEventCount] = useState(0);
   const controllerRef = useRef<ScrollRuntimeController | null>(null);
+  const isInitialMount = useRef(true);
 
   // Encoding options
-  const [endianness, setEndianness] = useState<"LE" | "BE">("BE");
-  const [presenceBytes, setPresenceBytes] = useState(false);
+  const [endianness, setEndianness] = useState<"LE" | "BE">(
+    stored.endianness || "BE",
+  );
+  const [presenceBytes, setPresenceBytes] = useState(
+    stored.presenceBytes ?? false,
+  );
 
   const isActive = runtimeState === "loading" || runtimeState === "running";
 
@@ -69,6 +124,16 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const requiredParamsMissing = params.some(
     (p) => p.required && !paramValues[p.name]?.trim(),
   );
+
+  // Persist settings to localStorage when they change (skip initial mount)
+  useEffect(() => {
+    if (!eventId) return;
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    saveScrollSettings(eventId, { paramValues, endianness, presenceBytes });
+  }, [eventId, paramValues, endianness, presenceBytes]);
 
   useEffect(() => {
     return () => {

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -21,12 +21,51 @@ interface ScrollExecutorProps {
   params: ScrollParam[];
   /** Base64-encoded WASM binary */
   wasmBase64: string;
+  /** Event ID used as localStorage key for persisting settings */
+  eventId?: string;
 }
 
 /** Stop a running scroll this long after its last subscription closes. */
 const INACTIVITY_STOP_MS = 3000;
 
-export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
+const SCROLL_STORAGE_PREFIX = "scroll_settings_";
+
+function loadScrollSettings(eventId: string): {
+  paramValues?: Record<string, string>;
+  endianness?: "LE" | "BE";
+  presenceBytes?: boolean;
+} {
+  try {
+    const stored = localStorage.getItem(SCROLL_STORAGE_PREFIX + eventId);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveScrollSettings(
+  eventId: string,
+  settings: {
+    paramValues: Record<string, string>;
+    endianness: "LE" | "BE";
+    presenceBytes: boolean;
+  },
+) {
+  try {
+    localStorage.setItem(
+      SCROLL_STORAGE_PREFIX + eventId,
+      JSON.stringify(settings),
+    );
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+export function ScrollExecutor({
+  params,
+  wasmBase64,
+  eventId,
+}: ScrollExecutorProps) {
   const { pubkey } = useAccount();
   const { relays: relayStates } = useRelayState();
 
@@ -34,17 +73,28 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
     .filter(([, state]) => state.connectionState === "connected")
     .map(([url]) => url);
 
-  // Pre-fill "me" params with logged-in pubkey
+  // Load persisted settings
+  const stored = eventId ? loadScrollSettings(eventId) : {};
+
+  // Pre-fill "me" params with logged-in pubkey, then overlay persisted values
   const defaultValues: Record<string, string> = {};
   for (const p of params) {
     if (p.name === "me" && p.type === "public_key" && pubkey) {
       defaultValues[p.name] = pubkey;
     }
   }
+  // Filter stored values to only include current params (remove stale keys)
+  const validParamNames = new Set(params.map((p) => p.name));
+  const filteredStored = Object.fromEntries(
+    Object.entries(stored.paramValues || {}).filter(([k]) =>
+      validParamNames.has(k),
+    ),
+  );
+  const initialValues = { ...defaultValues, ...filteredStored };
 
   const [runtimeState, setRuntimeState] = useState<ScrollRuntimeState>("idle");
   const [paramValues, setParamValues] =
-    useState<Record<string, string>>(defaultValues);
+    useState<Record<string, string>>(initialValues);
   const [displayedEventsMap, setDisplayedEventsMap] = useState<
     Map<string, NostrEvent>
   >(new Map());
@@ -54,10 +104,15 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const [eventCount, setEventCount] = useState(0);
   const controllerRef = useRef<ScrollRuntimeController | null>(null);
   const hasHadSubsRef = useRef(false);
+  const isInitialMount = useRef(true);
 
   // Encoding options
-  const [endianness, setEndianness] = useState<"LE" | "BE">("BE");
-  const [presenceBytes, setPresenceBytes] = useState(false);
+  const [endianness, setEndianness] = useState<"LE" | "BE">(
+    stored.endianness || "BE",
+  );
+  const [presenceBytes, setPresenceBytes] = useState(
+    stored.presenceBytes ?? false,
+  );
 
   const isActive = runtimeState === "loading" || runtimeState === "running";
 
@@ -88,6 +143,16 @@ export function ScrollExecutor({ params, wasmBase64 }: ScrollExecutorProps) {
   const requiredParamsMissing = params.some(
     (p) => p.required && !paramValues[p.name]?.trim(),
   );
+
+  // Persist settings to localStorage when they change (skip initial mount)
+  useEffect(() => {
+    if (!eventId) return;
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    saveScrollSettings(eventId, { paramValues, endianness, presenceBytes });
+  }, [eventId, paramValues, endianness, presenceBytes]);
 
   useEffect(() => {
     return () => {

--- a/src/components/scroll/ScrollExecutor.tsx
+++ b/src/components/scroll/ScrollExecutor.tsx
@@ -37,7 +37,17 @@ function loadScrollSettings(eventId: string): {
 } {
   try {
     const stored = localStorage.getItem(SCROLL_STORAGE_PREFIX + eventId);
-    return stored ? JSON.parse(stored) : {};
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    return {
+      paramValues:
+        typeof parsed?.paramValues === "object" && parsed.paramValues !== null
+          ? parsed.paramValues
+          : undefined,
+      // Don't trust storage: anything else would reach the WASM runtime.
+      endianness: parsed?.endianness === "LE" ? "LE" : "BE",
+      presenceBytes: parsed?.presenceBytes === true,
+    };
   } catch {
     return {};
   }
@@ -73,28 +83,27 @@ export function ScrollExecutor({
     .filter(([, state]) => state.connectionState === "connected")
     .map(([url]) => url);
 
-  // Load persisted settings
-  const stored = eventId ? loadScrollSettings(eventId) : {};
-
-  // Pre-fill "me" params with logged-in pubkey, then overlay persisted values
-  const defaultValues: Record<string, string> = {};
-  for (const p of params) {
-    if (p.name === "me" && p.type === "public_key" && pubkey) {
-      defaultValues[p.name] = pubkey;
-    }
-  }
-  // Filter stored values to only include current params (remove stale keys)
-  const validParamNames = new Set(params.map((p) => p.name));
-  const filteredStored = Object.fromEntries(
-    Object.entries(stored.paramValues || {}).filter(([k]) =>
-      validParamNames.has(k),
-    ),
-  );
-  const initialValues = { ...defaultValues, ...filteredStored };
+  // Read storage once. This component re-renders on every received event, so
+  // reading and parsing per render would be wasted work — and the values are
+  // only ever used to seed initial state.
+  const [stored] = useState(() => (eventId ? loadScrollSettings(eventId) : {}));
 
   const [runtimeState, setRuntimeState] = useState<ScrollRuntimeState>("idle");
-  const [paramValues, setParamValues] =
-    useState<Record<string, string>>(initialValues);
+  const [paramValues, setParamValues] = useState<Record<string, string>>(() => {
+    // Pre-fill "me" with the logged-in pubkey, then overlay persisted values,
+    // dropping any that no longer correspond to a declared param.
+    const defaults: Record<string, string> = {};
+    for (const p of params) {
+      if (p.name === "me" && p.type === "public_key" && pubkey) {
+        defaults[p.name] = pubkey;
+      }
+    }
+    const declared = new Set(params.map((p) => p.name));
+    const restored = Object.entries(stored.paramValues ?? {}).filter(([k]) =>
+      declared.has(k),
+    );
+    return { ...defaults, ...Object.fromEntries(restored) };
+  });
   const [displayedEventsMap, setDisplayedEventsMap] = useState<
     Map<string, NostrEvent>
   >(new Map());
@@ -108,7 +117,7 @@ export function ScrollExecutor({
 
   // Encoding options
   const [endianness, setEndianness] = useState<"LE" | "BE">(
-    stored.endianness || "BE",
+    stored.endianness ?? "BE",
   );
   const [presenceBytes, setPresenceBytes] = useState(
     stored.presenceBytes ?? false,


### PR DESCRIPTION
## Summary
- Store scroll parameter values, endianness, and presence bytes in localStorage keyed by event ID
- Load persisted settings on mount, merging with defaults (logged-in pubkey for `me` param)
- Filter stale param keys when scroll parameters change between versions
- Skip initial mount write to avoid unnecessary localStorage operations

## Issue
Closes #266

## Verification
- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Code review passed (2 rounds — fixed initial mount save and stale key filtering)

Generated with [Claude Code](https://claude.ai/code) via `/bug-sweep`