### PR TITLE
Add Attestation kind (31871) support

### DIFF
--- a/src/components/nostr/kinds/AttestationDetailRenderer.tsx
+++ b/src/components/nostr/kinds/AttestationDetailRenderer.tsx
@@ -1,0 +1,191 @@
+import { NostrEvent } from "@/types/nostr";
+import { UserName } from "../UserName";
+import { QuotedEvent } from "../QuotedEvent";
+import { getTagValue } from "applesauce-core/helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import {
+  ShieldCheck,
+  AlertCircle,
+  XCircle,
+  CheckCircle2,
+  FileText,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatTimestamp } from "@/hooks/useLocale";
+import { useGrimoire } from "@/core/state";
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; icon: React.ElementType; color: string; border: string }
+> = {
+  verifying: {
+    label: "Verifying",
+    icon: AlertCircle,
+    color: "text-amber-600",
+    border: "border-amber-200",
+  },
+  valid: {
+    label: "Valid",
+    icon: CheckCircle2,
+    color: "text-emerald-600",
+    border: "border-emerald-200",
+  },
+  invalid: {
+    label: "Invalid",
+    icon: XCircle,
+    color: "text-red-600",
+    border: "border-red-200",
+  },
+  revoked: {
+    label: "Revoked",
+    icon: XCircle,
+    color: "text-slate-500",
+    border: "border-slate-200",
+  },
+};
+
+function StatusHeader({ status }: { status: string }) {
+  const config = STATUS_CONFIG[status] ?? {
+    label: status,
+    icon: ShieldCheck,
+    color: "text-muted-foreground",
+    border: "border-border",
+  };
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg border px-3 py-2",
+        config.border,
+        config.color,
+      )}
+    >
+      <Icon className="size-5" />
+      <span className="text-sm font-semibold">{config.label}</span>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1 py-2 border-b border-border/30 last:border-0">
+      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <div className="text-sm">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * Detail renderer for Kind 31871 - Attestation
+ * Full view with all tags, referenced event, validity window, and notes.
+ */
+export function AttestationDetailRenderer({
+  event,
+}: {
+  event: NostrEvent;
+}) {
+  const { locale } = useGrimoire();
+
+  const status = getTagValue(event, "s");
+  const validFrom = getTagValue(event, "valid_from");
+  const validTo = getTagValue(event, "valid_to");
+  const expiration = getTagValue(event, "expiration");
+  const dTag = getTagValue(event, "d");
+  const eTag = getTagValue(event, "e");
+  const aTag = getTagValue(event, "a");
+  const requestTag = getTagValue(event, "request");
+
+  const validFromTs = validFrom ? parseInt(validFrom, 10) : undefined;
+  const validToTs = validTo ? parseInt(validTo, 10) : undefined;
+  const expirationTs = expiration ? parseInt(expiration, 10) : undefined;
+
+  const aPointer = aTag ? parseReplaceableAddress(aTag) : undefined;
+
+  return (
+    <div className="flex flex-col gap-5 p-6 max-w-2xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="size-5 text-muted-foreground" />
+        <h2 className="text-lg font-semibold">Attestation</h2>
+      </div>
+
+      {/* Attestor */}
+      <div className="flex items-center gap-1.5 text-sm">
+        <span className="text-muted-foreground">Attestor:</span>
+        <UserName pubkey={event.pubkey} className="font-medium" />
+      </div>
+
+      {/* Status */}
+      {status && <StatusHeader status={status} />}
+
+      {/* Assertion reference */}
+      {(eTag || aPointer) && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Assertion
+          </span>
+          {eTag && <QuotedEvent eventPointer={{ id: eTag }} depth={1} />}
+          {aPointer && <QuotedEvent addressPointer={aPointer} depth={1} />}
+        </div>
+      )}
+
+      {/* Metadata */}
+      <div className="flex flex-col">
+        {dTag && (
+          <DetailRow
+            label="Identifier"
+            value={<span className="font-mono text-xs break-all">{dTag}</span>}
+          />
+        )}
+        {validFromTs && (
+          <DetailRow
+            label="Valid From"
+            value={formatTimestamp(validFromTs, "long", locale.locale)}
+          />
+        )}
+        {validToTs && (
+          <DetailRow
+            label="Valid To"
+            value={formatTimestamp(validToTs, "long", locale.locale)}
+          />
+        )}
+        {expirationTs && (
+          <DetailRow
+            label="Expires"
+            value={formatTimestamp(expirationTs, "long", locale.locale)}
+          />
+        )}
+        {requestTag && (
+          <DetailRow
+            label="Request"
+            value={
+              <span className="font-mono text-xs break-all">{requestTag}</span>
+            }
+          />
+        )}
+      </div>
+
+      {/* Notes */}
+      {event.content && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            <FileText className="size-3" />
+            Notes
+          </div>
+          <div className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+            {event.content}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/nostr/kinds/AttestationRenderer.tsx
+++ b/src/components/nostr/kinds/AttestationRenderer.tsx
@@ -1,0 +1,129 @@
+import {
+  BaseEventProps,
+  BaseEventContainer,
+  ClickableEventTitle,
+} from "./BaseEventRenderer";
+import { Label } from "@/components/ui/label";
+import { QuotedEvent } from "../QuotedEvent";
+import { getTagValue } from "applesauce-core/helpers";
+import { parseReplaceableAddress } from "applesauce-core/helpers/pointers";
+import { ShieldCheck, Clock, AlertCircle, XCircle, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatTimestamp } from "@/hooks/useLocale";
+import { useGrimoire } from "@/core/state";
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; icon: React.ElementType; color: string; bg: string }
+> = {
+  verifying: {
+    label: "Verifying",
+    icon: AlertCircle,
+    color: "text-amber-600",
+    bg: "bg-amber-50",
+  },
+  valid: {
+    label: "Valid",
+    icon: CheckCircle2,
+    color: "text-emerald-600",
+    bg: "bg-emerald-50",
+  },
+  invalid: {
+    label: "Invalid",
+    icon: XCircle,
+    color: "text-red-600",
+    bg: "bg-red-50",
+  },
+  revoked: {
+    label: "Revoked",
+    icon: XCircle,
+    color: "text-slate-500",
+    bg: "bg-slate-50",
+  },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const config = STATUS_CONFIG[status] ?? {
+    label: status,
+    icon: ShieldCheck,
+    color: "text-muted-foreground",
+    bg: "bg-muted",
+  };
+  const Icon = config.icon;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium",
+        config.bg,
+        config.color,
+      )}
+    >
+      <Icon className="size-3" />
+      {config.label}
+    </span>
+  );
+}
+
+/**
+ * Renderer for Kind 31871 - Attestation
+ * Displays attestation status, referenced assertion, validity window, and notes.
+ */
+export function AttestationRenderer({ event }: BaseEventProps) {
+  const { locale } = useGrimoire();
+
+  const status = getTagValue(event, "s");
+  const validFrom = getTagValue(event, "valid_from");
+  const validTo = getTagValue(event, "valid_to");
+  const eTag = getTagValue(event, "e");
+  const aTag = getTagValue(event, "a");
+
+  const validFromTs = validFrom ? parseInt(validFrom, 10) : undefined;
+  const validToTs = validTo ? parseInt(validTo, 10) : undefined;
+
+  const aPointer = aTag ? parseReplaceableAddress(aTag) : undefined;
+
+  return (
+    <BaseEventContainer event={event}>
+      <div className="flex flex-col gap-2.5">
+        {/* Header: kind label + status */}
+        <div className="flex items-center gap-2">
+          <Label className="w-fit">Attestation</Label>
+          {status && <StatusBadge status={status} />}
+        </div>
+
+        {/* Referenced assertion */}
+        {eTag && (
+          <QuotedEvent eventPointer={{ id: eTag }} depth={2} />
+        )}
+        {aPointer && (
+          <QuotedEvent addressPointer={aPointer} depth={2} />
+        )}
+
+        {/* Validity window */}
+        {(validFromTs || validToTs) && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Clock className="size-3" />
+            {validFromTs && (
+              <span>From {formatTimestamp(validFromTs, "absolute", locale.locale)}</span>
+            )}
+            {validFromTs && validToTs && <span>–</span>}
+            {validToTs && (
+              <span>To {formatTimestamp(validToTs, "absolute", locale.locale)}</span>
+            )}
+          </div>
+        )}
+
+        {/* Note / content */}
+        {event.content && (
+          <ClickableEventTitle
+            event={event}
+            className="text-sm text-foreground line-clamp-3 leading-relaxed"
+          >
+            {event.content}
+          </ClickableEventTitle>
+        )}
+      </div>
+    </BaseEventContainer>
+  );
+}

