### PR TITLE
fix: declare uuid as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,8 @@
         "shiki": "^4.4.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
-        "unicode-emoji-json": "^0.9.0"
+        "unicode-emoji-json": "^0.9.0",
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -92,7 +93,6 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@types/shell-quote": "^1.7.5",
-        "@types/uuid": "^10.0.0",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/ui": "^4.1.10",
@@ -3719,11 +3719,6 @@
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -7840,6 +7835,20 @@
         "react-dnd": "^16.0.1"
       }
     },
+    "node_modules/react-mosaic-component/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
       "license": "MIT",
@@ -8687,14 +8696,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "shiki": "^4.4.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
-    "unicode-emoji-json": "^0.9.0"
+    "unicode-emoji-json": "^0.9.0",
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -105,7 +106,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/shell-quote": "^1.7.5",
-    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/ui": "^4.1.10",


### PR DESCRIPTION
Found while triaging open PRs, and it supersedes #282.

## Problem

`src/core/logic.ts:1` and `src/lib/spellbook-manager.ts:1` both do:

```ts
import { v4 as uuidv4 } from "uuid";
```

`uuid` was never declared in `package.json`. It resolved only because `react-mosaic-component` depends on it and npm hoists it to the top of `node_modules`. Typechecking worked only because `@types/uuid` *was* declared — types for a package we didn't depend on.

A phantom dependency like this breaks the moment the transitive provider changes. #274 (react-mosaic 7) changes that package's dependency set.

## Change

- Declare `uuid@^11` directly
- Remove `@types/uuid` — v11 ships its own declarations

## Supersedes #282

Dependabot's #282 bumps `@types/uuid` 10 → 11 and fails CI. The v11 types package is a stub, because uuid v11 ships types itself. Applied against the hoisted uuid **9**, it removes the declarations that version needs:

```
src/core/logic.ts(1,30): error TS7016: Could not find a declaration file for module 'uuid'
src/lib/spellbook-manager.ts(1,30): error TS7016: Could not find a declaration file for module 'uuid'
```

Bumping the types alone can't work — the runtime package has to move too, and once it does the types package isn't needed at all. #282 can be closed in favour of this.

## Note on the audit

`npm audit` still reports a moderate advisory for `uuid` via `react-mosaic-component`, which keeps its own nested copy. Our direct usage is now on 11.1.1; clearing the transitive one needs #274.

## Test plan

`npm run lint && npm run typecheck && npm run test:run && npm run build` — 0 lint errors, 1475/1475, clean typecheck and build. `v4` is unchanged between uuid 9 and 11, and both call sites use only `v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)