--- a/src/components/nostr/kinds/index.tsx
+++ b/src/components/nostr/kinds/index.tsx
@@ -178,6 +178,8 @@ import { TrustedAssertionRenderer } from "./TrustedAssertionRenderer";
 import { TrustedAssertionDetailRenderer } from "./TrustedAssertionDetailRenderer";
 import { TrustedProviderListRenderer } from "./TrustedProviderListRenderer";
 import { TrustedProviderListDetailRenderer } from "./TrustedProviderListDetailRenderer";
+import { AttestationRenderer } from "./AttestationRenderer";
+import { AttestationDetailRenderer } from "./AttestationDetailRenderer";
 import {
   MusicTrackRenderer,
   MusicTrackDetailRenderer,
@@ -294,6 +296,7 @@ const kindRenderers: Record<number, React.ComponentType<BaseEventProps>> = {
   30383: TrustedAssertionRenderer, // Event Assertion (NIP-85)
   30384: TrustedAssertionRenderer, // Address Assertion (NIP-85)
   30385: TrustedAssertionRenderer, // External Assertion (NIP-85)
+  31871: AttestationRenderer, // Attestation
   34139: PlaylistRenderer, // Music Playlist
   34235: Kind21Renderer, // Horizontal Video (NIP-71 legacy)
   34236: Kind22Renderer, // Vertical Video (NIP-71 legacy)
@@ -420,6 +423,7 @@ const detailRenderers: Record<
   30383: TrustedAssertionDetailRenderer, // Event Assertion Detail (NIP-85)
   30384: TrustedAssertionDetailRenderer, // Address Assertion Detail (NIP-85)
   30385: TrustedAssertionDetailRenderer, // External Assertion Detail (NIP-85)
+  31871: AttestationDetailRenderer, // Attestation Detail
   34128: NsiteLegacyDetailRenderer, // Legacy Nsite Detail (NIP-5A, deprecated)
   35128: NsiteNamedDetailRenderer, // Named Nsite Detail (NIP-5A)
   30617: RepositoryDetailRenderer, // Repository Detail (NIP-34)

--- a/src/constants/kinds.ts
+++ b/src/constants/kinds.ts
@@ -1475,6 +1475,13 @@ export const EVENT_KINDS: Record<number | string, EventKind> = {
   //   nip: "NUD: Custom Feeds",
   //   icon: Rss,
   // },
+  31871: {
+    kind: 31871,
+    name: "Attestation",
+    description: "Attestation of an assertion",
+    nip: "",
+    icon: ShieldCheck,
+  },
   31922: {
     kind: 31922,
     name: "Calendar Event",


### PR DESCRIPTION
## Summary

This PR adds support for the Attestation event kind **31871**, used by the [Attestr](https://attestr.xyz) protocol to express trust judgments about Nostr events.

## Changes

- **Kind registry** (`src/constants/kinds.ts`): Added `31871` with name "Attestation", description, and `ShieldCheck` icon.
- **Feed renderer** (`src/components/nostr/kinds/AttestationRenderer.tsx`): Displays:
  - Attestation status badge (`verifying`, `valid`, `invalid`, `revoked`)
  - Referenced assertion (via `e` or `a` tag, rendered inline with `QuotedEvent`)
  - Validity window (`valid_from` / `valid_to`)
  - Attestor's notes (`content`)
- **Detail renderer** (`src/components/nostr/kinds/AttestationDetailRenderer.tsx`): Full detail view with all metadata fields, formatted timestamps, and the assertion reference.
- **Renderer registration** (`src/components/nostr/kinds/index.tsx`): Registered both feed and detail renderers for kind 31871.

## Attestation Protocol

Attestations (kind 31871) reference another event and add lifecycle status, optional validity windows, and optional notes. Key tags:

- `d` — unique identifier
- `e` or `a` — target assertion reference
- `s` — status (`verifying`, `valid`, `invalid`, `revoked`)
- `valid_from`, `valid_to` — optional unix timestamps
- `content` — freeform notes/evidence

Learn more: [Attestr Developers](https://attestr.xyz/developers)